### PR TITLE
feat: add traefik edge and live portal

### DIFF
--- a/apps/portal/compose.yml
+++ b/apps/portal/compose.yml
@@ -5,16 +5,107 @@ services:
     image: nginx:alpine
     container_name: portal
     restart: unless-stopped
-    ports:
-      - "80:80"
+    # No published port on purpose — Traefik (edge/compose.yml) owns :80 and
+    # routes here by Host. This container is now unreachable except through the
+    # edge, which is the point: it can never collide with another project again.
     volumes:
       - ./html:/usr/share/nginx/html:ro
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.portal.loadbalancer.server.port=80
+
+      # The base name. Everything else on this box nests under it:
+      # <service>.dev.test for stack services, <project>.dev.test for projects,
+      # <sub>.<project>.dev.test for a project's own pieces.
+      - traefik.http.routers.portal.rule=Host(`dev.test`)
+      - traefik.http.routers.portal.entrypoints=web
+      - traefik.http.routers.portal.service=portal
+
+      # Catch-all so the bare IP (http://100.117.176.85, and the legacy
+      # http://100.93.197.10 via portproxy) still lands on the homepage — those
+      # requests carry an IP as Host, which matches no Host() rule and would
+      # otherwise 404. priority=1 keeps this below every real Host route, so it
+      # only catches what nothing else claimed. Also means a typo'd *.test name
+      # shows the portal (an index of what exists) instead of a bare 404.
+      - traefik.http.routers.portal-fallback.rule=PathPrefix(`/`)
+      - traefik.http.routers.portal-fallback.priority=1
+      - traefik.http.routers.portal-fallback.entrypoints=web
+      - traefik.http.routers.portal-fallback.service=portal
     deploy:
       resources:
         limits:
           memory: 64m
     networks: [devnet]
 
+  # ── The portal's read-only view of Docker ────────────────────────────────
+  # The portal page discovers what's running (ports, health, projects) instead
+  # of being a hand-written list. Traefik's API knows routes but not ports or
+  # health — only Docker does. nginx must NEVER touch the socket (it's
+  # root-equivalent), so this proxy stands in front of it.
+  #
+  # SECURITY — read this before changing anything here:
+  #
+  #  • CONTAINERS=1 does NOT mean "only /containers/json". docker-socket-proxy
+  #    gates by endpoint FAMILY, so it also permits /containers/{id}/json —
+  #    whose response includes Env, i.e. POSTGRES_PASSWORD and the Grafana admin
+  #    password. The actual boundary is the exact Path() rule in
+  #    ../../edge/dynamic/portal-api.yml. Never widen that to PathPrefix.
+  #
+  #  • POST=0 is load-bearing. Without it, CONTAINERS=1 also grants
+  #    /containers/{id}/kill|stop|restart to anyone who can reach this.
+  #
+  #  • This is on socketnet, NOT devnet, and publishes no port. It has no auth
+  #    of any kind, so reachability IS authorisation.
+  #
+  # What this exposes to the tailnet via /containers/json: container names,
+  # images, ports, health, labels, Mounts (host paths) and Command (argv).
+  # NOT Env. That's a home-dir-layout disclosure — acceptable on a personal
+  # tailnet, NOT acceptable if dev.test ever reaches beyond it.
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.3.0   # pinned: never :latest for a socket holder
+    container_name: portal-socket-proxy
+    restart: unless-stopped
+    environment:
+      # The ONLY grant.
+      CONTAINERS: 1
+      # Deny-by-default is the image's behaviour, but a socket proxy is the last
+      # place to trust a default surviving an image bump. Say it out loud.
+      POST:         0   # no mutation, ever
+      EXEC:         0   # container exec == root on this box
+      EVENTS:       0   # we poll; shrink the surface
+      PING:         0
+      VERSION:      0
+      AUTH:         0
+      SECRETS:      0
+      CONFIGS:      0
+      IMAGES:       0
+      INFO:         0
+      NETWORKS:     0
+      NODES:        0
+      PLUGINS:      0
+      SERVICES:     0
+      SESSION:      0
+      SWARM:        0
+      SYSTEM:       0
+      TASKS:        0
+      VOLUMES:      0
+      DISTRIBUTION: 0
+      BUILD:        0
+      COMMIT:       0
+    volumes:
+      # :ro is the second lock. The proxy is the real boundary, but a writable
+      # socket would leave POST=0 as the ONLY thing between the tailnet and root.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    # NO ports: — must never be reachable from the host network.
+    # NOT on devnet — see the security note above.
+    networks: [socketnet]
+    deploy:
+      resources:
+        limits:
+          memory: 32m
+
 networks:
   devnet:
+    external: true
+  socketnet:
     external: true

--- a/apps/portal/html/index.html
+++ b/apps/portal/html/index.html
@@ -6,182 +6,21 @@
 <title>Dev Box · Yehuda-HS</title>
 <link rel="preconnect" href="https://api.fontshare.com" crossorigin>
 <link href="https://api.fontshare.com/v2/css?f[]=clash-display@500,600,700&f[]=satoshi@400,500,700&display=swap" rel="stylesheet">
