### PR TITLE
fix: repair boot race that emptied every backup

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,41 +1,96 @@
 #!/usr/bin/env bash
 # Back up the dev stacks' stateful bits with simple rotation.
-set -euo pipefail
+#
+# Runs both from `just backup` and from stacks-backup.timer. systemd does not
+# load ~/stacks/.env the way just does (set dotenv-load), so source it here.
+#
+# Deliberately NOT `set -e`. The old script aborted the moment one service
+# failed, which is why a single bad postgres dump left redis, grafana and
+# portainer un-backed-up for six days without anything looking wrong.
+set -uo pipefail
+
 BK="${1:-/home/devssh/backups}"
 KEEP=14
 ts=$(date +%Y%m%d-%H%M%S)
-log() { printf '[backup %s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+[ -f "$root/.env" ] && { set -a; . "$root/.env"; set +a; }
+
+fails=0
+log()  { printf '[backup %s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+fail() { printf '[backup %s] FAIL: %s\n' "$(date +%H:%M:%S)" "$*" >&2; fails=$((fails + 1)); }
 running() { docker ps --format '{{.Names}}' | grep -qx "$1"; }
 
-mkdir -p "$BK"/{postgres,redis,grafana,portainer}
+# An empty artifact is worse than no artifact: rotation counts it and would
+# eventually evict a good backup with a worthless one.
+keep_if_real() {  # <file> <min-bytes> <label>
+  local f=$1 min=$2 label=$3 size
+  size=$([ -f "$f" ] && wc -c < "$f" || echo 0)
+  if [ "$size" -ge "$min" ]; then
+    log "$label -> $(basename "$f") ($(du -h "$f" | cut -f1))"
+  else
+    fail "$label produced ${size} bytes — discarding"
+    rm -f "$f"
+  fi
+}
 
-# Postgres — logical dump of all databases (consistent).
+mkdir -p "$BK"/{postgres,redis,grafana,portainer,env}
+
+# The timer is Persistent=true, so a schedule missed while the box was off
+# fires at the next boot — exactly when postgres is still initialising. Without
+# this wait the dump comes back empty and the backup silently reports success.
 if running postgres; then
-  docker exec postgres pg_dumpall -U "${POSTGRES_USER:-dev}" | gzip > "$BK/postgres/pg-$ts.sql.gz"
-  log "postgres -> pg-$ts.sql.gz ($(du -h "$BK/postgres/pg-$ts.sql.gz" | cut -f1))"
+  ready=0
+  for _ in $(seq 1 30); do
+    if docker exec postgres pg_isready -q -U "${POSTGRES_USER:-dev}" 2>/dev/null; then ready=1; break; fi
+    sleep 2
+  done
+  if [ "$ready" = 1 ]; then
+    docker exec postgres pg_dumpall -U "${POSTGRES_USER:-dev}" 2>/dev/null | gzip > "$BK/postgres/pg-$ts.sql.gz"
+    keep_if_real "$BK/postgres/pg-$ts.sql.gz" 1000 postgres
+  else
+    fail "postgres not ready after 60s — skipped"
+  fi
+else
+  fail "postgres not running — skipped"
 fi
 
-# Redis — force a save, then copy the rdb snapshot.
 if running redis; then
-  docker exec redis redis-cli SAVE >/dev/null
-  docker cp redis:/data/dump.rdb "$BK/redis/dump-$ts.rdb"
-  log "redis -> dump-$ts.rdb"
+  docker exec redis redis-cli SAVE >/dev/null 2>&1 \
+    && docker cp redis:/data/dump.rdb "$BK/redis/dump-$ts.rdb" 2>/dev/null
+  keep_if_real "$BK/redis/dump-$ts.rdb" 1 redis
+else
+  fail "redis not running — skipped"
 fi
 
-# Grafana — sqlite holds dashboards, users, alert rules.
 if running grafana; then
-  docker cp grafana:/var/lib/grafana/grafana.db "$BK/grafana/grafana-$ts.db"
-  log "grafana -> grafana-$ts.db"
+  docker cp grafana:/var/lib/grafana/grafana.db "$BK/grafana/grafana-$ts.db" 2>/dev/null
+  keep_if_real "$BK/grafana/grafana-$ts.db" 1000 grafana
+else
+  fail "grafana not running — skipped"
 fi
 
-# Portainer — boltdb holds users, endpoints, settings.
 if running portainer; then
-  docker cp portainer:/data/portainer.db "$BK/portainer/portainer-$ts.db" 2>/dev/null || true
-  log "portainer -> portainer-$ts.db"
+  docker cp portainer:/data/portainer.db "$BK/portainer/portainer-$ts.db" 2>/dev/null
+  keep_if_real "$BK/portainer/portainer-$ts.db" 1000 portainer
+else
+  fail "portainer not running — skipped"
 fi
 
-# Rotation — keep only the newest $KEEP files per service.
-for d in postgres redis grafana portainer; do
+# .env is gitignored and exists nowhere else on earth. Losing it loses every
+# credential on the box, so it belongs in the backup more than anything here.
+if [ -f "$root/.env" ]; then
+  install -m 600 "$root/.env" "$BK/env/env-$ts"
+  keep_if_real "$BK/env/env-$ts" 1 env
+else
+  fail ".env not found at $root/.env"
+fi
+
+for d in postgres redis grafana portainer env; do
   ls -1t "$BK/$d"/* 2>/dev/null | tail -n +$((KEEP + 1)) | xargs -r rm -f
 done
+
+if [ "$fails" -gt 0 ]; then
+  log "done WITH $fails FAILURE(S). retained newest $KEEP per service under $BK"
+  exit 1
+fi
 log "done. retained newest $KEEP per service under $BK"


### PR DESCRIPTION
## What
- Wait for `pg_isready` before dumping, and verify every artifact is non-empty before keeping it
- Continue past a failing service instead of aborting, and exit non-zero so failures are visible
- Back up `.env`, which is gitignored and existed in exactly one place on the box

## Why
The nightly backup had been producing nothing since 16 July while reporting success every night.
`stacks-backup.timer` is `Persistent=true`, so a schedule missed while the box was off fires at the
next boot — precisely when postgres is still initialising. The dump came back empty, the redirection
still wrote a 20-byte gzip that looked like a real backup, and `set -e` aborted the run before redis,
grafana and portainer were ever touched. Three of the four services had no backup for six days.

## How
The postgres step now polls `pg_isready` for up to 60s before dumping. Each artifact goes through a
size check that discards anything empty, because an empty file is worse than none — rotation counts it
and would eventually evict a good backup. Failures increment a counter and the script exits non-zero
rather than stopping at the first one. `.env` is sourced explicitly since systemd, unlike `just`, does
not honour `set dotenv-load`.

## Test plan
- [ ] \`just backup\` exits 0 and reports five non-trivial artifacts
- [ ] \`ls -la ~/backups/*\` shows postgres well above 1 KB, not 20 bytes
- [ ] Stopping a container makes the run report that failure and exit non-zero, with the others still backed up
- [ ] After a reboot, the Persistent catch-up run produces a real dump rather than an empty one
- [ ] \`~/backups/env/\` contains the credentials file with 0600 permissions

Generated by [Claude-Bot] of [@YehudaBriskman]