### PR TITLE
feat: add github sso for the dashboards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,22 @@ POSTGRES_PASSWORD=devpass
 POSTGRES_DB=dev
 GRAFANA_USER=admin
 GRAFANA_PASSWORD=admin
+
+# Wiki.js database password (required — `just up` aborts without it)
+WIKI_DB_PASSWORD=changeme
+
+# Grafana SMTP, for alert email
+GF_SMTP_ENABLED=false
+GF_SMTP_HOST=smtp.gmail.com:587
+GF_SMTP_USER=
+GF_SMTP_PASSWORD=
+GF_SMTP_FROM_ADDRESS=
+GF_SMTP_FROM_NAME=Grafana
+GF_SMTP_STARTTLS_POLICY=OpportunisticStartTLS
+ALERT_EMAIL_TO=
+
+# GitHub SSO — create an OAuth App at https://github.com/settings/developers
+# with callback http://auth.dev.test/oauth2/callback
+OAUTH2_CLIENT_ID=
+OAUTH2_CLIENT_SECRET=
+OAUTH2_COOKIE_SECRET=   # openssl rand -base64 32 | tr -- '+/' '-_'

--- a/apps/portal/compose.yml
+++ b/apps/portal/compose.yml
@@ -20,6 +20,7 @@ services:
       - traefik.http.routers.portal.rule=Host(`dev.test`)
       - traefik.http.routers.portal.entrypoints=web
       - traefik.http.routers.portal.service=portal
+      - traefik.http.routers.portal.middlewares=sso-errors@file,sso@file
 
       # Catch-all so the bare IP (http://100.117.176.85, and the legacy
       # http://100.93.197.10 via portproxy) still lands on the homepage — those
@@ -30,6 +31,8 @@ services:
       - traefik.http.routers.portal-fallback.rule=PathPrefix(`/`)
       - traefik.http.routers.portal-fallback.priority=1
       - traefik.http.routers.portal-fallback.entrypoints=web
+      # The fallback catches every unrouted host, so it gates the bare IP too.
+      - traefik.http.routers.portal-fallback.middlewares=sso-errors@file,sso@file
       - traefik.http.routers.portal-fallback.service=portal
     deploy:
       resources:

