### PR TITLE
fix: add loki retention and persist promtail positions

### DIFF
--- a/monitoring/compose.yml
+++ b/monitoring/compose.yml
@@ -72,6 +72,9 @@ services:
     restart: unless-stopped
     command: -config.file=/etc/loki/local-config.yaml
     volumes:
+      # Overrides the image config solely to add retention; see that file's
+      # header for why it is derived from the default instead of hand-written.
+      - ./loki-config.yml:/etc/loki/local-config.yaml:ro
       - loki_data:/loki
     ports:
       - "3100:3100"
@@ -88,6 +91,10 @@ services:
     command: -config.file=/etc/promtail/config.yml
     volumes:
       - ./promtail.yml:/etc/promtail/config.yml:ro
+      # Positions default to /tmp, which is empty again on every restart, so
+      # promtail re-read every container log from the start and duplicated the
+      # entire history into Loki each time it came back.
+      - promtail_positions:/tmp
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
     deploy:
@@ -132,6 +139,7 @@ services:
     networks: [devnet]
 
 volumes:
+  promtail_positions:
   prometheus_data:
   grafana_data:
   loki_data:

--- a/monitoring/loki-config.yml
+++ b/monitoring/loki-config.yml
@@ -1,0 +1,69 @@
+# Derived from the image's own /etc/loki/local-config.yaml (loki 3.7.3), with
+# retention appended and nothing else changed.
+#
+# Loki shipped with no retention whatsoever — the stock config defines neither
+# limits_config nor compactor — so /loki grew without bound. On this box Traefik
+# runs with --accesslog=true and promtail scrapes every container with no drop
+# rules, so every HTTP request became a log line. The WSL2 vhdx never shrinks,
+# so that space is not returned to Windows even after the data is deleted.
+#
+# Everything above the retention block is the image default verbatim. In
+# particular schema_config is left exactly as-is: the chunks already on disk
+# were written against tsdb/v13, and editing schema_config against existing
+# data is the usual way to break Loki on restart.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/usagestats/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false
+
+# ── retention (the only addition) ──────────────────────────────────────────
+# limits_config alone only marks data as expired; nothing is reclaimed until a
+# compactor runs with retention_enabled, which is why both stanzas are needed.
+limits_config:
+  retention_period: 168h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+  retention_delete_delay: 2h
+  compaction_interval: 10m


### PR DESCRIPTION
## What
- Add a 7 day retention period and an enabled compactor to Loki
- Move promtail's positions file onto a named volume

## Why
Loki ran on the image's default config, which defines neither `limits_config` nor `compactor`, so nothing was
ever deleted. Traefik runs with `--accesslog=true` and promtail scrapes every container with no drop rules,
so every HTTP request on the box becomes a log line. The disk underneath is a WSL2 vhdx, which never shrinks —
space would not return to Windows even after deletion. Separately, promtail kept its positions in `/tmp`, so
every restart re-shipped the full history of every container's logs.

## How
The config is the image default copied verbatim with only a retention block appended, so `schema_config` is
untouched — the chunks already on disk were written against `tsdb`/`v13`, and editing that against existing
data is the usual way to break Loki on restart. Both `limits_config` and `compactor` are required: the former
only marks data expired, the latter is what reclaims it.

## Test plan
- [ ] \`curl localhost:3100/ready\` returns ready after the change
- [ ] \`curl localhost:3100/config\` shows retention_period 168h and retention_enabled true
- [ ] Existing logs are still queryable in Grafana, i.e. the schema was not broken
- [ ] \`docker restart promtail\` does not re-ingest the whole history a second time
- [ ] /loki stops growing monotonically over the following week

Generated by [Claude-Bot] of [@YehudaBriskman]