### PR TITLE
fix: persist kafka data to the mounted volume

### DIFF
--- a/data/kafka/compose.yml
+++ b/data/kafka/compose.yml
@@ -11,6 +11,9 @@ services:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
       # INTERNAL (kafka:19092) for containers, EXTERNAL (localhost:9092) for host.
+      # Without this the broker writes to its built-in default and the volume
+      # mounted below stays empty, so every topic dies with the container.
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
       KAFKA_LISTENERS: INTERNAL://0.0.0.0:19092,EXTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
       KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:19092,EXTERNAL://localhost:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT


### PR DESCRIPTION
## What
- Set `KAFKA_LOG_DIRS=/var/lib/kafka/data` so the broker writes to the mounted volume

## Why
The `kafka_data` volume has been mounted at `/var/lib/kafka/data` since the stack was created, and it
was completely empty. The image's bundled config points `log.dirs` at `/tmp/kraft-controller-logs` and
`/tmp/kraft-broker-logs`, and nothing overrode it, so cluster metadata and every topic lived in the
container's writable layer. Any recreate — including a routine image pull on a box that runs `:latest` —
would have silently discarded the whole broker state.

## How
One environment variable, pointing `log.dirs` at the path the volume was already mounted on. There were
no topics on the broker at the time of the change, so nothing was lost in the transition.

## Test plan
- [ ] \`docker exec kafka ls /var/lib/kafka/data\` shows \`__cluster_metadata-0\` and \`meta.properties\`
- [ ] Create a topic, \`docker compose up -d --force-recreate kafka\`, confirm the topic still exists
- [ ] Broker reports healthy and \`kafka.dev.test\` returns 200
- [ ] kafka-exporter reconnects and its Prometheus target returns to up

Generated by [Claude-Bot] of [@YehudaBriskman]