--- a/auth/compose.yml
+++ b/auth/compose.yml
@@ -1,0 +1,78 @@
+name: auth
+
+# Single sign-on for the dashboards that have no authentication of their own.
+#
+# Dozzle serves every container's logs, Kafka-UI runs with DYNAMIC_CONFIG_ENABLED,
+# Prometheus accepts POST /-/quit, and the Traefik dashboard exposes /api/rawdata.
+# All of them were reachable by anything that could reach the tailnet. This puts
+# a GitHub login in front of them without touching the apps themselves.
+#
+# GitHub rather than Google as the provider for one concrete reason: Google
+# rejects http:// redirect URIs, which would force TLS, and TLS on *.dev.test
+# means a private CA installed on every device. Traffic here is already inside
+# WireGuard, so plaintext on the wire is not the exposure it would be on a LAN.
+
+services:
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1   # pinned: it is the auth boundary
+    container_name: oauth2-proxy
+    restart: unless-stopped
+    command:
+      - --provider=github
+      - --http-address=0.0.0.0:4180
+      # Only this GitHub account may sign in. Without it any GitHub user on
+      # earth who reaches the login page would be allowed straight through.
+      - --github-user=YehudaBriskman
+      - --email-domain=*
+      # Sessions are shared across every *.dev.test host, so one sign-in covers
+      # all of them and the redirect back from GitHub is allowed to land there.
+      - --cookie-domain=.dev.test
+      - --whitelist-domain=.dev.test
+      # No TLS on .dev.test, so a Secure cookie would never be sent back and the
+      # login loop would never terminate. Safe only because the tailnet is the
+      # transport; revisit the moment anything here is exposed beyond it.
+      - --cookie-secure=false
+      - --reverse-proxy=true
+      # Without this oauth2-proxy derives the callback from whichever host the
+      # user landed on (dozzle.dev.test/oauth2/callback, kafka.dev.test/...),
+      # and a GitHub OAuth App accepts exactly ONE registered callback URL, so
+      # every login but the first host would fail with redirect_uri mismatch.
+      # Pinning it sends every login through the one URL GitHub knows; the user
+      # is then returned to the host they came from via the whitelisted rd param.
+      - --redirect-url=http://auth.dev.test/oauth2/callback
+      # Traefik calls /oauth2/auth for a verdict; nothing proxies through here,
+      # so a static upstream is all that is needed.
+      - --upstream=static://202
+      - --set-xauthrequest=true
+      # NOT skip-provider-button. With it enabled /oauth2/sign_in returns a 302
+      # straight to GitHub, and Traefik's errors middleware serves CONTENT rather
+      # than following redirects — so it fetched that 302 server-to-server, threw
+      # away the Set-Cookie carrying the CSRF token, and rendered its body: a bare
+      # "Found" link pointing directly at github.com. Clicking it skipped
+      # /oauth2/start, so the browser never received a CSRF cookie and the callback
+      # died with "CSRF cookie not found". Rendering the real sign-in page means the
+      # button is a relative /oauth2/start link that the browser visits itself.
+      - --cookie-samesite=lax
+    environment:
+      OAUTH2_PROXY_CLIENT_ID:     ${OAUTH2_CLIENT_ID:?set OAUTH2_CLIENT_ID in .env}
+      OAUTH2_PROXY_CLIENT_SECRET: ${OAUTH2_CLIENT_SECRET:?set OAUTH2_CLIENT_SECRET in .env}
+      OAUTH2_PROXY_COOKIE_SECRET: ${OAUTH2_COOKIE_SECRET:?set OAUTH2_COOKIE_SECRET in .env}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.oauth.rule=Host(`auth.dev.test`)
+      - traefik.http.routers.oauth.entrypoints=web
+      - traefik.http.routers.oauth.service=oauth
+      - traefik.http.services.oauth.loadbalancer.server.port=4180
+    # No healthcheck: the image is distroless, with no shell and no wget, so
+    # every form of docker healthcheck fails and the container sits in
+    # "health: starting" forever. Liveness is observable instead through
+    # Traefik's forwardAuth, which fails loudly the moment this is down.
+    deploy:
+      resources:
+        limits:
+          memory: 128m
+    networks: [devnet]
+
+networks:
+  devnet:
+    external: true

--- a/data/kafka/compose.yml
+++ b/data/kafka/compose.yml
@@ -47,6 +47,9 @@ services:
       - traefik.http.routers.kafka.entrypoints=web
       - traefik.http.routers.kafka.service=kafka
       - traefik.http.services.kafka.loadbalancer.server.port=8080
+      # Kafka-UI runs with DYNAMIC_CONFIG_ENABLED and has no auth of its own, so
+      # anyone reaching it could add clusters and mutate topic config.
+      - traefik.http.routers.kafka.middlewares=sso-errors@file,sso@file
       - dev.portal.name=Kafka UI
       - dev.portal.desc=Browse the single-node KRaft broker — topics, partitions, consumer groups and live messages.
     restart: unless-stopped

--- a/edge/compose.yml
+++ b/edge/compose.yml
@@ -30,6 +30,13 @@ services:
       # watch=true picks up edits live; no Traefik restart needed to add a route.
       - --providers.file.directory=/etc/traefik/dynamic
       - --providers.file.watch=true
+      # CAVEAT: watch=true only works while the bind mount below still resolves.
+      # A bind mount pins the host inode at container-creation time, and git
+      # checkout deletes and recreates ./dynamic — after any branch switch this
+      # container keeps reading an orphaned, empty directory and silently serves a
+      # stale in-memory config. It ran that way from 16 to 21 Jul with every edit
+      # to ./dynamic having no effect. After any checkout:
+      #   docker compose -f edge/compose.yml up -d --force-recreate
       - --entrypoints.web.address=:80
       - --api.dashboard=true
       - --log.level=INFO
