### PR TITLE
chore: pin every floating image tag

### DIFF
--- a/data/kafka/compose.yml
+++ b/data/kafka/compose.yml
@@ -2,7 +2,7 @@ name: kafka
 
 services:
   kafka:
-    image: apache/kafka:latest
+    image: apache/kafka:4.3.1
     container_name: kafka
     restart: unless-stopped
     ports:
@@ -39,7 +39,7 @@ services:
     networks: [devnet]
 
   kafka-ui:
-    image: kafbat/kafka-ui:latest
+    image: kafbat/kafka-ui@sha256:7cda86a33344160309fdb65146332e4da65db81a945614f2fe32e210803f6fd1
     container_name: kafka-ui
     labels:
       - traefik.enable=true
@@ -67,7 +67,7 @@ services:
     networks: [devnet]
 
   kafka-exporter:
-    image: danielqsj/kafka-exporter:latest
+    image: danielqsj/kafka-exporter@sha256:a51b280b55a763deaa1bc5024310bc2954995d9160014d7445055dac6a090868
     container_name: kafka-exporter
     restart: unless-stopped
     command: ["--kafka.server=kafka:19092"]

--- a/data/postgres/compose.yml
+++ b/data/postgres/compose.yml
@@ -25,7 +25,7 @@ services:
     networks: [devnet]
 
   postgres-exporter:
-    image: quay.io/prometheuscommunity/postgres-exporter:latest
+    image: quay.io/prometheuscommunity/postgres-exporter@sha256:ac5ec343104fae0e2d84a27bb8d69b38430a11910c5382cad85d478d2bab713e
     container_name: postgres-exporter
     restart: unless-stopped
     environment:

--- a/data/redis/compose.yml
+++ b/data/redis/compose.yml
@@ -22,7 +22,7 @@ services:
     networks: [devnet]
 
   redis-exporter:
-    image: oliver006/redis_exporter:latest
+    image: oliver006/redis_exporter:v1.86.0
     container_name: redis-exporter
     restart: unless-stopped
     environment:

--- a/mgmt/compose.yml
+++ b/mgmt/compose.yml
@@ -2,7 +2,7 @@ name: mgmt
 
 services:
   portainer:
-    image: portainer/portainer-ce:latest
+    image: portainer/portainer-ce@sha256:f6bc23d1695530a609563fd65c180aaafec0fc02e019d5fc63d16b6fbe83addd
     container_name: portainer
     labels:
       - traefik.enable=true
@@ -31,7 +31,7 @@ services:
     networks: [devnet]
 
   dozzle:
-    image: amir20/dozzle:latest
+    image: amir20/dozzle:v10.6.10
     container_name: dozzle
     labels:
       - traefik.enable=true

--- a/monitoring/compose.yml
+++ b/monitoring/compose.yml
@@ -2,7 +2,7 @@ name: monitoring
 
 services:
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.13.1
     container_name: prometheus
     labels:
       - traefik.enable=true
@@ -33,7 +33,7 @@ services:
     networks: [devnet]
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:13.1.0
     container_name: grafana
     labels:
       - traefik.enable=true
@@ -67,7 +67,7 @@ services:
     networks: [devnet]
 
   loki:
-    image: grafana/loki:latest
+    image: grafana/loki:3.7.3
     container_name: loki
     restart: unless-stopped
     command: -config.file=/etc/loki/local-config.yaml
@@ -85,7 +85,7 @@ services:
     networks: [devnet]
 
   promtail:
-    image: grafana/promtail:latest
+    image: grafana/promtail:3.6.8
     container_name: promtail
     restart: unless-stopped
     command: -config.file=/etc/promtail/config.yml
@@ -104,7 +104,7 @@ services:
     networks: [devnet]
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.55.1
     container_name: cadvisor
     restart: unless-stopped
     privileged: true
@@ -123,7 +123,7 @@ services:
     networks: [devnet]
 
   node-exporter:
-    image: prom/node-exporter:latest
+    image: prom/node-exporter:v1.12.1
     container_name: node-exporter
     restart: unless-stopped
     command:


### PR DESCRIPTION
## What
- Pin nine images to the exact version they are already running
- Pin the four that cannot self-report a version by digest instead

## Why
Thirteen images tracked a floating tag on a box designed to run unattended and restart containers by itself.
Any recreate — a routine `docker compose pull`, or a container restart after an image update — could silently
bring in a new major version. `apache/kafka:latest` was the dangerous one: crossing a KRaft metadata version
boundary that way is not reversible without restoring the volume.

## How
Each candidate tag was checked against the registry with `docker manifest inspect` before being written, so a
pin that does not resolve can never reach the file. Where an image could not report its version, the digest of
the running image is used, which is stricter than a tag. Nothing was recreated: the pins take effect at the
next deliberate update.

## Test plan
- [ ] `grep -rn 'image:.*:latest' --include='*.yml' .` returns nothing outside `host/`
- [ ] Every compose file passes `docker compose config`
- [ ] `docker compose pull` succeeds for each stack, i.e. every pinned reference resolves
- [ ] All 25 containers still running, none recreated by this change

Generated by [Claude-Bot] of [@YehudaBriskman]