-<style>
-  :root{
-    --bg:#050607; --ink:#f4f6fb; --mut:#9aa4b6; --dim:#5c6678;
-    --line:rgba(255,255,255,.08); --line2:rgba(255,255,255,.15);
-    --glass:rgba(255,255,255,.026);
-    --v:#8b5cf6; --c:#22d3ee; --am:#fbbf24; --em:#34d399; --p:#fb7185;
-    --ok:#34d399; --down:#fb7185; --wait:#fbbf24;
-    --disp:"Clash Display",ui-sans-serif,system-ui,sans-serif;
-    --sans:"Satoshi",ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;
-    --mono:ui-monospace,"JetBrains Mono","SF Mono",Menlo,monospace;
-  }
-  *{margin:0;padding:0;box-sizing:border-box}
-  html{scroll-behavior:smooth}
-  body{font-family:var(--sans);background:var(--bg);color:var(--ink);-webkit-font-smoothing:antialiased;overflow-x:hidden;line-height:1.5}
-  a{color:inherit;text-decoration:none}
-  .mono{font-family:var(--mono)}
-
-  /* ================= BACKGROUND ================= */
-  .bg{position:fixed;inset:0;z-index:-3;overflow:hidden;background:radial-gradient(120% 90% at 50% -10%,#0a0c12,#050607 60%)}
-  .layer{position:absolute;inset:-10%;will-change:transform;transition:transform .5s cubic-bezier(.2,.7,.2,1)}
-  .orb{position:absolute;border-radius:50%;filter:blur(100px);opacity:.5;mix-blend-mode:screen}
-  .orb.a{width:620px;height:620px;left:-140px;top:-200px;background:radial-gradient(circle,#6d28d9,transparent 62%);animation:f1 24s ease-in-out infinite}
-  .orb.b{width:540px;height:540px;right:-150px;top:-100px;background:radial-gradient(circle,#0e7490,transparent 62%);animation:f2 28s ease-in-out infinite}
-  .orb.c{width:500px;height:500px;left:36%;top:52%;background:radial-gradient(circle,#9d174d,transparent 64%);opacity:.3;animation:f3 32s ease-in-out infinite}
-  @keyframes f1{50%{transform:translate(120px,90px) scale(1.12)}}
-  @keyframes f2{50%{transform:translate(-110px,120px) scale(1.08)}}
-  @keyframes f3{50%{transform:translate(60px,-90px) scale(1.15)}}
-
-  .grid-bg{position:fixed;inset:0;z-index:-3;
-    background-image:linear-gradient(var(--line) 1px,transparent 1px),linear-gradient(90deg,var(--line) 1px,transparent 1px);
-    background-size:60px 60px;mask-image:radial-gradient(ellipse 90% 65% at 50% 0%,#000 15%,transparent 72%);
-    animation:pan 40s linear infinite;opacity:.6}
-  @keyframes pan{to{background-position:60px 60px}}
-
-  .lines{position:fixed;inset:0;z-index:-2;pointer-events:none;overflow:hidden}
-  .lines svg{position:absolute}
-  #sp1{top:-14%;right:-10%;width:760px;height:760px;color:var(--v);opacity:.16;animation:spin 70s linear infinite}
-  #sp2{bottom:-22%;left:-14%;width:680px;height:680px;color:var(--c);opacity:.13;animation:spin 90s linear infinite reverse}
-  .rings{top:-160px;right:-160px;width:620px;height:620px;color:var(--c);opacity:.14;animation:spin 120s linear infinite}
-  @keyframes spin{to{transform:rotate(360deg)}}
-  .ring-line{fill:none;stroke:currentColor;stroke-width:1}
-  .spiral{fill:none;stroke:currentColor;stroke-width:1.2}
-
-  .dots{position:fixed;inset:0;z-index:-2;pointer-events:none}
-  .dots i{position:absolute;width:3px;height:3px;border-radius:50%;background:#fff;opacity:.25;animation:rise linear infinite}
-  @keyframes rise{0%{transform:translateY(0);opacity:0}12%{opacity:.35}100%{transform:translateY(-120vh);opacity:0}}
-
-  .grain{position:fixed;inset:0;z-index:-1;pointer-events:none;opacity:.035;
-    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
-
-  /* ================= LAYOUT ================= */
-  .wrap{max-width:1120px;margin:0 auto;padding:0 24px}
-  .reveal{opacity:0;transform:translateY(32px);transition:opacity .8s cubic-bezier(.2,.7,.2,1),transform .8s cubic-bezier(.2,.7,.2,1)}
-  .reveal.rl{transform:translateX(-36px)}
-  .reveal.rr{transform:translateX(36px)}
-  .reveal.in{opacity:1;transform:none}
-  .progress{position:fixed;top:0;left:0;height:2px;width:100%;z-index:60;transform-origin:0 50%;transform:scaleX(0);background:linear-gradient(90deg,var(--v),var(--c),var(--em));box-shadow:0 0 12px rgba(139,92,246,.6)}
-
-  nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(14px);background:linear-gradient(180deg,rgba(5,6,7,.7),rgba(5,6,7,0));border-bottom:1px solid transparent;transition:.3s}
-  nav.scrolled{border-color:var(--line);background:rgba(5,6,7,.85)}
-  .nav-in{max-width:1120px;margin:0 auto;padding:15px 24px;display:flex;align-items:center;justify-content:space-between}
-  .logo{display:flex;align-items:center;gap:11px;font-family:var(--disp);font-weight:600;letter-spacing:-.02em;font-size:16px}
-  .logo .mark{width:34px;height:34px;border-radius:10px;display:grid;place-items:center;font-size:15px;background:linear-gradient(135deg,var(--v),var(--c));box-shadow:0 6px 22px rgba(139,92,246,.4)}
-  .nav-links{display:flex;gap:28px;font-size:14px;color:var(--mut)}
-  .nav-links a{transition:color .2s;position:relative}
-  .nav-links a:hover{color:var(--ink)}
-  @media(max-width:720px){.nav-links{display:none}}
-
-  /* ================= HERO ================= */
-  .hero{padding:150px 0 90px;text-align:center;position:relative;will-change:transform,opacity}
-  .pill{display:inline-flex;align-items:center;gap:9px;font-size:13px;color:var(--mut);border:1px solid var(--line);background:var(--glass);border-radius:999px;padding:8px 15px;margin-bottom:30px}
-  .pulse{width:8px;height:8px;border-radius:50%;background:var(--ok);animation:pulse 2.4s infinite}
-  @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(52,211,153,.5)}70%{box-shadow:0 0 0 10px rgba(52,211,153,0)}100%{box-shadow:0 0 0 0 rgba(52,211,153,0)}}
-  h1{font-family:var(--disp);font-weight:600;letter-spacing:-.035em;line-height:1.01;font-size:clamp(2.8rem,7.6vw,5.6rem)}
-  h1 .g{background:linear-gradient(105deg,var(--v),var(--c) 55%,var(--p));-webkit-background-clip:text;background-clip:text;color:transparent}
-  .lede{max-width:60ch;margin:26px auto 0;color:var(--mut);font-size:clamp(1rem,1.6vw,1.18rem)}
-  .cta{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin-top:38px}
-  .btn{display:inline-flex;align-items:center;gap:9px;font-weight:600;font-size:14.5px;padding:13px 22px;border-radius:12px;transition:.2s;border:1px solid var(--line2)}
-  .btn.primary{background:linear-gradient(135deg,var(--v),var(--c));color:#08090c;border:none;box-shadow:0 10px 30px rgba(139,92,246,.35)}
-  .btn.primary:hover{transform:translateY(-2px);box-shadow:0 16px 40px rgba(139,92,246,.45)}
-  .btn.ghost{color:var(--ink);background:var(--glass)}
-  .btn.ghost:hover{border-color:var(--line2);background:rgba(255,255,255,.06)}
-
-  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;margin:100px 0 0;border:1px solid var(--line);border-radius:20px;overflow:hidden;background:var(--line)}
-  .stat{background:rgba(8,9,12,.6);backdrop-filter:blur(6px);padding:28px 22px;text-align:center}
-  .stat .n{font-family:var(--disp);font-weight:600;font-size:clamp(1.9rem,3.6vw,2.7rem);letter-spacing:-.02em;background:linear-gradient(120deg,#fff,#9aa4b6);-webkit-background-clip:text;background-clip:text;color:transparent}
-  .stat .l{color:var(--dim);font-size:12px;margin-top:6px;text-transform:uppercase;letter-spacing:.14em}
-  @media(max-width:640px){.stats{grid-template-columns:repeat(2,1fr)}}
-
-  /* ================= DIVIDER ================= */
-  .divider{display:flex;align-items:center;gap:18px;margin:20px 0;opacity:.9}
-  .divider .l{flex:1;height:1px;background:linear-gradient(90deg,transparent,var(--line2),transparent)}
-  .divider .d{width:8px;height:8px;transform:rotate(45deg);border:1px solid var(--line2);animation:pulse2 3s ease-in-out infinite}
-  @keyframes pulse2{50%{background:var(--line2)}}
-
-  /* ================= SECTIONS ================= */
-  section{padding:150px 0}
-  .sec-head{max-width:640px}
-  .eyebrow{font-family:var(--mono);font-size:12.5px;letter-spacing:.22em;text-transform:uppercase;color:var(--v);margin-bottom:14px;display:flex;align-items:center;gap:10px}
-  .eyebrow::before{content:"";width:24px;height:1px;background:var(--v)}
-  .h2{font-family:var(--disp);font-weight:600;letter-spacing:-.03em;font-size:clamp(1.8rem,3.8vw,2.7rem);line-height:1.06}
-  .lead{color:var(--mut);margin-top:14px;max-width:56ch;font-size:15.5px}
-
-  /* ================= CATEGORY PANELS ================= */
-  .cat{position:relative;border:1px solid var(--line);border-radius:22px;background:linear-gradient(180deg,rgba(255,255,255,.02),rgba(255,255,255,.004));padding:32px;margin-top:44px;overflow:hidden}
-  .cat::before{content:"";position:absolute;top:0;left:30px;right:30px;height:2px;background:linear-gradient(90deg,var(--acc),transparent);opacity:.8}
-  .cat-head{display:flex;align-items:center;gap:18px;margin-bottom:22px}
-  .cat-idx{font-family:var(--disp);font-weight:600;font-size:15px;color:var(--acc);border:1px solid var(--line2);border-radius:11px;width:44px;height:44px;display:grid;place-items:center;flex:none;background:color-mix(in srgb,var(--acc) 12%,transparent)}
-  .cat-head h3{font-family:var(--disp);font-weight:600;font-size:19px;letter-spacing:-.01em}
-  .cat-head .cat-sub{color:var(--dim);font-size:13px;margin-top:2px}
-  .cat-head .tail{flex:1;height:1px;background:var(--line)}
-  .cat-head .cnt{font-family:var(--mono);font-size:11.5px;color:var(--dim);border:1px solid var(--line);border-radius:999px;padding:5px 11px}
-
-  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:16px}
-  .card{position:relative;border:1px solid var(--line);border-radius:16px;background:var(--glass);padding:22px;overflow:hidden;transition:transform .25s cubic-bezier(.2,.7,.2,1),border-color .25s;isolation:isolate}
-  .card::before{content:"";position:absolute;inset:0;z-index:-1;opacity:0;transition:opacity .3s;background:radial-gradient(460px circle at var(--mx,50%) var(--my,50%),color-mix(in srgb,var(--acc) 20%,transparent),transparent 42%)}
-  .card:hover{transform:translateY(-4px);border-color:color-mix(in srgb,var(--acc) 45%,var(--line2))}
-  .card:hover::before{opacity:1}
-  a.card{cursor:pointer}
-  .card .row{display:flex;align-items:center;gap:13px;margin-bottom:14px}
-  .card .ico{width:44px;height:44px;border-radius:12px;display:grid;place-items:center;font-size:22px;background:rgba(255,255,255,.05);border:1px solid var(--line);flex:none}
-  .card .nm{font-family:var(--disp);font-weight:600;font-size:17px;letter-spacing:-.01em;display:flex;align-items:center;gap:9px}
-  .card .pt{font-family:var(--mono);font-size:11.5px;color:var(--dim);margin-top:1px}
-  .dot{width:8px;height:8px;border-radius:50%;background:var(--wait);flex:none;transition:.3s}
-  .dot.up{background:var(--ok);box-shadow:0 0 10px rgba(52,211,153,.7)}
-  .dot.down{background:var(--down)}
-  .card .desc{color:var(--mut);font-size:13.5px;min-height:40px}
-  .card .go{display:inline-flex;align-items:center;gap:7px;margin-top:15px;font-size:13px;font-weight:600;color:#cdd6e6}
-  .card:hover .go{color:#fff}
-  .card .go svg{transition:transform .2s}
-  .card:hover .go svg{transform:translateX(3px)}
-  .card .go.cli{color:var(--dim);font-weight:500}
-  /* staggered card entrance, keyed off each panel's reveal (keeps hover intact) */
-  .cat.reveal{transform:none}
-  .cat:not(.in) .card{opacity:0}
-  .cat.in .card{animation:cardIn .7s cubic-bezier(.2,.7,.2,1) backwards}
-  .cat.in .card:nth-child(2){animation-delay:.11s}
-  .cat.in .card:nth-child(3){animation-delay:.22s}
-  @keyframes cardIn{from{opacity:0;transform:translateY(34px)}to{opacity:1;transform:none}}
-
-  /* ================= WHY / ROADMAP ================= */
-  .split{display:grid;grid-template-columns:1fr 1.2fr;gap:44px;align-items:start}
-  @media(max-width:800px){.split{grid-template-columns:1fr;gap:22px}}
-  .split p{color:var(--mut);font-size:15.5px;margin-top:14px}
-  .split p b{color:var(--ink);font-weight:600}
-  .road{display:grid;gap:12px;counter-reset:r;margin-top:28px}
-  .road li{list-style:none;display:flex;gap:16px;align-items:flex-start;border:1px solid var(--line);border-radius:14px;padding:17px 19px;background:var(--glass);transition:.2s}
-  .road li:hover{border-color:var(--line2);transform:translateX(5px)}
-  .road li::before{counter-increment:r;content:counter(r,decimal-leading-zero);font-family:var(--mono);font-size:12px;color:var(--c);border:1px solid var(--line2);border-radius:8px;padding:5px 8px;flex:none}
-  .road li span{color:var(--mut);font-size:14.5px}
-  .road li b{color:var(--ink)}
-
-  footer{border-top:1px solid var(--line);margin-top:20px;padding:34px 0 64px}
-  .foot{display:flex;flex-wrap:wrap;gap:20px;justify-content:space-between;align-items:center;color:var(--dim);font-size:13px}
-  .cmds{display:flex;flex-wrap:wrap;gap:8px}
-  .cmds code{font-family:var(--mono);font-size:12px;color:var(--mut);border:1px solid var(--line);border-radius:7px;padding:5px 9px;background:var(--glass)}
-</style>
+<link rel="stylesheet" href="/portal.css">
 </head>
 <body>
   <div class="progress" id="prog"></div>
   <div class="bg">
-    <div class="layer" data-depth="18"><div class="orb a"></div><div class="orb b"></div><div class="orb c"></div></div>
+    <div class="layer" data-depth="18"><span class="orb a"></span><span class="orb b"></span><span class="orb c"></span></div>
   </div>
   <div class="grid-bg"></div>
   <div class="lines">
-    <svg id="sp1" viewBox="0 0 400 400"><path class="spiral"/></svg>
-    <svg id="sp2" viewBox="0 0 400 400"><path class="spiral"/></svg>
+    <svg id="sp1" viewBox="0 0 400 400"><path class="spiral" d=""/></svg>
+    <svg id="sp2" viewBox="0 0 400 400"><path class="spiral" d=""/></svg>
     <svg class="rings" viewBox="0 0 400 400">
-      <circle class="ring-line" cx="200" cy="200" r="60"/>
-      <circle class="ring-line" cx="200" cy="200" r="110"/>
-      <circle class="ring-line" cx="200" cy="200" r="160" stroke-dasharray="4 8"/>
-      <circle class="ring-line" cx="200" cy="200" r="196"/>
-      <line class="ring-line" x1="200" y1="4" x2="200" y2="396"/>
-      <line class="ring-line" x1="4" y1="200" x2="396" y2="200"/>
-      <line class="ring-line" x1="45" y1="45" x2="355" y2="355"/>
-      <line class="ring-line" x1="355" y1="45" x2="45" y2="355"/>
+      <circle class="ring-line" cx="200" cy="200" r="80"/>
+      <circle class="ring-line" cx="200" cy="200" r="130"/>
+      <circle class="ring-line" cx="200" cy="200" r="180"/>
     </svg>
   </div>
   <div class="dots" id="dots"></div>
@@ -189,221 +28,121 @@
 
   <nav id="nav">
     <div class="nav-in">
-      <div class="logo"><span class="mark">◆</span> Dev&nbsp;Box</div>
+      <a class="logo" href="#services"><span class="mark"></span> Dev Box</a>
       <div class="nav-links">
-        <a href="#services">Services</a><a href="#why">Why</a><a href="#roadmap">Roadmap</a><a data-port="3001">Wiki</a>
+        <a href="#services">Services</a>
+        <a href="#ports">Ports</a>
+        <a href="#routes">Routes</a>
+        <a data-host="wiki.dev.test">Wiki</a>
       </div>
     </div>
   </nav>
 
   <header class="hero wrap">
-    <div class="pill reveal"><span class="pulse"></span> <span id="status-txt">All systems operational</span> · <span id="via" class="mono" style="color:var(--dim)">Yehuda-HS</span></div>
+    <!-- #status-txt and .pulse double as the freshness indicator: green = live,
+         amber = stale (last seen Ns ago), rose = APIs unreachable. -->
+    <div class="pill reveal"><span class="pulse"></span> <span id="status-txt">Loading…</span> · <span id="via" class="mono" style="color:var(--dim)">Yehuda-HS</span></div>
     <h1 class="reveal">One box.<br><span class="g">Everything running.</span></h1>
-    <p class="lede reveal">A self-hosted development environment — databases, streaming, full observability and a wiki — that <b style="color:var(--ink)">monitors itself, alerts on failure, and backs itself up</b>, reachable from any laptop over Tailscale.</p>
+    <p class="lede reveal">A self-hosted development environment — reachable from any laptop over Tailscale, routed by name instead of by port. This page <b style="color:var(--ink)">discovers what's actually running</b>; nothing below is hand-written.</p>
     <div class="cta reveal">
-      <a class="btn primary" data-port="3000">Open Grafana</a>
-      <a class="btn ghost" data-port="3001">Open Wiki</a>
-      <a class="btn ghost" href="#services">Browse services ↓</a>
+      <a class="btn primary" data-host="grafana.dev.test">Open Grafana</a>
+      <a class="btn ghost" data-host="wiki.dev.test">Open Wiki</a>
+      <a class="btn ghost" href="#ports">Port map ↓</a>
     </div>
+    <!-- Counts are filled from live data by renderHero(); the markup values are
+         only a no-JS fallback. -->
     <div class="stats reveal">
-      <div class="stat"><div class="n" data-count="18">18</div><div class="l">Services</div></div>
-      <div class="stat"><div class="n" data-count="10">10</div><div class="l">vCPU</div></div>
-      <div class="stat"><div class="n" data-count="23">23</div><div class="l">GB RAM</div></div>
-      <div class="stat"><div class="n" data-count="6">6</div><div class="l">Stacks</div></div>
+      <div class="stat"><div class="n" id="n-services" data-count="0">–</div><div class="l">Services</div></div>
+      <div class="stat"><div class="n" id="n-projects" data-count="0">–</div><div class="l">Projects</div></div>
+      <div class="stat"><div class="n" id="n-stacks"   data-count="0">–</div><div class="l">Stacks</div></div>
+      <div class="stat"><div class="n" id="n-ports"    data-count="0">–</div><div class="l">Open ports</div></div>
     </div>
   </header>
 
-  <section id="services" class="wrap">
-    <div class="sec-head reveal"><div class="eyebrow">Services</div><div class="h2">Everything, one click away</div>
-      <p class="lead">Live status is probed from whatever address you opened this page — Tailscale or LAN both work.</p></div>
-
-    <div class="cat reveal" style="--acc:var(--v)">
-      <div class="cat-head"><span class="cat-idx">01</span><div><h3>Observability</h3><div class="cat-sub">metrics · dashboards · logs</div></div><span class="tail"></span><span class="cnt">2</span></div>
-      <div class="grid">
-        <a class="card" data-port="3000">
-          <div class="row"><div class="ico">📊</div><div><div class="nm">Grafana <span class="dot"></span></div><div class="pt">:3000</div></div></div>
-          <div class="desc">Dashboards for the whole box — host, every container, the DBs, Kafka and the Docker daemon. Plus searchable logs via Loki.</div>
-          <span class="go">Open <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
-        </a>
-        <a class="card" data-port="9090" data-path="/targets">
-          <div class="row"><div class="ico">🎯</div><div><div class="nm">Prometheus <span class="dot"></span></div><div class="pt">:9090</div></div></div>
-          <div class="desc">Metrics store and the engine behind the alerts. Inspect raw metrics and every scrape target.</div>
-          <span class="go">Open <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
-        </a>
-      </div>
+  <main class="wrap" id="services">
+    <div class="sec-head reveal">
+      <div class="eyebrow">Live</div>
+      <h2 class="h2">Everything on this box</h2>
+      <p class="lead">Discovered from Traefik and Docker every 10 seconds. Add a service with two Traefik labels and it appears here on its own — no edit to this page.</p>
     </div>
 
-    <div class="cat reveal" style="--acc:var(--c)">
-      <div class="cat-head"><span class="cat-idx">02</span><div><h3>Logs &amp; Management</h3><div class="cat-sub">inspect · control · exec</div></div><span class="tail"></span><span class="cnt">2</span></div>
-      <div class="grid">
-        <a class="card" data-port="8080">
-          <div class="row"><div class="ico">📜</div><div><div class="nm">Dozzle <span class="dot"></span></div><div class="pt">:8080</div></div></div>
-          <div class="desc">Live container logs in the browser — zero config, the fastest way to see what a service is doing right now.</div>
-          <span class="go">Open <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
-        </a>
-        <a class="card" data-port="9000">
-          <div class="row"><div class="ico">🐳</div><div><div class="nm">Portainer <span class="dot"></span></div><div class="pt">:9000</div></div></div>
-          <div class="desc">Full Docker management UI — start/stop, exec, inspect volumes and networks. Login-protected.</div>
-          <span class="go">Open <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
-        </a>
-      </div>
+    <div class="tabs" role="tablist" aria-label="Views">
+      <button role="tab" data-tab="services" aria-selected="true" aria-controls="tab-services">Services</button>
+      <button role="tab" data-tab="ports"    aria-selected="false" aria-controls="tab-ports">Ports</button>
+      <button role="tab" data-tab="routes"   aria-selected="false" aria-controls="tab-routes">Routes</button>
+      <span class="sp"></span>
+      <span class="hint"><kbd>/</kbd> filter · <kbd>r</kbd> refresh</span>
     </div>
 
-    <div class="cat reveal" style="--acc:var(--am)">
-      <div class="cat-head"><span class="cat-idx">03</span><div><h3>Data &amp; Streaming</h3><div class="cat-sub">postgres · redis · kafka</div></div><span class="tail"></span><span class="cnt">2</span></div>
-      <div class="grid">
-        <a class="card" data-port="8081">
-          <div class="row"><div class="ico">🌊</div><div><div class="nm">Kafka-UI <span class="dot"></span></div><div class="pt">:8081</div></div></div>
-          <div class="desc">Browse the single-node KRaft broker — topics, partitions, consumer groups and live messages.</div>
-          <span class="go">Open <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
-        </a>
-        <div class="card">
-          <div class="row"><div class="ico">🗄️</div><div><div class="nm">Postgres · Redis · Kafka</div><div class="pt">5432 · 6379 · 9092</div></div></div>
-          <div class="desc">Shared dev data on <span class="mono" style="color:var(--mut)">devnet</span>. Kept off the network for safety — reach them over an SSH tunnel.</div>
-          <span class="go cli">TCP · via ssh tunnel</span>
-        </div>
-      </div>
-    </div>
-
-    <div class="cat reveal" style="--acc:var(--em)">
-      <div class="cat-head"><span class="cat-idx">04</span><div><h3>Apps &amp; Platform</h3><div class="cat-sub">docs · kubernetes</div></div><span class="tail"></span><span class="cnt">2</span></div>
-      <div class="grid">
-        <a class="card" data-port="3001">
-          <div class="row"><div class="ico">📚</div><div><div class="nm">Wiki.js <span class="dot"></span></div><div class="pt">:3001</div></div></div>
-          <div class="desc">The system wiki in Markdown — tooling, stacks, SSH, WSL and Kubernetes. Login-protected, backed by Postgres.</div>
-          <span class="go">Open <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>
-        </a>
-        <div class="card">
-          <div class="row"><div class="ico">☸️</div><div><div class="nm">Kubernetes</div><div class="pt">minikube</div></div></div>
-          <div class="desc">Local cluster for k8s work — drive it with <span class="mono" style="color:var(--mut)">k9s</span>, kubectl, helm and tilt. Auto-starts on boot.</div>
-          <span class="go cli">CLI · k9s</span>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <div class="wrap"><div class="divider"><span class="l"></span><span class="d"></span><span class="l"></span></div></div>
-
-  <section id="why" class="wrap">
-    <div class="split">
-      <div class="reveal rl"><div class="eyebrow">Why</div><div class="h2">Built to be<br>trusted with<br>real work.</div></div>
-      <div class="reveal rr">
-        <p>A laptop is a bad place to run Postgres, Kafka and a monitoring stack — it sleeps, runs out of RAM, and nothing survives a reboot. This box moves all of that to an <b>always-on machine</b> with 10 cores and 23&nbsp;GB, reachable anywhere over <b>Tailscale</b>, so the laptop stays light and the infrastructure stays put.</p>
-        <p>It isn't just "some containers." It's an environment that <b>watches its own health</b>, <b>emails you when something breaks</b>, and <b>can't quietly lose your data</b> — memory-capped, auto-restarting, backed up nightly, version-controlled in <span class="mono" style="color:var(--mut)">~/stacks</span>, and documented in the wiki.</p>
-      </div>
-    </div>
-  </section>
-
-  <div class="wrap"><div class="divider"><span class="l"></span><span class="d"></span><span class="l"></span></div></div>
-
-  <section id="roadmap" class="wrap">
-    <div class="sec-head reveal"><div class="eyebrow">Roadmap</div><div class="h2">What's next</div></div>
-    <ul class="road reveal">
-      <li><span><b>Single-domain reverse proxy + local TLS</b> — services at <span class="mono">name.dev</span> instead of ports.</span></li>
-      <li><span><b>Two-way Git sync for the wiki</b> — every page versioned as Markdown on disk.</span></li>
-      <li><span><b>A project workspace on devnet</b> with hot-reload against the shared databases.</span></li>
-      <li><span><b>More dashboards &amp; alert rules</b> — per-service SLOs and restart-storm detection.</span></li>
-      <li><span><b>Secrets hardening</b> — rotate the dev credentials into a managed store.</span></li>
-      <li><span><b>CI → deploy to minikube via tilt</b> for a real inner-loop.</span></li>
-    </ul>
-  </section>
+    <!-- id prefix "tab-" is deliberate: bare id="ports" would collide with the
+         #ports hash route and make scroll-behavior:smooth fight the router. -->
+    <section id="tab-services" role="tabpanel" aria-labelledby="services"><div class="skel"></div></section>
+    <section id="tab-ports"    role="tabpanel" hidden></section>
+    <section id="tab-routes"   role="tabpanel" hidden></section>
+  </main>
 
   <footer>
     <div class="wrap foot">
-      <div class="cmds"><code>just up</code><code>just doctor</code><code>just backup</code><code>just urls</code></div>
-      <div>Yehuda-HS · versioned in <span class="mono">~/stacks</span> · <a data-port="3001" style="color:var(--c)">docs →</a></div>
+      <div class="cmds">
+        <code>just up</code> <code>just urls</code> <code>just doctor</code> <code>tilt up --host=0.0.0.0</code>
+      </div>
+      <a href="#services" style="color:var(--c)">back to top ↑</a>
     </div>
   </footer>
 
+<script type="module">
+  import { init } from '/portal.js';
+  init();
+</script>
 <script>
-  const host = location.hostname;
-  document.getElementById('via').textContent = host.startsWith('100.') ? 'tailscale · '+host : host;
-
-  // Generate Archimedean spirals
-  function spiralPath(turns, gap){
-    let d='', first=true;
-    for(let a=0; a<=turns*Math.PI*2; a+=0.18){
-      const r=gap*a, x=200+Math.cos(a)*r, y=200+Math.sin(a)*r;
-      d += (first?'M':'L') + x.toFixed(1) + ' ' + y.toFixed(1) + ' '; first=false;
+  // Decoration only — no data, no DOM the module owns. Kept inline and separate
+  // so a failure here can never stop the service list from rendering.
+  (function(){
+    function spiralPath(turns, gap){
+      let d='', first=true;
+      for(let a=0; a<=turns*Math.PI*2; a+=0.18){
+        const r=gap*a, x=200+Math.cos(a)*r, y=200+Math.sin(a)*r;
+        d += (first?'M':'L') + x.toFixed(1) + ' ' + y.toFixed(1) + ' '; first=false;
+      }
+      return d;
     }
-    return d;
-  }
-  document.querySelector('#sp1 .spiral').setAttribute('d', spiralPath(9, 10));
-  document.querySelector('#sp2 .spiral').setAttribute('d', spiralPath(7, 13));
+    document.querySelector('#sp1 .spiral').setAttribute('d', spiralPath(9, 10));
+    document.querySelector('#sp2 .spiral').setAttribute('d', spiralPath(7, 13));
 
-  // Floating particles
-  const dots=document.getElementById('dots');
-  for(let i=0;i<16;i++){
-    const s=document.createElement('i');
-    const dur=14+Math.random()*22, delay=-Math.random()*dur;
-    s.style.left=Math.random()*100+'vw';
-    s.style.top=100+Math.random()*20+'vh';
-    s.style.animationDuration=dur+'s';
-    s.style.animationDelay=delay+'s';
-    s.style.opacity=(.12+Math.random()*.25).toFixed(2);
-    dots.appendChild(s);
-  }
+    const dots=document.getElementById('dots');
+    for(let i=0;i<16;i++){
+      const s=document.createElement('i');
+      const dur=14+Math.random()*22, delay=-Math.random()*dur;
+      s.style.left=Math.random()*100+'vw'; s.style.top=100+Math.random()*20+'vh';
+      s.style.animationDuration=dur+'s'; s.style.animationDelay=delay+'s';
+      s.style.opacity=(.12+Math.random()*.25).toFixed(2);
+      dots.appendChild(s);
+    }
 
-  // Combined parallax + scroll engine (rAF-throttled)
-  const layers=[...document.querySelectorAll('.layer')];
-  const linesEl=document.querySelector('.lines');
-  const heroEl=document.querySelector('.hero');
-  const navEl=document.getElementById('nav');
-  const barEl=document.getElementById('prog');
-  let mx=0,my=0,sy=window.scrollY,raf=null;
-  function render(){
-    const doc=document.documentElement;
-    for(const l of layers){const d=+l.dataset.depth||14; l.style.transform=`translate(${(mx*d).toFixed(1)}px,${(my*d+sy*0.10).toFixed(1)}px)`;}
-    if(linesEl) linesEl.style.transform=`translate(${(mx*-10).toFixed(1)}px,${(sy*-0.05).toFixed(1)}px)`;
-    if(heroEl){const k=Math.min(1,sy/640); heroEl.style.opacity=(1-k*0.9).toFixed(3); heroEl.style.transform=`translateY(${(sy*0.16).toFixed(1)}px)`;}
-    if(navEl) navEl.classList.toggle('scrolled',sy>10);
-    if(barEl){const p=sy/((doc.scrollHeight-doc.clientHeight)||1); barEl.style.transform=`scaleX(${Math.min(1,p).toFixed(4)})`;}
-    raf=null;
-  }
-  function schedule(){ if(!raf) raf=requestAnimationFrame(render); }
-  addEventListener('mousemove',e=>{ mx=e.clientX/innerWidth-.5; my=e.clientY/innerHeight-.5; schedule(); });
-  addEventListener('scroll',()=>{ sy=window.scrollY; schedule(); },{passive:true});
-  addEventListener('resize',schedule);
-  render();
+    const layers=[...document.querySelectorAll('.layer')];
+    const linesEl=document.querySelector('.lines'), heroEl=document.querySelector('.hero');
+    const navEl=document.getElementById('nav'), barEl=document.getElementById('prog');
+    let mx=0,my=0,sy=window.scrollY,raf=null;
+    function render(){
+      const doc=document.documentElement;
+      for(const l of layers){const d=+l.dataset.depth||14; l.style.transform=`translate(${(mx*d).toFixed(1)}px,${(my*d+sy*0.10).toFixed(1)}px)`;}
+      if(linesEl) linesEl.style.transform=`translate(${(mx*-10).toFixed(1)}px,${(sy*-0.05).toFixed(1)}px)`;
+      if(heroEl){const k=Math.min(1,sy/640); heroEl.style.opacity=(1-k*0.9).toFixed(3); heroEl.style.transform=`translateY(${(sy*0.16).toFixed(1)}px)`;}
+      if(navEl) navEl.classList.toggle('scrolled',sy>10);
+      if(barEl){const p=sy/((doc.scrollHeight-doc.clientHeight)||1); barEl.style.transform=`scaleX(${Math.min(1,p).toFixed(4)})`;}
+      raf=null;
+    }
+    function schedule(){ if(!raf) raf=requestAnimationFrame(render); }
+    addEventListener('mousemove',e=>{ mx=e.clientX/innerWidth-.5; my=e.clientY/innerHeight-.5; schedule(); });
+    addEventListener('scroll',()=>{ sy=window.scrollY; schedule(); },{passive:true});
+    addEventListener('resize',schedule);
+    render();
 
-  // Links (host-relative)
-  document.querySelectorAll('[data-port]').forEach(el=>{
-    const u=`http://${host}:${el.dataset.port}${el.dataset.path||''}`;
-    if(el.tagName==='A') el.href=u;
-  });
-
-  // Card spotlight
-  document.querySelectorAll('.card').forEach(c=>{
-    c.addEventListener('mousemove',e=>{const r=c.getBoundingClientRect();
-      c.style.setProperty('--mx',(e.clientX-r.left)+'px');
-      c.style.setProperty('--my',(e.clientY-r.top)+'px');});
-  });
-
-  // Scroll reveal
-  const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.12});
-  document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
-
-  // Count-up
-  function count(el){const t=+el.dataset.count;let n=0;const step=Math.max(1,Math.round(t/28));
-    const id=setInterval(()=>{n+=step;if(n>=t){n=t;clearInterval(id)}el.textContent=n},28);}
-  const so=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){count(e.target);so.unobserve(e.target)}}),{threshold:.5});
-  document.querySelectorAll('.n[data-count]').forEach(el=>so.observe(el));
-
-  // Live status
-  const cards=[...document.querySelectorAll('.card[data-port]')];
-  const withDot=cards.filter(c=>c.querySelector('.dot'));
-  let up=0, done=0;
-  withDot.forEach(card=>{
-    const dot=card.querySelector('.dot');
-    const u=`http://${host}:${card.dataset.port}/`;
-    const to=new Promise((_,r)=>setTimeout(r,4500));
-    Promise.race([fetch(u,{mode:'no-cors',cache:'no-store'}),to])
-      .then(()=>{dot.className='dot up';up++})
-      .catch(()=>{dot.className='dot down'})
-      .finally(()=>{if(++done===withDot.length){
-        document.getElementById('status-txt').textContent = up===done?'All systems operational':`${up}/${done} services up`;
-      }});
-  });
+    // Static links in nav/hero (the module owns everything inside the tabs).
+    document.querySelectorAll('[data-host]').forEach(el=>{
+      if(el.tagName==='A') el.href = `http://${el.dataset.host}${el.dataset.path||''}`;
+    });
+  })();
 </script>
 </body>
 </html>

--- a/apps/portal/html/portal.css
+++ b/apps/portal/html/portal.css
@@ -1,0 +1,275 @@
+:root{
+    --bg:#050607; --ink:#f4f6fb; --mut:#9aa4b6; --dim:#5c6678;
+    --line:rgba(255,255,255,.08); --line2:rgba(255,255,255,.15);
+    --glass:rgba(255,255,255,.026);
+    --v:#8b5cf6; --c:#22d3ee; --am:#fbbf24; --em:#34d399; --p:#fb7185;
+    --ok:#34d399; --down:#fb7185; --wait:#fbbf24;
+    --disp:"Clash Display",ui-sans-serif,system-ui,sans-serif;
+    --sans:"Satoshi",ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;
+    --mono:ui-monospace,"JetBrains Mono","SF Mono",Menlo,monospace;
+  }
+  *{margin:0;padding:0;box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);background:var(--bg);color:var(--ink);-webkit-font-smoothing:antialiased;overflow-x:hidden;line-height:1.5}
+  a{color:inherit;text-decoration:none}
+  .mono{font-family:var(--mono)}
+
+  /* ================= BACKGROUND ================= */
+  .bg{position:fixed;inset:0;z-index:-3;overflow:hidden;background:radial-gradient(120% 90% at 50% -10%,#0a0c12,#050607 60%)}
+  .layer{position:absolute;inset:-10%;will-change:transform;transition:transform .5s cubic-bezier(.2,.7,.2,1)}
+  .orb{position:absolute;border-radius:50%;filter:blur(100px);opacity:.5;mix-blend-mode:screen}
+  .orb.a{width:620px;height:620px;left:-140px;top:-200px;background:radial-gradient(circle,#6d28d9,transparent 62%);animation:f1 24s ease-in-out infinite}
+  .orb.b{width:540px;height:540px;right:-150px;top:-100px;background:radial-gradient(circle,#0e7490,transparent 62%);animation:f2 28s ease-in-out infinite}
+  .orb.c{width:500px;height:500px;left:36%;top:52%;background:radial-gradient(circle,#9d174d,transparent 64%);opacity:.3;animation:f3 32s ease-in-out infinite}
+  @keyframes f1{50%{transform:translate(120px,90px) scale(1.12)}}
+  @keyframes f2{50%{transform:translate(-110px,120px) scale(1.08)}}
+  @keyframes f3{50%{transform:translate(60px,-90px) scale(1.15)}}
+
+  .grid-bg{position:fixed;inset:0;z-index:-3;
+    background-image:linear-gradient(var(--line) 1px,transparent 1px),linear-gradient(90deg,var(--line) 1px,transparent 1px);
+    background-size:60px 60px;mask-image:radial-gradient(ellipse 90% 65% at 50% 0%,#000 15%,transparent 72%);
+    animation:pan 40s linear infinite;opacity:.6}
+  @keyframes pan{to{background-position:60px 60px}}
+
+  .lines{position:fixed;inset:0;z-index:-2;pointer-events:none;overflow:hidden}
+  .lines svg{position:absolute}
+  #sp1{top:-14%;right:-10%;width:760px;height:760px;color:var(--v);opacity:.16;animation:spin 70s linear infinite}
+  #sp2{bottom:-22%;left:-14%;width:680px;height:680px;color:var(--c);opacity:.13;animation:spin 90s linear infinite reverse}
+  .rings{top:-160px;right:-160px;width:620px;height:620px;color:var(--c);opacity:.14;animation:spin 120s linear infinite}
+  @keyframes spin{to{transform:rotate(360deg)}}
+  .ring-line{fill:none;stroke:currentColor;stroke-width:1}
+  .spiral{fill:none;stroke:currentColor;stroke-width:1.2}
+
+  .dots{position:fixed;inset:0;z-index:-2;pointer-events:none}
+  .dots i{position:absolute;width:3px;height:3px;border-radius:50%;background:#fff;opacity:.25;animation:rise linear infinite}
+  @keyframes rise{0%{transform:translateY(0);opacity:0}12%{opacity:.35}100%{transform:translateY(-120vh);opacity:0}}
+
+  .grain{position:fixed;inset:0;z-index:-1;pointer-events:none;opacity:.035;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+
+  /* ================= LAYOUT ================= */
+  .wrap{max-width:1120px;margin:0 auto;padding:0 24px}
+  /* NOTE the html.js guard. .reveal hides content until JS reveals it, so an
+     unguarded rule means "portal.js broke" == "the whole page is invisible".
+     portal.js sets html.js first thing; no JS -> no hiding -> page still works. */
+  html.js .reveal{opacity:0;transform:translateY(32px);transition:opacity .8s cubic-bezier(.2,.7,.2,1),transform .8s cubic-bezier(.2,.7,.2,1)}
+  html.js .reveal.rl{transform:translateX(-36px)}
+  html.js .reveal.rr{transform:translateX(36px)}
+  html.js .reveal.in{opacity:1;transform:none}
+  .progress{position:fixed;top:0;left:0;height:2px;width:100%;z-index:60;transform-origin:0 50%;transform:scaleX(0);background:linear-gradient(90deg,var(--v),var(--c),var(--em));box-shadow:0 0 12px rgba(139,92,246,.6)}
+
+  nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(14px);background:linear-gradient(180deg,rgba(5,6,7,.7),rgba(5,6,7,0));border-bottom:1px solid transparent;transition:.3s}
+  nav.scrolled{border-color:var(--line);background:rgba(5,6,7,.85)}
+  .nav-in{max-width:1120px;margin:0 auto;padding:15px 24px;display:flex;align-items:center;justify-content:space-between}
+  .logo{display:flex;align-items:center;gap:11px;font-family:var(--disp);font-weight:600;letter-spacing:-.02em;font-size:16px}
+  .logo .mark{width:34px;height:34px;border-radius:10px;display:grid;place-items:center;font-size:15px;background:linear-gradient(135deg,var(--v),var(--c));box-shadow:0 6px 22px rgba(139,92,246,.4)}
+  .nav-links{display:flex;gap:28px;font-size:14px;color:var(--mut)}
+  .nav-links a{transition:color .2s;position:relative}
+  .nav-links a:hover{color:var(--ink)}
+  @media(max-width:720px){.nav-links{display:none}}
+
+  /* ================= HERO ================= */
+  .hero{padding:150px 0 90px;text-align:center;position:relative;will-change:transform,opacity}
+  .pill{display:inline-flex;align-items:center;gap:9px;font-size:13px;color:var(--mut);border:1px solid var(--line);background:var(--glass);border-radius:999px;padding:8px 15px;margin-bottom:30px}
+  .pulse{width:8px;height:8px;border-radius:50%;background:var(--ok);animation:pulse 2.4s infinite}
+  @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(52,211,153,.5)}70%{box-shadow:0 0 0 10px rgba(52,211,153,0)}100%{box-shadow:0 0 0 0 rgba(52,211,153,0)}}
+  h1{font-family:var(--disp);font-weight:600;letter-spacing:-.035em;line-height:1.01;font-size:clamp(2.8rem,7.6vw,5.6rem)}
+  h1 .g{background:linear-gradient(105deg,var(--v),var(--c) 55%,var(--p));-webkit-background-clip:text;background-clip:text;color:transparent}
+  .lede{max-width:60ch;margin:26px auto 0;color:var(--mut);font-size:clamp(1rem,1.6vw,1.18rem)}
+  .cta{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin-top:38px}
+  .btn{display:inline-flex;align-items:center;gap:9px;font-weight:600;font-size:14.5px;padding:13px 22px;border-radius:12px;transition:.2s;border:1px solid var(--line2)}
+  .btn.primary{background:linear-gradient(135deg,var(--v),var(--c));color:#08090c;border:none;box-shadow:0 10px 30px rgba(139,92,246,.35)}
+  .btn.primary:hover{transform:translateY(-2px);box-shadow:0 16px 40px rgba(139,92,246,.45)}
+  .btn.ghost{color:var(--ink);background:var(--glass)}
+  .btn.ghost:hover{border-color:var(--line2);background:rgba(255,255,255,.06)}
+
+  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;margin:100px 0 0;border:1px solid var(--line);border-radius:20px;overflow:hidden;background:var(--line)}
+  .stat{background:rgba(8,9,12,.6);backdrop-filter:blur(6px);padding:28px 22px;text-align:center}
+  .stat .n{font-family:var(--disp);font-weight:600;font-size:clamp(1.9rem,3.6vw,2.7rem);letter-spacing:-.02em;background:linear-gradient(120deg,#fff,#9aa4b6);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .stat .l{color:var(--dim);font-size:12px;margin-top:6px;text-transform:uppercase;letter-spacing:.14em}
+  @media(max-width:640px){.stats{grid-template-columns:repeat(2,1fr)}}
+
+  /* ================= DIVIDER ================= */
+  .divider{display:flex;align-items:center;gap:18px;margin:20px 0;opacity:.9}
+  .divider .l{flex:1;height:1px;background:linear-gradient(90deg,transparent,var(--line2),transparent)}
+  .divider .d{width:8px;height:8px;transform:rotate(45deg);border:1px solid var(--line2);animation:pulse2 3s ease-in-out infinite}
+  @keyframes pulse2{50%{background:var(--line2)}}
+
+  /* ================= SECTIONS ================= */
+  section{padding:150px 0}
+  .sec-head{max-width:640px}
+  .eyebrow{font-family:var(--mono);font-size:12.5px;letter-spacing:.22em;text-transform:uppercase;color:var(--v);margin-bottom:14px;display:flex;align-items:center;gap:10px}
+  .eyebrow::before{content:"";width:24px;height:1px;background:var(--v)}
+  .h2{font-family:var(--disp);font-weight:600;letter-spacing:-.03em;font-size:clamp(1.8rem,3.8vw,2.7rem);line-height:1.06}
+  .lead{color:var(--mut);margin-top:14px;max-width:56ch;font-size:15.5px}
+
+  /* ================= CATEGORY PANELS ================= */
+  .cat{position:relative;border:1px solid var(--line);border-radius:22px;background:linear-gradient(180deg,rgba(255,255,255,.02),rgba(255,255,255,.004));padding:32px;margin-top:44px;overflow:hidden}
+  .cat::before{content:"";position:absolute;top:0;left:30px;right:30px;height:2px;background:linear-gradient(90deg,var(--acc),transparent);opacity:.8}
+  .cat-head{display:flex;align-items:center;gap:18px;margin-bottom:22px}
+  .cat-idx{font-family:var(--disp);font-weight:600;font-size:15px;color:var(--acc);border:1px solid var(--line2);border-radius:11px;width:44px;height:44px;display:grid;place-items:center;flex:none;background:color-mix(in srgb,var(--acc) 12%,transparent)}
+  .cat-head h3{font-family:var(--disp);font-weight:600;font-size:19px;letter-spacing:-.01em}
+  .cat-head .cat-sub{color:var(--dim);font-size:13px;margin-top:2px}
+  .cat-head .tail{flex:1;height:1px;background:var(--line)}
+  .cat-head .cnt{font-family:var(--mono);font-size:11.5px;color:var(--dim);border:1px solid var(--line);border-radius:999px;padding:5px 11px}
+
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:16px}
+  .card{position:relative;border:1px solid var(--line);border-radius:16px;background:var(--glass);padding:22px;overflow:hidden;transition:transform .25s cubic-bezier(.2,.7,.2,1),border-color .25s;isolation:isolate}
+  .card::before{content:"";position:absolute;inset:0;z-index:-1;opacity:0;transition:opacity .3s;background:radial-gradient(460px circle at var(--mx,50%) var(--my,50%),color-mix(in srgb,var(--acc) 20%,transparent),transparent 42%)}
+  .card:hover{transform:translateY(-4px);border-color:color-mix(in srgb,var(--acc) 45%,var(--line2))}
+  .card:hover::before{opacity:1}
+  a.card{cursor:pointer}
+  .card .row{display:flex;align-items:center;gap:13px;margin-bottom:14px}
+  .card .ico{width:44px;height:44px;border-radius:12px;display:grid;place-items:center;font-size:22px;background:rgba(255,255,255,.05);border:1px solid var(--line);flex:none}
+  .card .nm{font-family:var(--disp);font-weight:600;font-size:17px;letter-spacing:-.01em;display:flex;align-items:center;gap:9px}
+  .card .pt{font-family:var(--mono);font-size:11.5px;color:var(--dim);margin-top:1px}
+  .dot{width:8px;height:8px;border-radius:50%;background:var(--wait);flex:none;transition:.3s}
+  .dot.up{background:var(--ok);box-shadow:0 0 10px rgba(52,211,153,.7)}
+  .dot.down{background:var(--down)}
+  .card .desc{color:var(--mut);font-size:13.5px;min-height:40px}
+  .card .go{display:inline-flex;align-items:center;gap:7px;margin-top:15px;font-size:13px;font-weight:600;color:#cdd6e6}
+  .card:hover .go{color:#fff}
+  .card .go svg{transition:transform .2s}
+  .card:hover .go svg{transform:translateX(3px)}
+  .card .go.cli{color:var(--dim);font-weight:500}
+  /* staggered card entrance, keyed off each panel's reveal (keeps hover intact) */
+  .cat.reveal{transform:none}
+  html.js .cat:not(.in) .card{opacity:0}
+  .cat.in .card{animation:cardIn .7s cubic-bezier(.2,.7,.2,1) backwards}
+  @keyframes cardIn{from{opacity:0;transform:translateY(34px)}to{opacity:1;transform:none}}
+
+  /* ================= WHY / ROADMAP ================= */
+  .split{display:grid;grid-template-columns:1fr 1.2fr;gap:44px;align-items:start}
+  @media(max-width:800px){.split{grid-template-columns:1fr;gap:22px}}
+  .split p{color:var(--mut);font-size:15.5px;margin-top:14px}
+  .split p b{color:var(--ink);font-weight:600}
+  .road{display:grid;gap:12px;counter-reset:r;margin-top:28px}
+  .road li{list-style:none;display:flex;gap:16px;align-items:flex-start;border:1px solid var(--line);border-radius:14px;padding:17px 19px;background:var(--glass);transition:.2s}
+  .road li:hover{border-color:var(--line2);transform:translateX(5px)}
+  .road li::before{counter-increment:r;content:counter(r,decimal-leading-zero);font-family:var(--mono);font-size:12px;color:var(--c);border:1px solid var(--line2);border-radius:8px;padding:5px 8px;flex:none}
+  .road li span{color:var(--mut);font-size:14.5px}
+  .road li b{color:var(--ink)}
+
+  footer{border-top:1px solid var(--line);margin-top:20px;padding:34px 0 64px}
+  .foot{display:flex;flex-wrap:wrap;gap:20px;justify-content:space-between;align-items:center;color:var(--dim);font-size:13px}
+  .cmds{display:flex;flex-wrap:wrap;gap:8px}
+  .cmds code{font-family:var(--mono);font-size:12px;color:var(--mut);border:1px solid var(--line);border-radius:7px;padding:5px 9px;background:var(--glass)}
+
+  /* ================= ACCESSIBILITY ================= */
+  /* The .reveal line is LOAD-BEARING: .reveal starts at opacity:0 and only
+     transitions to 1. Kill the transition without this and every section stays
+     invisible — the page renders blank. (That's a real bug in the old portal.) */
+  @media (prefers-reduced-motion: reduce){
+    html{scroll-behavior:auto}
+    *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+      transition-duration:.01ms!important;scroll-behavior:auto!important}
+    html.js .reveal{opacity:1;transform:none}
+    .layer,.lines,.dots,.grid-bg{display:none}
+  }
+
+  /* ================= CARD STAGGER ================= */
+  /* Generalized: the old rules only defined delays for nth-child(2|3), so a 4th
+     card animated with no delay. JS sets --i per card. min() caps the cascade at
+     ~600ms so a 14-card panel doesn't take a second to appear. */
+  .cat.in .card{animation-delay:calc(min(var(--i,0),10) * .06s)}
+
+  /* ================= STATUS DOTS ================= */
+  /* data-state, not className: the old JS did dot.className='dot up', which
+     REPLACES the class list and would wipe any other class on the element. */
+  .dot[data-state="up"]{background:var(--ok);box-shadow:0 0 10px rgba(52,211,153,.7)}
+  .dot[data-state="down"]{background:var(--down)}
+  .dot[data-state="starting"]{background:var(--wait)}
+  .dot[data-state="unknown"]{background:var(--dim)}
+
+  /* ================= TABS ================= */
+  .tabs{display:flex;gap:6px;align-items:center;margin:26px 0 6px;flex-wrap:wrap}
+  .tabs button{font-family:var(--sans);font-size:13.5px;font-weight:600;color:var(--mut);
+    background:transparent;border:1px solid transparent;border-radius:11px;padding:9px 15px;cursor:pointer;
+    transition:color .2s,background .2s,border-color .2s}
+  .tabs button:hover{color:var(--ink);background:var(--glass)}
+  .tabs button[aria-selected="true"]{color:var(--ink);background:var(--glass);border-color:var(--line2)}
+  .tabs .sp{flex:1}
+  .tabs .hint{font-family:var(--mono);font-size:11px;color:var(--dim)}
+  .tabs .hint kbd{border:1px solid var(--line2);border-radius:5px;padding:1px 5px;background:var(--glass)}
+  [role="tabpanel"][hidden]{display:none}
+
+  /* Stale: greyed but STILL CLICKABLE. If the API dies but Grafana is fine, the
+     links must keep working — losing them would be worse than stale data. */
+  .stale{opacity:.55;filter:saturate(.4);transition:opacity .3s}
+
+  /* ================= TOOLBAR ================= */
+  .tbar{display:flex;gap:12px;align-items:center;margin:18px 0 14px;flex-wrap:wrap}
+  .tbar input[type="search"]{flex:1;min-width:200px;font-family:var(--sans);font-size:13.5px;color:var(--ink);
+    background:var(--glass);border:1px solid var(--line);border-radius:11px;padding:10px 14px;outline:none;
+    transition:border-color .2s}
+  .tbar input[type="search"]:focus{border-color:color-mix(in srgb,var(--v) 55%,var(--line2))}
+  .chips{display:flex;gap:5px}
+  .chips button{font-family:var(--mono);font-size:11px;color:var(--dim);background:var(--glass);
+    border:1px solid var(--line);border-radius:999px;padding:6px 12px;cursor:pointer;transition:.2s}
+  .chips button:hover{color:var(--ink)}
+  .chips button.on{color:var(--ink);border-color:var(--line2);background:rgba(255,255,255,.06)}
+
+  /* ================= TABLE ================= */
+  /* Wrapper scrolls on its own — body{overflow-x:hidden} would clip it otherwise. */
+  .tbl-wrap{overflow-x:auto;border:1px solid var(--line);border-radius:16px;background:var(--glass)}
+  .tbl{width:100%;min-width:680px;border-collapse:collapse;font-size:13px}
+  .tbl th{text-align:left;font-family:var(--mono);font-size:10.5px;font-weight:500;color:var(--dim);
+    text-transform:uppercase;letter-spacing:.06em;padding:13px 16px;border-bottom:1px solid var(--line);
+    cursor:pointer;user-select:none;white-space:nowrap;transition:color .2s}
+  .tbl th:hover{color:var(--mut)}
+  .tbl th[aria-sort]{color:var(--ink)}
+  .tbl th[aria-sort="ascending"]::after{content:" ↑"}
+  .tbl th[aria-sort="descending"]::after{content:" ↓"}
+  .tbl td{padding:12px 16px;border-bottom:1px solid var(--line);vertical-align:middle}
+  .tbl tbody tr:last-child td{border-bottom:none}
+  .tbl tbody tr{transition:background .15s}
+  .tbl tbody tr:hover{background:rgba(255,255,255,.03)}
+  .tbl .mono{font-family:var(--mono);font-size:12px}
+  .tbl a:hover{color:var(--c)}
+
+  .tag{display:inline-flex;align-items:center;gap:5px;font-family:var(--mono);font-size:10.5px;
+    border-radius:999px;padding:3px 9px;border:1px solid var(--line2);white-space:nowrap}
+  /* Rose = reachable from the tailnet. This finally uses --p, which was dead
+     as an accent (it only appeared in the h1 gradient). */
+  .tag.public{color:var(--p);border-color:color-mix(in srgb,var(--p) 40%,transparent);
+    background:color-mix(in srgb,var(--p) 10%,transparent)}
+  .tag.loopback{color:var(--dim)}
+  .tag.warn{color:var(--am);border-color:color-mix(in srgb,var(--am) 40%,transparent);
+    background:color-mix(in srgb,var(--am) 10%,transparent)}
+  .tag.bad{color:var(--down);border-color:color-mix(in srgb,var(--down) 40%,transparent);
+    background:color-mix(in srgb,var(--down) 10%,transparent)}
+
+  /* ================= STATES ================= */
+  .state{border:1px solid var(--line);border-radius:16px;background:var(--glass);padding:40px 28px;text-align:center}
+  .state h4{font-family:var(--disp);font-size:16px;font-weight:600;margin-bottom:8px}
+  .state p{color:var(--mut);font-size:13.5px;max-width:56ch;margin:0 auto}
+  .state .btn{margin-top:18px}
+  .state.err h4{color:var(--down)}
+  .skel{border:1px solid var(--line);border-radius:22px;height:180px;margin-top:44px;
+    background:linear-gradient(90deg,var(--glass),rgba(255,255,255,.05),var(--glass));
+    background-size:200% 100%;animation:shim 1.4s linear infinite}
+  @keyframes shim{to{background-position:-200% 0}}
+
+  .badge{font-family:var(--mono);font-size:10px;color:var(--dim);border:1px solid var(--line);
+    border-radius:999px;padding:2px 8px;margin-left:8px}
+  @media(max-width:640px){ section{padding:90px 0} .cat{padding:22px} }
+
+  /* ================= TAB PANEL LAYOUT ================= */
+  /* section{padding:150px 0} was hitting every <section role="tabpanel">, so each
+     tab opened with ~150px of dead space before its first panel. Panels bring
+     their own margin. */
+  [role="tabpanel"]{padding:0}
+  [role="tabpanel"] > .cat:first-child{margin-top:22px}
+  .tbl-wrap{margin-top:0}
+
+  /* The page background (spirals/orbs) is busy; --glass at 2.6% alpha let it
+     bleed straight through the table and cards, which read as noise. Opaque-ish
+     surface + blur keeps the depth without costing legibility. */
+  .tbl-wrap,.cat,.card,.state{background:rgba(9,11,15,.72);backdrop-filter:blur(9px)}
+  .cat{background:linear-gradient(180deg,rgba(255,255,255,.02),transparent),rgba(9,11,15,.66)}
+
+  /* Long names + a badge were wrapping the title onto two lines and breaking
+     card alignment ("CVOps · Tilt"). Let the badge drop instead of the name. */
+  .nm{flex-wrap:wrap;align-items:center;row-gap:4px}
+  .nm .badge{flex:none}
+  .card .pt{overflow-wrap:anywhere}

--- a/apps/portal/html/portal.js
+++ b/apps/portal/html/portal.js
@@ -1,0 +1,764 @@
+// Dev-box portal — discovers what's running instead of being a hand-written list.
+//
+// Data comes from two read-only APIs, both same-origin under /-/api/* (see
+// ~/stacks/edge/dynamic/portal-api.yml), so there's no CORS anywhere:
+//
+//   Traefik  -> every route, including host processes (@file). The SKELETON.
+//   Docker   -> ports, health, images, compose labels.        ENRICHMENT.
+//
+// Either can die and the page still renders. See loadAll() / the failure notes.
+//
+// Everything above the "RENDER" banner is PURE — no DOM, no fetch, no globals —
+// so the join can be tested in node against the live APIs. That's deliberate:
+// the join is the part with real bugs in it.
+
+export const BASE = 'dev.test';
+const STACK_ROOT = '/home/devssh/stacks/';
+const INFRA_PROJECTS = new Set(['edge', 'portal']);
+
+// ── Pure: hostname handling ────────────────────────────────────────────────
+
+// Extract the Host() value from a Traefik rule.
+//
+// Returns null for ANYTHING it doesn't fully understand — `PathPrefix(`/`)`
+// (portal-fallback has no Host at all), HostRegexp, multi-host Host(`a`,`b`).
+// Guessing here silently files cards under the wrong project, which is worse
+// than not showing them: a null falls through to the Routes tab, visibly.
+export function extractHost(rule) {
+  if (typeof rule !== 'string') return null;
+  if (/HostRegexp/i.test(rule)) return null;
+  const m = rule.match(/Host\(`([^`]+)`\)/);
+  if (!m) return null;
+  // Host(`a`,`b`) — more than one host in a single call. Don't pick one.
+  if (/Host\(`[^`]+`\s*,/.test(rule)) return null;
+  return m[1];
+}
+
+// Where does a hostname sit in the dev.test hierarchy?
+//   dev.test            -> depth 0, the portal itself
+//   grafana.dev.test    -> depth 1, leaf 'grafana',  parent null
+//   s3.cvops.dev.test   -> depth 2, leaf 's3',       parent 'cvops'
+export function nest(host) {
+  if (!host) return { depth: null, parent: null, leaf: null };
+  if (host === BASE) return { depth: 0, parent: null, leaf: null };
+  if (!host.endsWith('.' + BASE)) return { depth: null, parent: null, leaf: host };
+  const labels = host.slice(0, -(BASE.length + 1)).split('.');
+  return {
+    depth: labels.length,
+    leaf: labels[0],
+    parent: labels.length > 1 ? labels[labels.length - 1] : null,
+  };
+}
+
+// ── Pure: classification ───────────────────────────────────────────────────
+
+// project vs stack vs infra, from the compose file's location on disk.
+// No hand-maintained list: a project is simply a compose file that doesn't
+// live under ~/stacks.
+export function classify(container) {
+  if (!container) return { group: 'host', groupKind: 'project' };
+  const labels = container.Labels || {};
+  const cfg = labels['com.docker.compose.project.config_files'];
+  const proj = labels['com.docker.compose.project'];
+  // minikube and anything else started outside compose has neither.
+  if (!cfg || !proj) return { group: 'unmanaged', groupKind: 'infra' };
+  const first = cfg.split(',')[0];
+  if (first.startsWith(STACK_ROOT)) {
+    return { group: proj, groupKind: INFRA_PROJECTS.has(proj) ? 'infra' : 'stack' };
+  }
+  return { group: proj, groupKind: 'project' };
+}
+
+const titleCase = (s) =>
+  String(s).replace(/[-_]+/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase());
+
+// ORDER MATTERS — first substring match wins. Vendor-prefixed images mean the
+// specific product must precede the vendor: grafana/loki would otherwise match
+// 'grafana' and show a dashboard icon.
+const IMAGE_ICONS = [
+  ['loki', '📜'], ['promtail', '📜'], ['dozzle', '📜'],
+  ['grafana', '📊'], ['prometheus', '🎯'],
+  ['traefik', '🚦'], ['portainer', '🐳'], ['socket-proxy', '🔌'],
+  ['nginx', '🌐'], ['postgres', '🐘'], ['redis', '🧠'], ['kafka', '🌊'],
+  ['garage', '🧊'], ['wiki', '📚'], ['minikube', '☸️'],
+  ['cadvisor', '📈'], ['node-exporter', '🖥️'], ['exporter', '📈'],
+];
+// Accepts either a normalized node (container.image) or a raw docker container
+// (container.Image) — the two differ in case and mixing them silently drops
+// every icon to a letter fallback.
+export function iconFor(node) {
+  const img = String(node.container?.image || node.container?.Image || '').toLowerCase();
+  for (const [k, v] of IMAGE_ICONS) if (img.includes(k)) return v;
+  return (node.name || '?').replace(/[^A-Za-z0-9]/g, '').charAt(0).toUpperCase() || '•';
+}
+
+// Display name for a compose project: `dev.portal.project` on ANY of its
+// containers names the whole project. One label fixes every breadcrumb, panel
+// title and unrouted card — titleCase can't know that "cvops" is "CVOps".
+export function projectNames(containers = []) {
+  const m = new Map();
+  for (const c of containers) {
+    const L = c.Labels || {};
+    const p = L['com.docker.compose.project'], n = L['dev.portal.project'];
+    if (p && n) m.set(p, n);
+  }
+  return m;
+}
+
+// Name with zero labels required. Labels only add polish — if this needs labels
+// to be *correct*, the defaults are wrong.
+export function defaultName(host, container, names = new Map()) {
+  const n = nest(host);
+  const proj = container?.Labels?.['com.docker.compose.project'];
+  const nice = (g) => names.get(g) || titleCase(g);
+
+  let base = container?.Labels?.['com.docker.compose.service'];
+  if (!base) base = n.leaf;
+  if (!base) base = (container?.Names?.[0] || '').replace(/^\//, '');
+  if (!base) base = 'unknown';
+  const title = titleCase(base);
+
+  // Routed under a project: s3.cvops.dev.test -> "CVOps · S3"
+  if (n.parent) return `${nice(n.parent)} · ${title}`;
+  // Unrouted but owned by a project: cvops-postgres-1 -> "CVOps · Postgres",
+  // so it can't be confused with the stack's own Postgres in another panel.
+  if (!host && proj && classify(container).groupKind === 'project' && titleCase(proj) !== title) {
+    return `${nice(proj)} · ${title}`;
+  }
+  return title;
+}
+
+// Non-HTTP things are listed but not linked — clicking an S3 or postgres
+// endpoint in a browser is never what you wanted.
+const NON_HTTP = ['garage', 'postgres', 'redis', 'kafka:', 'apache/kafka', 'socket-proxy'];
+export function isBrowsable(host, container) {
+  if (!host) return false;
+  const img = (container?.Image || '').toLowerCase();
+  return !NON_HTTP.some((k) => img.includes(k));
+}
+
+// ── Pure: status ───────────────────────────────────────────────────────────
+
+// Health IS a top-level field on /containers/json (docker 29 / API 1.55).
+// Strictly better than a no-cors probe, which can't tell a 502 error page from
+// success. The probe is kept ONLY for @file routes with no container.
+export function statusOf(container, kind) {
+  if (!container) return 'unknown';           // resolved by probe if routed
+  const h = container.Health || container.State?.Health?.Status;
+  if (h === 'healthy') return 'up';
+  if (h === 'unhealthy') return 'down';
+  if (h === 'starting') return 'starting';
+  return container.State === 'running' ? 'up' : 'down';
+}
+
+// ── Pure: the join ─────────────────────────────────────────────────────────
+
+// router -> service -> server url -> devnet IP -> container
+export function merge(routers = [], services = [], containers = []) {
+  const svcByKey = new Map(services.map((s) => [s.name, s]));
+  const names = projectNames(containers);
+
+  // devnet ONLY. Traefik runs --providers.docker.network=devnet so every
+  // docker-provider server URL is a devnet IP. Indexing all networks would
+  // collide: 172.18.0.x and 172.19.0.x both exist on this box.
+  const ctrByIp = new Map();
+  for (const c of containers) {
+    const ip = c.NetworkSettings?.Networks?.devnet?.IPAddress;
+    if (ip) ctrByIp.set(ip, c);
+  }
+  // Fallback join: containers carry their own traefik.http.routers.<n>.rule
+  // labels, so router->container survives a stale Traefik server IP.
+  const ctrByRouter = new Map();
+  for (const c of containers) {
+    for (const k of Object.keys(c.Labels || {})) {
+      const m = k.match(/^traefik\.http\.routers\.([^.]+)\./);
+      if (m) ctrByRouter.set(m[1], c);
+    }
+  }
+
+  const nodes = [];
+  const claimed = new Set();
+
+  // Pass 1 — everything Traefik routes.
+  for (const r of routers) {
+    const host = extractHost(r.rule);
+    if (!host) continue;                       // Routes tab only (portal-fallback)
+
+    // router.service has NO @provider suffix, but service.name does.
+    // Except dashboard@docker, whose service is already 'api@internal'.
+    const svcKey = r.service?.includes('@') ? r.service : `${r.service}@${r.provider}`;
+    const svc = svcByKey.get(svcKey);
+    const urls = svc?.loadBalancer?.servers?.map((s) => s.url).filter(Boolean) || [];
+
+    let container = null;
+    for (const u of urls) {
+      let ip;
+      try { ip = new URL(u).hostname; } catch { continue; }
+      if (ctrByIp.has(ip)) { container = ctrByIp.get(ip); break; }
+    }
+    if (!container) container = ctrByRouter.get(String(r.name).split('@')[0]) || null;
+    if (container) claimed.add(container.Id);
+
+    nodes.push(makeNode({
+      route: r, host, serverUrls: urls, container, names,
+      kind: container ? 'routed' : 'orphan-route',
+    }));
+  }
+
+  // Pass 2 — containers with no route that still publish a port. "Route OR
+  // published port" is the correct definition of "a thing a human can reach".
+  // Drops promtail/exporters (no route, no port) — they're plumbing.
+  for (const c of containers) {
+    if (claimed.has(c.Id)) continue;
+    if (!(c.Ports || []).some((p) => p.PublicPort)) continue;
+    nodes.push(makeNode({ route: null, host: null, container: c, names, kind: 'unrouted' }));
+  }
+
+  return nodes;
+}
+
+function makeNode({ route, host, serverUrls = [], container, kind, names = new Map() }) {
+  const n = nest(host);
+  const cls = classify(container);
+  const L = container?.Labels || {};
+  const pick = (key, fallback) => L[`dev.portal.${key}`] ?? fallback;
+
+  const name = pick('name', defaultName(host, container, names));
+  const path = pick('path', '');
+  const browsable = isBrowsable(host, container);
+
+  const node = {
+    id: route ? route.name : `container:${container?.Id?.slice(0, 12)}`,
+    kind,
+    name,
+    host: host || null,
+    path,
+    url: host && browsable ? `http://${host}${path}` : null,
+    browsable,
+    // hostname nesting BEATS config_files: it's what puts cvops-tilt@file (no
+    // container at all) in the CVOps panel. Makes the DNS convention load-bearing.
+    group: pick('group', n.parent || cls.group),
+    groupKind: pick('groupKind', n.parent ? 'project' : cls.groupKind),
+    parent: n.parent,
+    depth: n.depth,
+    order: Number(pick('order', 100)) || 100,
+    hidden: pick('hidden', 'false') === 'true',
+    route: route ? {
+      router: route.name, provider: route.provider, rule: route.rule,
+      priority: route.priority, entryPoints: route.entryPoints,
+      status: route.status, serverUrls,
+    } : null,
+    container: container ? {
+      id: container.Id.slice(0, 12),
+      name: (container.Names?.[0] || '').replace(/^\//, ''),
+      image: container.Image,
+      state: container.State,
+      statusText: container.Status,
+      health: container.Health || null,
+      labels: L,
+    } : null,
+    ports: portsOf(container),
+    status: statusOf(container, kind),
+  };
+  node.icon = pick('icon', iconFor(node));
+  node.desc = pick('desc', defaultDesc(node));
+  return node;
+}
+
+function defaultDesc(node) {
+  if (node.kind === 'orphan-route' && node.route?.provider === 'file') {
+    return 'Host process reached through the edge. Expect 502 when it is not running.';
+  }
+  if (node.kind === 'orphan-route') {
+    return 'Route registered, but no container found on devnet — it may have stopped.';
+  }
+  if (node.kind === 'unrouted') {
+    return `${node.container?.image || 'Container'} — published port, no edge route.`;
+  }
+  return `${node.container?.image || ''}`.trim() || 'Routed service.';
+}
+
+// Docker lists 0.0.0.0 and :: as separate rows for the same bind — collapse
+// them, prefer IPv4, or every port shows twice.
+export function portsOf(container) {
+  if (!container?.Ports) return [];
+  const seen = new Map();
+  for (const p of container.Ports) {
+    if (!p.PublicPort) continue;               // internal-only, not reachable
+    const ip = p.IP === '::' ? '0.0.0.0' : (p.IP || '0.0.0.0');
+    const key = `${ip}:${p.PublicPort}/${p.Type}`;
+    if (seen.has(key)) continue;
+    seen.set(key, {
+      hostIp: ip,
+      hostPort: p.PublicPort,
+      containerPort: p.PrivatePort,
+      proto: p.Type,
+      scope: ip === '127.0.0.1' ? 'loopback' : 'public',
+    });
+  }
+  return [...seen.values()].sort((a, b) => a.hostPort - b.hostPort);
+}
+
+// Every published port on the box, flattened — the collision map.
+export function allPorts(containers = []) {
+  const rows = [];
+  for (const c of containers) {
+    const cls = classify(c);
+    for (const p of portsOf(c)) {
+      rows.push({
+        ...p,
+        container: (c.Names?.[0] || '').replace(/^\//, ''),
+        image: c.Image,
+        group: cls.group,
+        groupKind: cls.groupKind,
+      });
+    }
+  }
+  return rows;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// RENDER — everything below touches the DOM. Everything above is pure.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// @file routers have no container to label, so overrides live here. Two entries
+// isn't a config system. If this reaches ~8, promote it to a fetched portal.json.
+const HOST_OVERRIDES = {
+  'tilt.cvops.dev.test': { icon: '🔧', desc: 'Build logs, resource status and manual triggers for the CVOps dev loop. Needs `tilt up --host=0.0.0.0`.' },
+};
+
+// Last-resort floor: shown only if BOTH APIs are unreachable. This is the page
+// you open when things are broken, so it must never be blank.
+const KNOWN_HOSTS = [
+  ['dev.test', 'Portal'], ['grafana.dev.test', 'Grafana'], ['prometheus.dev.test', 'Prometheus'],
+  ['dozzle.dev.test', 'Dozzle'], ['portainer.dev.test', 'Portainer'], ['kafka.dev.test', 'Kafka UI'],
+  ['wiki.dev.test', 'Wiki.js'], ['traefik.dev.test', 'Traefik'], ['cvops.dev.test', 'CVOps'],
+];
+
+const ACCENTS = ['--v', '--c', '--am', '--em', '--p'];
+const POLL_OK = 10_000, POLL_FAIL = 60_000, MAX_BACKOFF = 3;
+const state = { nodes: [], ports: [], routers: [], errors: [], at: 0, fails: 0, tab: 'services', q: '', filter: 'all',
+  sort: { key: 'hostPort', dir: 1 }, sig: null, portSig: null, routeSig: null };
+const $ = (s, r = document) => r.querySelector(s);
+const el = (t, cls, txt) => { const e = document.createElement(t); if (cls) e.className = cls; if (txt != null) e.textContent = txt; return e; };
+
+// ── fetch ──────────────────────────────────────────────────────────────────
+async function getJSON(path, signal) {
+  const r = await fetch(path, { signal, cache: 'no-store' });
+  if (!r.ok) { const e = new Error(`${r.status}`); e.status = r.status; e.path = path; throw e; }
+  return r.json();
+}
+async function loadAll() {
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), 5000);
+  try {
+    // allSettled, not all: partial results are first-class. Traefik is the
+    // skeleton, docker is enrichment — either can die alone.
+    const [routers, services, containers] = await Promise.allSettled([
+      getJSON('/-/api/traefik/http/routers', ac.signal),
+      getJSON('/-/api/traefik/http/services', ac.signal),
+      getJSON('/-/api/docker/containers/json', ac.signal),
+    ]);
+    const errors = [];
+    const R = routers.status === 'fulfilled' ? routers.value : (errors.push({ src: 'traefik', e: routers.reason }), []);
+    const S = services.status === 'fulfilled' ? services.value : [];
+    const C = containers.status === 'fulfilled' ? containers.value : (errors.push({ src: 'docker', e: containers.reason }), []);
+    if (!R.length && !C.length) throw new Error('both APIs unreachable');
+    return { routers: R, nodes: merge(R, S, C), ports: allPorts(C), errors };
+  } finally { clearTimeout(t); }
+}
+
+// ── grouping ───────────────────────────────────────────────────────────────
+// Projects get one panel each. Stack collapses into ONE panel: each stack
+// service is its own compose project (monitoring, mgmt, kafka, wiki, postgres,
+// redis), which would otherwise render six near-empty panels for no gain.
+function panelize(nodes) {
+  const vis = nodes.filter((n) => !n.hidden);
+  // A project's display name comes from its own depth-1 node if labelled, so
+  // "cvops" can present as "CVOps" in breadcrumbs without a second label.
+  const nice = new Map();
+  for (const n of vis) {
+    const L = n.container?.labels || {};
+    if (L['dev.portal.project']) nice.set(n.group, L['dev.portal.project']);
+  }
+  const title = (g) => nice.get(g) || g.replace(/[-_]/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase());
+  const byOrder = (a, b) => (a.depth ?? 9) - (b.depth ?? 9) || a.order - b.order || a.name.localeCompare(b.name);
+
+  const panels = [];
+  const projects = [...new Set(vis.filter((n) => n.groupKind === 'project').map((n) => n.group))].sort();
+  for (const g of projects) panels.push({ title: title(g), sub: 'project · ' + g, nodes: vis.filter((n) => n.group === g).sort(byOrder) });
+
+  const stack = vis.filter((n) => n.groupKind === 'stack').sort((a, b) => a.group.localeCompare(b.group) || byOrder(a, b));
+  if (stack.length) panels.push({ title: 'Stack', sub: 'shared dev services · ' + [...new Set(stack.map((n) => n.group))].join(' · '), nodes: stack });
+
+  const infra = vis.filter((n) => n.groupKind === 'infra').sort(byOrder);
+  if (infra.length) panels.push({ title: 'Infrastructure', sub: 'the edge itself · usually you can ignore this', nodes: infra });
+  return panels;
+}
+
+// ── services tab ───────────────────────────────────────────────────────────
+function cardFor(node, i) {
+  const ov = HOST_OVERRIDES[node.host] || {};
+  const clickable = node.browsable && node.url;
+  const c = el(clickable ? 'a' : 'div', 'card');
+  c.dataset.id = node.id;                    // stable key for reconciliation
+  c.style.setProperty('--i', String(i));
+  if (clickable) { c.href = node.url; c.title = node.url; }
+
+  const row = el('div', 'row');
+  row.append(el('div', 'ico', ov.icon || node.icon));
+  const meta = el('div');
+  const nm = el('div', 'nm', node.name);
+  const dot = el('span', 'dot');
+  dot.dataset.state = node.status;                 // never touches className
+  dot.title = node.container?.statusText || node.status;
+  nm.append(dot);
+  if (node.route?.provider === 'file') nm.append(Object.assign(el('span', 'badge', 'host process'), { title: 'Runs on the host, not in a container' }));
+  if (node.kind === 'orphan-route' && node.route?.provider === 'docker') nm.append(el('span', 'badge', 'no container'));
+  meta.append(nm, el('div', 'pt', node.host || node.ports.map((p) => `:${p.hostPort}`).join(' ') || node.container?.name || ''));
+  row.append(meta);
+
+  c.append(row, el('div', 'desc', ov.desc || node.desc));
+  const go = el('span', clickable ? 'go' : 'go cli');
+  go.textContent = clickable ? 'Open ' : (node.ports.length ? `${node.ports[0].proto.toUpperCase()} · not a web UI` : 'no route');
+  if (clickable) go.insertAdjacentHTML('beforeend', '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg>');
+  c.append(go);
+  return c;
+}
+
+// Signature of everything the Services tab actually displays. Poll returns are
+// usually byte-identical, so this lets us skip the DOM entirely most of the time.
+function sigOf(nodes) {
+  return nodes.map((n) => `${n.id}|${n.status}|${n.name}|${n.url}|${n.desc}`).join('\n');
+}
+
+function renderServices() {
+  const root = $('#tab-services');
+  const q = state.q.toLowerCase();
+  let panels = panelize(state.nodes);
+  if (q) {
+    panels = panels
+      .map((p) => ({ ...p, nodes: p.nodes.filter((n) => `${n.name} ${n.host} ${n.group} ${n.container?.image || ''}`.toLowerCase().includes(q)) }))
+      .filter((p) => p.nodes.length);
+  }
+
+  // Nothing displayed has changed -> touch nothing. Rebuilding identical DOM
+  // re-runs the entrance animation on every card, which reads as the whole page
+  // flashing/jumping every poll. This guard is why the page sits still.
+  const sig = state.tab + '\u0000' + q + '\u0000' + sigOf(panels.flatMap((p) => p.nodes)) + '\u0000' + panels.map((p) => p.title).join(',');
+  if (sig === state.sig && root.querySelector('.cat')) return;
+  state.sig = sig;
+
+  // Clear the loading skeleton, any error/empty state, and the static floor.
+  // The floor's .cat has no data-panel, so the reconciler below would never
+  // remove it and real panels would stack underneath it.
+  root.querySelectorAll('.skel, .state, .cat:not([data-panel])').forEach((e) => e.remove());
+  if (!panels.length) { root.textContent = ''; root.append(emptyState(`No services match “${state.q}”`)); return; }
+
+  // ── reconcile panels by title (stable key) ───────────────────────────────
+  const keep = new Set();
+  panels.forEach((p, i) => {
+    keep.add(p.title);
+    let cat = root.querySelector(`.cat[data-panel="${CSS.escape(p.title)}"]`);
+    if (!cat) {
+      cat = el('div', 'cat reveal');
+      cat.dataset.panel = p.title;
+      const head = el('div', 'cat-head');
+      head.append(el('span', 'cat-idx'));
+      const tw = el('div'); tw.append(el('h3'), el('div', 'cat-sub'));
+      head.append(tw, el('span', 'tail'), el('span', 'cnt'));
+      cat.append(head, el('div', 'grid'));
+      root.append(cat);
+      observeReveals(root);
+    }
+    cat.style.setProperty('--acc', `var(${ACCENTS[i % ACCENTS.length]})`);
+    setText(cat.querySelector('.cat-idx'), String(i + 1).padStart(2, '0'));
+    setText(cat.querySelector('h3'), p.title);
+    setText(cat.querySelector('.cat-sub'), p.sub);
+    setText(cat.querySelector('.cnt'), String(p.nodes.length));
+
+    // ── reconcile cards by node id ─────────────────────────────────────────
+    const grid = cat.querySelector('.grid');
+    const alive = new Set();
+    p.nodes.forEach((n, j) => {
+      alive.add(n.id);
+      let card = grid.querySelector(`[data-id="${CSS.escape(n.id)}"]`);
+      if (!card) { card = cardFor(n, j); grid.append(card); }   // new -> animates once, correctly
+      else patchCard(card, n);                                   // existing -> update in place, no animation
+      card.style.setProperty('--i', String(j));
+    });
+    grid.querySelectorAll('[data-id]').forEach((c) => { if (!alive.has(c.dataset.id)) c.remove(); });
+  });
+  root.querySelectorAll('.cat[data-panel]').forEach((c) => { if (!keep.has(c.dataset.panel)) c.remove(); });
+
+  probeOrphans();
+}
+
+const setText = (e, v) => { if (e && e.textContent !== v) e.textContent = v; };
+
+// Update an existing card without replacing it. Every write is guarded by a
+// comparison so we never dirty the DOM (or restart a transition) for no reason.
+function patchCard(card, n) {
+  const ov = HOST_OVERRIDES[n.host] || {};
+  const dot = card.querySelector('.dot');
+  if (dot && dot.dataset.state !== n.status) {
+    dot.dataset.state = n.status;                       // transitions colour smoothly
+    dot.title = n.container?.statusText || n.status;
+  }
+  setText(card.querySelector('.ico'), ov.icon || n.icon);
+  const nm = card.querySelector('.nm');
+  if (nm && nm.firstChild && nm.firstChild.nodeType === 3) setText(nm.firstChild, n.name);
+  setText(card.querySelector('.pt'), n.host || n.ports.map((p) => `:${p.hostPort}`).join(' ') || n.container?.name || '');
+  setText(card.querySelector('.desc'), ov.desc || n.desc);
+  const url = n.browsable && n.url ? n.url : null;
+  if (url && card.tagName === 'A' && card.getAttribute('href') !== url) { card.href = url; card.title = url; }
+}
+
+// ── ports tab ──────────────────────────────────────────────────────────────
+const PORT_COLS = [
+  ['hostPort', 'Host'], ['containerPort', '→ Container'], ['container', 'Container'],
+  ['group', 'Group'], ['proto', 'Proto'], ['scope', 'Scope'],
+];
+function renderPorts() {
+  const root = $('#tab-ports');
+  // Same anti-flicker guard as the Services tab: identical data -> no DOM work.
+  // Without this the table is destroyed and rebuilt every 10s, which throws away
+  // focus, text selection and scroll position mid-read.
+  const sig = 'ports\u0000' + state.q + '\u0000' + (state.filter || 'all') + '\u0000' + state.sort.key + state.sort.dir +
+    '\u0000' + state.ports.map((r) => `${r.hostIp}:${r.hostPort}>${r.containerPort}|${r.container}|${r.scope}`).join(';');
+  const focused = document.activeElement?.id === 'q';
+  if (sig === state.portSig && root.querySelector('.tbl')) return;
+  state.portSig = sig;
+  root.textContent = '';
+  if (!state.ports.length) {
+    return root.append(errState('Container data unavailable',
+      'Ports come from Docker — Traefik does not know about them. The socket-proxy looks unreachable. Everything else on this page still works.'));
+  }
+  const bar = el('div', 'tbar');
+  const inp = Object.assign(el('input'), { type: 'search', id: 'q', placeholder: 'Filter ports…   /', value: state.q });
+  inp.addEventListener('input', debounce(() => { state.q = inp.value; state.portSig = null; setHash(); renderPorts(); }, 120));
+  const chips = el('div', 'chips');
+  for (const [f, label] of [['all', 'All'], ['public', 'Exposed'], ['loopback', 'Loopback']]) {
+    const b = el('button', state.filter === f || (!state.filter && f === 'all') ? 'on' : '', label);
+    b.onclick = () => { state.filter = f; state.portSig = null; renderPorts(); };
+    chips.append(b);
+  }
+  const cnt = el('span', 'cnt');
+  bar.append(inp, chips, cnt);
+
+  let rows = state.ports.slice();
+  if (state.filter && state.filter !== 'all') rows = rows.filter((r) => r.scope === state.filter);
+  const q = state.q.toLowerCase();
+  if (q) rows = rows.filter((r) => `${r.hostPort} ${r.containerPort} ${r.container} ${r.group} ${r.image} ${r.scope}`.toLowerCase().includes(q));
+  const { key, dir } = state.sort;
+  rows.sort((a, b) => (typeof a[key] === 'number' ? a[key] - b[key] : String(a[key]).localeCompare(String(b[key]))) * dir || a.hostPort - b.hostPort);
+  cnt.textContent = `${rows.length} of ${state.ports.length}`;
+
+  const wrap = el('div', 'tbl-wrap'), tbl = el('table', 'tbl'), thead = el('thead'), htr = el('tr');
+  for (const [k, label] of PORT_COLS) {
+    const th = el('th', null, label); th.dataset.sort = k;
+    if (key === k) th.setAttribute('aria-sort', dir === 1 ? 'ascending' : 'descending');
+    th.onclick = () => { state.sort = { key: k, dir: key === k ? -dir : 1 }; state.portSig = null; renderPorts(); };
+    htr.append(th);
+  }
+  thead.append(htr);
+  const tb = el('tbody');
+  for (const r of rows) {
+    const tr = el('tr');
+    // Show the address that works from where you're reading, not 0.0.0.0.
+    const shown = r.hostIp === '0.0.0.0' ? location.hostname : r.hostIp;
+    const c1 = el('td'); const a = el(r.scope === 'public' ? 'a' : 'span', 'mono', `${shown}:${r.hostPort}`);
+    if (r.scope === 'public') { a.href = `http://${shown}:${r.hostPort}`; }
+    a.title = `bound on ${r.hostIp}`; c1.append(a);
+    tr.append(c1, el('td', 'mono', String(r.containerPort)), el('td', null, r.container), el('td', 'mono', r.group), el('td', 'mono', r.proto));
+    const c6 = el('td'); c6.append(el('span', `tag ${r.scope}`, r.scope === 'public' ? 'exposed' : 'loopback')); tr.append(c6);
+    tb.append(tr);
+  }
+  tbl.append(thead, tb); wrap.append(tbl); root.append(bar, wrap);
+  // Rebuilding the toolbar blurs the filter box mid-keystroke; restore it.
+  if (focused) { inp.focus(); inp.setSelectionRange(inp.value.length, inp.value.length); }
+}
+
+// ── routes tab ─────────────────────────────────────────────────────────────
+function renderRoutes() {
+  const root = $('#tab-routes');
+  const sig = 'routes\u0000' + state.routers.map((r) => `${r.name}|${r.rule}|${r.status}`).join(';');
+  if (sig === state.routeSig && root.querySelector('.tbl')) return;
+  state.routeSig = sig;
+  root.textContent = '';
+  if (!state.routers.length) return root.append(errState('Traefik API unreachable', 'Check edge/dynamic/portal-api.yml is loaded: docker logs traefik'));
+  const byRouter = new Map(state.nodes.filter((n) => n.route).map((n) => [n.route.router, n]));
+  const wrap = el('div', 'tbl-wrap'), tbl = el('table', 'tbl');
+  tbl.innerHTML = '<thead><tr><th>Router</th><th>Rule</th><th>Provider</th><th>Service</th><th>Target</th><th>State</th></tr></thead>';
+  const tb = el('tbody');
+  for (const r of state.routers.slice().sort((a, b) => a.name.localeCompare(b.name))) {
+    const n = byRouter.get(r.name), tr = el('tr');
+    tr.append(el('td', 'mono', r.name.split('@')[0]), el('td', 'mono', r.rule), el('td', 'mono', r.provider || '—'), el('td', 'mono', r.service || '—'),
+      el('td', 'mono', n?.route?.serverUrls?.join(', ') || n?.container?.name || '—'));
+    const st = el('td');
+    if (n?.kind === 'orphan-route' && r.provider === 'file') st.append(el('span', 'tag warn', 'host process'));
+    else if (n?.kind === 'orphan-route') st.append(el('span', 'tag bad', 'no container'));
+    else if (r.status === 'enabled') st.append(el('span', 'tag', 'ok'));
+    else st.append(el('span', 'tag bad', r.status || '?'));
+    tr.append(st); tb.append(tr);
+  }
+  tbl.append(tb); wrap.append(tbl); root.append(wrap);
+}
+
+// ── shared UI ──────────────────────────────────────────────────────────────
+function emptyState(msg) {
+  const s = el('div', 'state'); s.append(el('h4', null, msg));
+  const b = el('a', 'btn ghost', 'Clear filter'); b.href = 'javascript:void 0';
+  b.onclick = () => { state.q = ''; setHash(); render(); };
+  s.append(b); return s;
+}
+function errState(title, body) {
+  const s = el('div', 'state err'); s.append(el('h4', null, title), el('p', null, body));
+  const b = el('a', 'btn ghost', 'Retry'); b.href = 'javascript:void 0'; b.onclick = () => tick();
+  s.append(b); return s;
+}
+function staticFloor() {
+  const root = $('#tab-services');
+  if (root.querySelector('.state.err')) return;   // already showing; don't rebuild (it would flicker)
+  root.textContent = '';
+  root.append(errState('Cannot reach the APIs', 'Showing known service names only — live status, ports and projects are unavailable. Traefik or the portal API routes may be down. The links below still work if the services do.'));
+  const cat = el('div', 'cat reveal in'); cat.style.setProperty('--acc', 'var(--v)');
+  const grid = el('div', 'grid');
+  KNOWN_HOSTS.forEach(([h, name], i) => grid.append(cardFor({ name, host: h, url: `http://${h}`, browsable: true, icon: '•', desc: 'Known service — status unavailable.', status: 'unknown', ports: [], order: 100 }, i)));
+  cat.append(grid); root.append(cat);
+  probeAll(KNOWN_HOSTS.map(([h]) => h));
+}
+
+// no-cors probe: ONLY for things with no container to ask (host processes,
+// static floor). Everything else uses Docker's Health, which is honest.
+function probeOrphans() {
+  for (const n of state.nodes) {
+    if (n.kind !== 'orphan-route' || !n.url) continue;
+    probe(n.url).then((ok) => {
+      n.status = ok ? 'up' : 'down';
+      document.querySelectorAll(`.card[title="${n.url}"] .dot`).forEach((d) => { d.dataset.state = n.status; });
+    });
+  }
+}
+function probeAll(hosts) {
+  hosts.forEach((h) => probe(`http://${h}/`).then((ok) => {
+    document.querySelectorAll(`.card[title="http://${h}"] .dot`).forEach((d) => { d.dataset.state = ok ? 'up' : 'down'; });
+  }));
+}
+const probe = (u) => Promise.race([
+  fetch(u, { mode: 'no-cors', cache: 'no-store' }).then(() => true),
+  new Promise((r) => setTimeout(() => r(false), 4500)),
+]).catch(() => false);
+
+// ── hero / freshness ───────────────────────────────────────────────────────
+function renderHero() {
+  const up = state.nodes.filter((n) => n.status === 'up').length;
+  const projects = new Set(state.nodes.filter((n) => n.groupKind === 'project').map((n) => n.group)).size;
+  const stacks = new Set(state.nodes.filter((n) => n.groupKind === 'stack').map((n) => n.group)).size;
+  const pulse = $('.pulse'), txt = $('#status-txt');
+  if (state.fails === 0) {
+    txt.textContent = `${up}/${state.nodes.length} up · ${projects} project${projects === 1 ? '' : 's'} · ${stacks} stacks`;
+    if (pulse) pulse.style.background = 'var(--ok)';
+  } else {
+    const age = Math.round((Date.now() - state.at) / 1000);
+    txt.textContent = state.at ? `Stale · last seen ${age}s ago · retrying` : 'Cannot reach APIs · retrying';
+    if (pulse) { pulse.style.background = state.at ? 'var(--wait)' : 'var(--down)'; pulse.style.animation = 'none'; }
+  }
+  setNum('#n-services', state.nodes.length); setNum('#n-projects', projects);
+  setNum('#n-ports', state.ports.length); setNum('#n-stacks', stacks);
+  document.querySelectorAll('main, #tab-services, #tab-ports, #tab-routes').forEach((e) => e.classList.toggle('stale', state.fails > 0));
+}
+const setNum = (sel, v) => { const e = $(sel); if (e) { e.dataset.count = String(v); e.textContent = String(v); } };
+
+// ── tabs / hash ────────────────────────────────────────────────────────────
+const TABS = new Set(['services', 'ports', 'routes']);
+function readHash() {
+  const [tab = 'services', ...rest] = location.hash.slice(1).split('/');
+  return { tab: TABS.has(tab) ? tab : 'services', q: decodeURIComponent(rest.join('/') || '') };
+}
+// replaceState, not location.hash= : otherwise every keystroke is a back entry.
+function setHash() {
+  const h = '#' + state.tab + (state.q ? '/' + encodeURIComponent(state.q) : '');
+  history.replaceState(null, '', h);
+}
+function route() {
+  const { tab, q } = readHash();
+  state.tab = tab; state.q = q; state.sig = null;  // tab/filter change -> force a repaint
+  for (const t of TABS) {
+    $(`#tab-${t}`).hidden = t !== tab;
+    $(`.tabs button[data-tab="${t}"]`)?.setAttribute('aria-selected', String(t === tab));
+  }
+  render();
+}
+function render() {
+  renderHero();
+  if (state.tab === 'services') {
+    if (state.nodes.length) renderServices();
+    else if (state.fails > 0) staticFloor();   // tried and failed -> known-hosts floor
+    // else: no data yet and no failure -> leave the skeleton up
+  }
+  else if (state.tab === 'ports') renderPorts();
+  else renderRoutes();
+}
+
+// ── behaviours that must survive re-render ─────────────────────────────────
+// The originals were one-shot querySelectorAll at parse time: they'd silently
+// do nothing on dynamically created cards.
+let io;
+function observeReveals(root) {
+  io ??= new IntersectionObserver((es) => es.forEach((e) => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } }), { threshold: .12 });
+  root.querySelectorAll('.reveal:not(.in)').forEach((e) => io.observe(e));
+}
+function delegateSpotlight() {
+  document.addEventListener('mousemove', (e) => {
+    const c = e.target.closest?.('.card'); if (!c) return;
+    const r = c.getBoundingClientRect();
+    c.style.setProperty('--mx', (e.clientX - r.left) + 'px');
+    c.style.setProperty('--my', (e.clientY - r.top) + 'px');
+  }, { passive: true });
+}
+const debounce = (fn, ms) => { let t; return (...a) => { clearTimeout(t); t = setTimeout(() => fn(...a), ms); }; };
+const isTyping = (t) => /^(INPUT|TEXTAREA|SELECT)$/.test(t?.tagName) || t?.isContentEditable;
+
+// ── poll loop ──────────────────────────────────────────────────────────────
+let timer;
+async function tick() {
+  try {
+    const d = await loadAll();
+    Object.assign(state, { nodes: d.nodes, ports: d.ports, routers: d.routers, errors: d.errors, at: Date.now(), fails: 0 });
+    render();
+  } catch (e) {
+    state.fails++; renderHero();
+    if (!state.nodes.length) render();     // never blank: fall to the static floor
+  } finally { schedule(); }
+}
+function schedule() {
+  clearTimeout(timer);
+  if (document.hidden) return;             // this page lives in a background tab for days
+  timer = setTimeout(tick, state.fails >= MAX_BACKOFF ? POLL_FAIL : POLL_OK);
+}
+
+// ── init ───────────────────────────────────────────────────────────────────
+export function init() {
+  // FIRST: opt into the JS-only styles. portal.css hides .reveal only under
+  // html.js, so if this module never runs the page still renders in full.
+  document.documentElement.classList.add('js');
+  const via = $('#via'); if (via) via.textContent = location.hostname.startsWith('100.') ? 'tailscale · ' + location.hostname : location.hostname;
+  document.querySelectorAll('.tabs button[data-tab]').forEach((b) => { b.onclick = () => { location.hash = '#' + b.dataset.tab; }; });
+  addEventListener('hashchange', route);
+  document.addEventListener('visibilitychange', () => { if (!document.hidden) tick(); });
+  addEventListener('keydown', (e) => {
+    if (isTyping(e.target)) { if (e.key === 'Escape') e.target.blur(); return; }
+    if (e.key === '/') { e.preventDefault(); location.hash = '#ports'; setTimeout(() => $('#q')?.focus(), 0); }
+    else if (e.key === 'r') tick();
+    else if (e.key === 'Escape' && state.q) { state.q = ''; setHash(); render(); }
+  });
+  delegateSpotlight();
+  // Observe EVERY .reveal in the document, not just the ones inside the tabs.
+  // .reveal starts at opacity:0 and only becomes visible when .in is added, so
+  // anything unobserved stays permanently invisible — the hero, the headline
+  // and the section head all live outside #tab-services and would vanish.
+  observeReveals(document);
+  route();
+  tick();
+}

--- a/apps/wiki/compose.yml
+++ b/apps/wiki/compose.yml
@@ -4,6 +4,12 @@ services:
   wiki:
     image: ghcr.io/requarks/wiki:2
     container_name: wiki
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.wiki.rule=Host(`wiki.dev.test`)
+      - traefik.http.routers.wiki.entrypoints=web
+      - traefik.http.routers.wiki.service=wiki
+      - traefik.http.services.wiki.loadbalancer.server.port=3000
     restart: unless-stopped
     environment:
       DB_TYPE: postgres

--- a/data/kafka/compose.yml
+++ b/data/kafka/compose.yml
@@ -38,6 +38,14 @@ services:
   kafka-ui:
     image: kafbat/kafka-ui:latest
     container_name: kafka-ui
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.kafka.rule=Host(`kafka.dev.test`)
+      - traefik.http.routers.kafka.entrypoints=web
+      - traefik.http.routers.kafka.service=kafka
+      - traefik.http.services.kafka.loadbalancer.server.port=8080
+      - dev.portal.name=Kafka UI
+      - dev.portal.desc=Browse the single-node KRaft broker — topics, partitions, consumer groups and live messages.
     restart: unless-stopped
     ports:
       - "8081:8080"

--- a/edge/compose.yml
+++ b/edge/compose.yml
@@ -1,0 +1,72 @@
+name: edge
+
+# The single front door for everything on this box.
+#
+# Why this exists: host ports are a flat global namespace with no allocator, so
+# every project reaches for 3000/8080/5432 and collides with whatever got there
+# first. Traefik routes by Host header instead, so services stop competing for
+# port numbers entirely — a new project publishes NO host port, it just declares
+# a name. Names are infinite; ports are 65535 and everyone picks the same dozen.
+#
+# Consequence: this is the ONLY container that should ever publish :80, and the
+# Tailscale/portproxy layer needs exactly one rule, forever.
+
+services:
+  traefik:
+    image: traefik:v3.6
+    container_name: traefik
+    restart: unless-stopped
+    command:
+      # Discover routes from container labels. exposedbydefault=false means a
+      # container is invisible until it opts in with traefik.enable=true, so
+      # nothing gets published by accident just by joining devnet.
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      # Containers sit on several networks (devnet, project-local, minikube).
+      # Pin discovery to devnet or Traefik may pick the wrong container IP.
+      - --providers.docker.network=devnet
+      # File provider for things that AREN'T containers — host processes like
+      # Tilt's UI have no labels to discover, so they're declared in ./dynamic.
+      # watch=true picks up edits live; no Traefik restart needed to add a route.
+      - --providers.file.directory=/etc/traefik/dynamic
+      - --providers.file.watch=true
+      - --entrypoints.web.address=:80
+      - --api.dashboard=true
+      - --log.level=INFO
+      - --accesslog=true
+    environment:
+      # Traefik's bundled Docker SDK falls back to API v1.24 when it doesn't
+      # negotiate, and this daemon (29.6.1, API 1.55) rejects anything below
+      # 1.40 — the provider then silently loads no routes and every request
+      # 404s. Pin a version inside the daemon's supported range.
+      DOCKER_API_VERSION: "1.44"
+    ports:
+      - "80:80"
+    volumes:
+      # Read-only: Traefik only needs to watch the container list. The socket is
+      # root-equivalent, so never mount it writable here.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./dynamic:/etc/traefik/dynamic:ro
+    extra_hosts:
+      # Lets the file-provider routes above reach processes on the host
+      # (Tilt UI, and any future host-side dev server).
+      - "host.docker.internal:host-gateway"
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.dashboard.rule=Host(`traefik.dev.test`)
+      - traefik.http.routers.dashboard.entrypoints=web
+      - traefik.http.routers.dashboard.service=api@internal
+    deploy:
+      resources:
+        limits:
+          memory: 128m
+    # socketnet: reaches portal-socket-proxy for the portal's read-only Docker
+    # API (see edge/dynamic/portal-api.yml). Traefik and the proxy are the only
+    # two members — the proxy has no auth, so reachability is authorisation.
+    networks: [devnet, socketnet]
+
+networks:
+  devnet:
+    external: true
+  socketnet:
+    external: true

--- a/edge/dynamic/host-services.yml
+++ b/edge/dynamic/host-services.yml
@@ -1,0 +1,35 @@
+# Traefik routes for processes running on the HOST, not in containers.
+#
+# Containers declare themselves with labels (see any compose.yml). A host
+# process has nothing to label, so it goes here instead. Traefik watches this
+# directory — edits apply live, no restart.
+#
+# host.docker.internal resolves to the host gateway via extra_hosts in
+# ../compose.yml. The host process must bind an address the container can
+# actually reach: 127.0.0.1 is NOT reachable from inside a container, so the
+# process needs --host=0.0.0.0 (or the bridge IP). That's the usual reason a
+# route here 502s.
+#
+# Naming: these nest under the PROJECT they belong to
+# (<sub>.<project>.dev.test), not at the top level. Tilt is per-project — a
+# flat `tilt.dev.test` could only ever mean one project's Tilt.
+
+http:
+  routers:
+    cvops-tilt:
+      rule: "Host(`tilt.cvops.dev.test`)"
+      entryPoints: [web]
+      service: cvops-tilt
+
+  services:
+    cvops-tilt:
+      loadBalancer:
+        servers:
+          # CVOps' Tilt dev UI: build logs, resource status, manual triggers.
+          # Started by `tilt up --host=0.0.0.0 --port=10350` in the CVOps repo —
+          # without --host it binds 127.0.0.1 and this route 502s.
+          # 502 when no Tilt is running is expected, not a bug.
+          #
+          # A second project running Tilt needs its own --port (10350 is a host
+          # port and only one process can hold it) plus its own entry here.
+          - url: "http://host.docker.internal:10350"

--- a/edge/dynamic/portal-api.yml
+++ b/edge/dynamic/portal-api.yml
@@ -1,0 +1,81 @@
+# The portal's read-only data plane.
+#
+# The portal page (dev.test) discovers what's running instead of being a
+# hand-written list. It needs two read-only APIs, and it gets them under its OWN
+# origin at /-/api/* — same-origin means zero CORS, no preflight, no headers to
+# tune. `/-/` is a RESERVED prefix on every vhost on this box.
+#
+# ── SECURITY: THE RULES BELOW ARE THE BOUNDARY ─────────────────────────────
+#
+# Every rule here is Path() — an EXACT match. Never PathPrefix. This is not
+# style, it is the entire security control:
+#
+#   docker-socket-proxy's CONTAINERS=1 gates by endpoint FAMILY, so it happily
+#   serves /containers/{id}/json — whose response body includes Env. On this box
+#   that means POSTGRES_PASSWORD and the Grafana admin password. A PathPrefix
+#   here would publish every container's environment to the tailnet.
+#
+#   The socket-proxy env vars do NOT prevent this. Only these Path() rules do.
+#
+# To add an endpoint: add a Path() line. Never widen to PathPrefix.
+# Verify after any change:
+#   curl -s -o /dev/null -w '%{http_code}\n' \
+#     http://dev.test/-/api/docker/containers/$(docker ps -q | head -1)/json
+#   # MUST print 404.
+#
+# ── Why no Host() rule ─────────────────────────────────────────────────────
+# The bare IP (http://100.117.176.85) lands on portal-fallback, which serves the
+# portal. If these routers were scoped to Host(`dev.test`), the page would load
+# there but every fetch would fall through to nginx and 404. Host-less Path() at
+# priority 100 works from every name AND the bare IP. Priority 100 sits above
+# portal-fallback (1) and every Host route (~16-27).
+
+http:
+  routers:
+    # Exactly one Docker endpoint. Nothing else is reachable.
+    portal-api-docker:
+      rule: "Path(`/-/api/docker/containers/json`)"
+      entryPoints: [web]
+      priority: 100
+      middlewares: [portal-api-docker-rewrite]
+      service: portal-socket-proxy
+
+    # The Traefik API is read-only by nature (no mutating endpoints), and
+    # traefik.dev.test already serves it unauthenticated, so these four paths
+    # grant no authority that isn't already there.
+    portal-api-traefik:
+      rule: >-
+        Path(`/-/api/traefik/http/routers`)
+        || Path(`/-/api/traefik/http/services`)
+        || Path(`/-/api/traefik/overview`)
+        || Path(`/-/api/traefik/version`)
+      entryPoints: [web]
+      priority: 100
+      middlewares: [portal-api-traefik-rewrite]
+      service: api@internal
+
+  middlewares:
+    # /-/api/docker/containers/json -> /containers/json
+    portal-api-docker-rewrite:
+      replacePathRegex:
+        regex: "^/-/api/docker/(.*)"
+        replacement: "/$1"
+
+    # /-/api/traefik/http/routers -> /api/http/routers
+    #
+    # replacePathRegex, not stripPrefix: stripPrefix would leave /http/routers,
+    # so the client would have to request /-/api/traefik/api/http/routers with
+    # `api` twice. This keeps the client URL clean.
+    portal-api-traefik-rewrite:
+      replacePathRegex:
+        regex: "^/-/api/traefik/(.*)"
+        replacement: "/api/$1"
+
+  services:
+    # Reached by Docker DNS over socketnet. The docker provider can't see this
+    # container (it's not on devnet, by design), which is exactly why it's
+    # declared here in the file provider rather than via labels.
+    portal-socket-proxy:
+      loadBalancer:
+        servers:
+          - url: "http://portal-socket-proxy:2375"

--- a/justfile
+++ b/justfile
@@ -4,13 +4,23 @@ set dotenv-load := true
 default:
     @just --list
 
-# Create the shared docker network (idempotent)
+# Create the shared docker networks (idempotent)
 network:
     -docker network create devnet 2>/dev/null || true
+    # socketnet holds exactly two containers: traefik + portal-socket-proxy.
+    # docker-socket-proxy has NO auth, so network reachability IS authorisation —
+    # on devnet, any of ~20 containers (incl. third-party wiki.js, kafka-ui) could
+    # read the docker socket through it. Keep the blast radius at two.
+    -docker network create socketnet 2>/dev/null || true
 
 # Bring up EVERYTHING
-up: network up-monitoring up-data up-mgmt up-apps
+up: network up-edge up-monitoring up-data up-mgmt up-apps
     @echo "All stacks up. Run 'just urls' for access."
+
+# Edge: Traefik — the single front door on :80, routes *.test by Host header.
+# Must come up before anything that expects to be routed.
+up-edge: network
+    docker compose -f edge/compose.yml up -d
 
 # Observability: grafana, prometheus, loki, cadvisor, node-exporter
 up-monitoring: network
@@ -33,6 +43,7 @@ up-apps: network
 
 # Stop everything (keeps volumes/data)
 down:
+    -docker compose -f edge/compose.yml down
     -docker compose -f apps/portal/compose.yml down
     -docker compose -f apps/wiki/compose.yml down
     -docker compose -f mgmt/compose.yml down
@@ -43,6 +54,7 @@ down:
 
 # Stop everything AND delete all data volumes (DESTRUCTIVE)
 nuke:
+    -docker compose -f edge/compose.yml down -v
     -docker compose -f apps/portal/compose.yml down -v
     -docker compose -f apps/wiki/compose.yml down -v
     -docker compose -f mgmt/compose.yml down -v
@@ -75,18 +87,36 @@ psql:
 redis:
     docker exec -it redis redis-cli
 
-# Print the direct dashboard URLs (no tunnel — Windows port-proxy forwards to WSL)
+# Print access URLs. Named services route through Traefik; *.test resolves via
+# the local dnsmasq, published to the tailnet by Tailscale split DNS.
 urls:
-    @echo "Direct access from your laptop — no tunnel. Use whichever host reaches you:"
-    @echo "  Tailscale (anywhere): 100.93.197.10   |   LAN: 192.168.68.57"
+    @echo "This box is a tailnet node: yehuda-wsl / 100.117.176.85 — reachable directly,"
+    @echo "no portproxy. Any *.test name resolves to it from any device on the tailnet."
     @echo ""
-    @echo "  ⭐ Portal    http://100.93.197.10          (start here — the dashboard)"
-    @echo "  Grafana      http://100.93.197.10:3000   (admin / admin)"
-    @echo "  Prometheus   http://100.93.197.10:9090"
-    @echo "  Portainer    http://100.93.197.10:9000   (set password on first visit)"
-    @echo "  Dozzle       http://100.93.197.10:8080   (live container logs)"
-    @echo "  Kafka-UI     http://100.93.197.10:8081"
-    @echo "  Wiki.js      http://100.93.197.10:3001   (login required)"
+    @echo "  ⭐ START HERE   http://dev.test          (the portal — index of everything)"
     @echo ""
-    @echo "Databases are NOT port-proxied (kept off the network). Reach via ssh tunnel:"
-    @echo "  ssh -L 5432:localhost:5432 -L 6379:localhost:6379 -L 9092:localhost:9092 devssh@100.93.197.10"
+    @echo "  Stack services  <name>.dev.test:"
+    @echo "    Grafana       http://grafana.dev.test      (admin / admin)"
+    @echo "    Prometheus    http://prometheus.dev.test"
+    @echo "    Dozzle        http://dozzle.dev.test       (live container logs)"
+    @echo "    Portainer     http://portainer.dev.test    (set password on first visit)"
+    @echo "    Kafka-UI      http://kafka.dev.test"
+    @echo "    Wiki.js       http://wiki.dev.test         (login required)"
+    @echo "    Traefik       http://traefik.dev.test      (which routes are registered)"
+    @echo ""
+    @echo "  Projects        <project>.dev.test — their pieces nest underneath:"
+    @echo "    CVOps         http://cvops.dev.test        (run 'tilt up' in the repo first)"
+    @echo "    CVOps · Tilt  http://tilt.cvops.dev.test   (needs 'tilt up --host=0.0.0.0')"
+    @echo "    CVOps · S3    http://s3.cvops.dev.test     (garage; presigned URLs only)"
+    @echo ""
+    @echo "  Adding a service = 2 Traefik labels + a name, never a port."
+    @echo "  See ~/claude-notes/dev-networking.md."
+    @echo ""
+    @echo "  The bare IP http://100.117.176.85 (and the legacy http://100.93.197.10 via"
+    @echo "  the Windows portproxy) still lands on the portal — Traefik catch-all route."
+    @echo ""
+    @echo "Databases stay off the network (loopback-bound). Reach via ssh tunnel:"
+    @echo "  ssh -L 5432:localhost:5432 -L 6379:localhost:6379 -L 9092:localhost:9092 devssh@100.117.176.85"
+    @echo ""
+    @echo "If *.test stops resolving: check 'systemctl status dnsmasq' and that Tailscale"
+    @echo "split DNS (admin console → DNS → Nameservers) still points 'test' at 100.117.176.85."

--- a/mgmt/compose.yml
+++ b/mgmt/compose.yml
@@ -4,6 +4,12 @@ services:
   portainer:
     image: portainer/portainer-ce:latest
     container_name: portainer
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.portainer.rule=Host(`portainer.dev.test`)
+      - traefik.http.routers.portainer.entrypoints=web
+      - traefik.http.routers.portainer.service=portainer
+      - traefik.http.services.portainer.loadbalancer.server.port=9000
     restart: unless-stopped
     ports:
       - "9000:9000"
@@ -19,6 +25,12 @@ services:
   dozzle:
     image: amir20/dozzle:latest
     container_name: dozzle
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.dozzle.rule=Host(`dozzle.dev.test`)
+      - traefik.http.routers.dozzle.entrypoints=web
+      - traefik.http.routers.dozzle.service=dozzle
+      - traefik.http.services.dozzle.loadbalancer.server.port=8080
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/monitoring/compose.yml
+++ b/monitoring/compose.yml
@@ -4,6 +4,12 @@ services:
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.prometheus.rule=Host(`prometheus.dev.test`)
+      - traefik.http.routers.prometheus.entrypoints=web
+      - traefik.http.routers.prometheus.service=prometheus
+      - traefik.http.services.prometheus.loadbalancer.server.port=9090
     restart: unless-stopped
     command:
       - --config.file=/etc/prometheus/prometheus.yml
@@ -26,6 +32,12 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.grafana.rule=Host(`grafana.dev.test`)
+      - traefik.http.routers.grafana.entrypoints=web
+      - traefik.http.routers.grafana.service=grafana
+      - traefik.http.services.grafana.loadbalancer.server.port=3000
     restart: unless-stopped
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}


### PR DESCRIPTION
## What
- Add Traefik v3.6 as the single front door on :80, routing `*.dev.test` by Host header
- Route grafana/prometheus/portainer/dozzle/kafka-ui/wiki by name via labels
- Add a read-only Docker socket proxy and rebuild the portal to discover services live

## Why
Host ports are a flat global namespace with no allocator, so every project reached for
3000/8080/5432 and collided with whatever claimed it first. Routing by Host header removes
the competition entirely — names are unlimited, ports are not. The portal had the same class
of problem in miniature: a hand-written service list that drifted silently every time a stack
was added or renamed, so it described the box as it was whenever someone last edited it.

## How
Traefik discovers containers with `exposedbydefault=false`, so nothing is published by accident;
host processes without labels are declared in `edge/dynamic/` instead. The portal joins the
Traefik router and service APIs against the Docker container list, reaching Docker through
`tecnativa/docker-socket-proxy` with `CONTAINERS` as its only grant — the proxy sits on its own
two-member `socketnet` and publishes no port, and Traefik forwards exactly one endpoint through
an exact `Path()` rule. Published host ports are kept for now so existing bookmarks keep working.

## Test plan
- [ ] \`just up\` brings up edge before the stacks; \`docker ps\` shows traefik holding :80
- [ ] \`curl -H 'Host: grafana.dev.test' http://localhost/\` returns 302 (and wiki/portainer/dozzle/kafka resolve)
- [ ] Bare IP and any unrouted host land on the portal via portal-fallback
- [ ] Portal Services/Ports/Routes tabs populate from live data, not the static floor
- [ ] \`curl http://localhost/-/api/docker/containers/<id>/json\` does NOT return container Env
- [ ] Known gap: \`*.dev.test\` does not resolve from inside WSL (dnsmasq binds only the tailnet IP, and generateResolvConf=true rewrites resolv.conf each boot) — tracked separately

Generated by [Claude-Bot] of [@YehudaBriskman]