@@ -56,6 +63,9 @@ services:
       - traefik.http.routers.dashboard.rule=Host(`traefik.dev.test`)
       - traefik.http.routers.dashboard.entrypoints=web
       - traefik.http.routers.dashboard.service=api@internal
+      # The dashboard serves api@internal unauthenticated, including /api/rawdata,
+      # which dumps the entire dynamic config - every router, service and middleware.
+      - traefik.http.routers.dashboard.middlewares=sso-errors@file,sso@file
     deploy:
       resources:
         limits:

--- a/edge/dynamic/auth.yml
+++ b/edge/dynamic/auth.yml
@@ -1,0 +1,43 @@
+# The SSO middleware chain, and the /oauth2/ routes that make it usable.
+#
+# Attach `sso-errors,sso` (in that order) to any router that should require a
+# login. Order matters: the request passes through sso-errors on the way in and
+# the 401 from sso passes back out through it, which is what turns a bare 401
+# into the sign-in page.
+
+http:
+  routers:
+    # Host-less on purpose, exactly like the portal API routes: the sign-in
+    # flow has to work on whichever hostname the user landed on, otherwise the
+    # redirect after login arrives at a host with no /oauth2/ handler and 404s.
+    oauth2-endpoints:
+      rule: "PathPrefix(`/oauth2/`)"
+      entryPoints: [web]
+      priority: 100
+      service: oauth2-proxy
+
+  services:
+    oauth2-proxy:
+      loadBalancer:
+        servers:
+          - url: "http://oauth2-proxy:4180"
+
+  middlewares:
+    # Asks oauth2-proxy for a verdict on every request. 202 lets it through,
+    # 401 means no valid session.
+    sso:
+      forwardAuth:
+        address: "http://oauth2-proxy:4180/oauth2/auth"
+        trustForwardHeader: true
+        authResponseHeaders:
+          - X-Auth-Request-User
+          - X-Auth-Request-Email
+
+    # Without this a signed-out user gets a blank 401 with no way forward.
+    # Traefik fetches the sign-in page from oauth2-proxy and serves it in place
+    # of the 401, so the login appears at the URL that was actually requested.
+    sso-errors:
+      errors:
+        status: ["401"]
+        service: oauth2-proxy
+        query: "/oauth2/sign_in?rd={url}"

--- a/edge/dynamic/portal-api.yml
+++ b/edge/dynamic/portal-api.yml
@@ -37,7 +37,10 @@ http:
       rule: "Path(`/-/api/docker/containers/json`)"
       entryPoints: [web]
       priority: 100
-      middlewares: [portal-api-docker-rewrite]
+      # sso also closes the DNS-rebinding hole: a rebound request carries the
+      # attacker's Host, so the .dev.test-scoped session cookie is never sent
+      # and this returns 401 instead of the container list.
+      middlewares: [sso-errors@file, sso@file, portal-api-docker-rewrite]
       service: portal-socket-proxy
 
     # The Traefik API is read-only by nature (no mutating endpoints), and
@@ -51,7 +54,7 @@ http:
         || Path(`/-/api/traefik/version`)
       entryPoints: [web]
       priority: 100
-      middlewares: [portal-api-traefik-rewrite]
+      middlewares: [sso-errors@file, sso@file, portal-api-traefik-rewrite]
       service: api@internal
 
   middlewares:

--- a/justfile
+++ b/justfile
@@ -14,13 +14,18 @@ network:
     -docker network create socketnet 2>/dev/null || true
 
 # Bring up EVERYTHING
-up: network up-edge up-monitoring up-data up-mgmt up-apps
+up: network up-edge up-auth up-monitoring up-data up-mgmt up-apps
     @echo "All stacks up. Run 'just urls' for access."
 
 # Edge: Traefik — the single front door on :80, routes *.test by Host header.
 # Must come up before anything that expects to be routed.
 up-edge: network
     docker compose -f edge/compose.yml up -d
