### PR TITLE
fix: resolve empty dashboard datasource placeholders

### DIFF
--- a/monitoring/dashboards/kafka.json
+++ b/monitoring/dashboards/kafka.json
@@ -1,34 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS_WH211",
-      "label": "Prometheus",
-      "description": "kafka_exporter",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "5.1.1"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": "5.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "5.0.0"
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -55,7 +25,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS_WH211}",
+      "datasource": "prometheus",
       "fill": 0,
       "gridPos": {
         "h": 10,
@@ -144,7 +114,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS_WH211}",
+      "datasource": "prometheus",
       "fill": 0,
       "gridPos": {
         "h": 10,
@@ -234,7 +204,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS_WH211}",
+      "datasource": "prometheus",
       "fill": 0,
       "gridPos": {
         "h": 10,
@@ -322,7 +292,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS_WH211}",
+      "datasource": "prometheus",
       "fill": 0,
       "gridPos": {
         "h": 10,
@@ -411,7 +381,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS_WH211}",
+      "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -507,7 +477,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS_WH211}",
+        "datasource": "prometheus",
         "hide": 0,
         "includeAll": false,
         "label": "Job",
@@ -527,7 +497,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS_WH211}",
+        "datasource": "prometheus",
         "hide": 0,
         "includeAll": false,
         "label": "Instance",
@@ -547,7 +517,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS_WH211}",
+        "datasource": "prometheus",
         "hide": 0,
         "includeAll": true,
         "label": "Topic",

--- a/monitoring/dashboards/redis.json
+++ b/monitoring/dashboards/redis.json
@@ -1,47 +1,5 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROM",
-      "label": "prom",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "gauge",
-      "name": "Gauge",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "10.3.3"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -70,7 +28,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -138,7 +96,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "max(max_over_time(redis_uptime_in_seconds{instance=~\"$instance\"}[$__interval]))",
           "format": "time_series",
@@ -156,7 +114,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -225,7 +183,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum(redis_connected_clients{instance=~\"$instance\"})",
           "format": "time_series",
@@ -243,7 +201,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -316,7 +274,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum(100 * (redis_memory_used_bytes{instance=~\"$instance\"}  / redis_memory_max_bytes{instance=~\"$instance\"}))",
           "format": "time_series",
@@ -334,7 +292,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -418,7 +376,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(redis_commands_total{instance=~\"$instance\"} [1m])) by (cmd)",
           "format": "time_series",
@@ -436,7 +394,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -521,7 +479,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "irate(redis_keyspace_hits_total{instance=~\"$instance\"}[5m])",
           "format": "time_series",
@@ -537,7 +495,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "irate(redis_keyspace_misses_total{instance=~\"$instance\"}[5m])",
           "format": "time_series",
@@ -557,7 +515,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -658,7 +616,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "redis_memory_used_bytes{instance=~\"$instance\"}",
           "format": "time_series",
@@ -672,7 +630,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "redis_memory_max_bytes{instance=~\"$instance\"}",
           "format": "time_series",
@@ -689,7 +647,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -773,7 +731,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(redis_net_input_bytes_total{instance=~\"$instance\"}[5m]))",
           "format": "time_series",
@@ -785,7 +743,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(redis_net_output_bytes_total{instance=~\"$instance\"}[5m]))",
           "format": "time_series",
@@ -802,7 +760,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -909,7 +867,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum (redis_db_keys{instance=~\"$instance\"}) by (db, instance)",
           "format": "time_series",
@@ -927,7 +885,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -1011,7 +969,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum (redis_db_keys{instance=~\"$instance\"}) by (instance) - sum (redis_db_keys_expiring{instance=~\"$instance\"}) by (instance)",
           "format": "time_series",
@@ -1025,7 +983,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum (redis_db_keys_expiring{instance=~\"$instance\"}) by (instance)",
           "format": "time_series",
@@ -1043,7 +1001,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -1172,7 +1130,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(redis_expired_keys_total{instance=~\"$instance\"}[5m])) by (instance)",
           "format": "time_series",
@@ -1188,7 +1146,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum(rate(redis_evicted_keys_total{instance=~\"$instance\"}[5m])) by (instance)",
           "format": "time_series",
@@ -1205,7 +1163,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -1288,7 +1246,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum(redis_connected_clients{instance=~\"$instance\"})",
           "format": "time_series",
@@ -1299,7 +1257,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum(redis_blocked_clients{instance=~\"$instance\"})",
           "format": "time_series",
@@ -1314,7 +1272,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -1418,7 +1376,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum(irate(redis_commands_duration_seconds_total{instance =~ \"$instance\"}[1m])) by (cmd)\n  /\nsum(irate(redis_commands_total{instance =~ \"$instance\"}[1m])) by (cmd)\n",
           "format": "time_series",
@@ -1436,7 +1394,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROM}"
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -1519,7 +1477,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROM}"
+            "uid": "prometheus"
           },
           "expr": "sum(irate(redis_commands_duration_seconds_total{instance=~\"$instance\"}[1m])) by (cmd) != 0",
           "format": "time_series",
@@ -1547,7 +1505,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROM}"
+          "uid": "prometheus"
         },
         "definition": "label_values(redis_up, namespace)",
         "hide": 0,
@@ -1569,7 +1527,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROM}"
+          "uid": "prometheus"
         },
         "definition": "label_values(redis_up{namespace=~\"$namespace\"}, instance)",
         "hide": 0,


### PR DESCRIPTION
## What
- Replace the unresolved `${DS_PROM}` and `${DS_PROMETHEUS_WH211}` placeholders with the provisioned `prometheus` uid
- Drop the `__inputs` blocks that file provisioning cannot process

## Why
The redis and kafka dashboards were exported from grafana.com and committed without going through the import
wizard, which is what normally substitutes those placeholders. File provisioning ignores `__inputs` entirely,
so every panel referenced a datasource variable that never existed and rendered "Datasource not found" —
34 panels in redis and 8 in kafka, meaning both dashboards were completely blank.

## How
Direct substitution of the datasource uid that `provisioning/datasources/datasources.yml` already defines.
The other three dashboards were checked and were already correct: cadvisor and postgres use the literal uid,
and node-exporter-full backs its variable with a real `datasource`-type template var.

## Test plan
- [ ] Redis dashboard renders data instead of "Datasource not found"
- [ ] Kafka Exporter Overview renders data
- [ ] \`grep -l '\${DS_' monitoring/dashboards/*.json\` returns nothing
- [ ] cadvisor, postgres and node-exporter dashboards still render

Generated by [Claude-Bot] of [@YehudaBriskman]