+
+# SSO: oauth2-proxy, guards the dashboards that have no login of their own.
+# Must be up before the routers that reference its middleware.
+up-auth: network
+    docker compose -f auth/compose.yml up -d
 
 # Observability: grafana, prometheus, loki, cadvisor, node-exporter
 up-monitoring: network
@@ -43,6 +48,7 @@ up-apps: network
 
 # Stop everything (keeps volumes/data)
 down:
+    -docker compose -f auth/compose.yml down
     -docker compose -f edge/compose.yml down
     -docker compose -f apps/portal/compose.yml down
     -docker compose -f apps/wiki/compose.yml down
@@ -54,6 +60,7 @@ down:
 
 # Stop everything AND delete all data volumes (DESTRUCTIVE)
 nuke:
+    -docker compose -f auth/compose.yml down -v
     -docker compose -f edge/compose.yml down -v
     -docker compose -f apps/portal/compose.yml down -v
     -docker compose -f apps/wiki/compose.yml down -v

--- a/mgmt/compose.yml
+++ b/mgmt/compose.yml
@@ -31,6 +31,9 @@ services:
       - traefik.http.routers.dozzle.entrypoints=web
       - traefik.http.routers.dozzle.service=dozzle
       - traefik.http.services.dozzle.loadbalancer.server.port=8080
+      # Dozzle streams every container's logs and ships with no auth of its
+      # own, so it sits behind the GitHub SSO chain (see edge/dynamic/auth.yml).
+      - traefik.http.routers.dozzle.middlewares=sso-errors@file,sso@file
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/monitoring/compose.yml
+++ b/monitoring/compose.yml
@@ -10,6 +10,9 @@ services:
       - traefik.http.routers.prometheus.entrypoints=web
       - traefik.http.routers.prometheus.service=prometheus
       - traefik.http.services.prometheus.loadbalancer.server.port=9090
+      # Prometheus runs with --web.enable-lifecycle, so an unauthenticated caller
+      # can POST /-/quit and stop it. No auth of its own exists to prevent that.
+      - traefik.http.routers.prometheus.middlewares=sso-errors@file,sso@file
     restart: unless-stopped
     command:
       - --config.file=/etc/prometheus/prometheus.yml


### PR DESCRIPTION
## What
- Add oauth2-proxy as a Traefik forwardAuth target, with GitHub as the identity provider
- Require a session on Dozzle, Kafka-UI, Prometheus, the Traefik dashboard and the portal
- Document that `git checkout` silently stales Traefik's `./dynamic` bind mount

## Why
Four dashboards had no authentication at all. Dozzle streams every container's logs, Kafka-UI runs with
`DYNAMIC_CONFIG_ENABLED`, Prometheus accepts `POST /-/quit`, and the Traefik dashboard serves `/api/rawdata`.
Anything that reached the tailnet had full access to all of them. Gating the portal's docker API also closes
a DNS-rebinding weakness, since a rebound origin never receives the `.dev.test`-scoped cookie.

## How
GitHub rather than Google because Google rejects `http` redirect URIs, which would force TLS on `.dev.test`
and a private CA on every device; traffic here is already inside WireGuard. The callback is pinned to a single
host because a GitHub OAuth App permits exactly one, and the cookie is scoped to `.dev.test` so one sign-in
covers every service. `--skip-provider-button` is deliberately *not* set: Traefik's `errors` middleware serves
content and cannot follow redirects, so it would swallow the CSRF `Set-Cookie` and break the callback.

## Test plan
- [ ] Incognito to \`http://dozzle.dev.test\` shows a Sign in with GitHub page, not a bare "Found" link
- [ ] Completing the GitHub flow lands in Dozzle with no 403 CSRF error
- [ ] One sign-in then covers kafka, prometheus, traefik and dev.test without re-authenticating
- [ ] \`curl\` with no cookie returns 401 for all five, and 401 for /-/api/docker/containers/json
- [ ] Grafana, Wiki and Portainer still reach their own login pages
- [ ] A GitHub account other than the configured one is rejected after authorising

Generated by [Claude-Bot] of [@YehudaBriskman]