### PR TITLE
fix: bind databases to loopback only

### DIFF
--- a/data/kafka/compose.yml
+++ b/data/kafka/compose.yml
@@ -6,7 +6,9 @@ services:
     container_name: kafka
     restart: unless-stopped
     ports:
-      - "9092:9092"
+      # Loopback only. EXTERNAL advertises localhost:9092, so this listener was
+      # only ever usable from the box or through the ssh tunnel anyway.
+      - "127.0.0.1:9092:9092"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller

--- a/data/postgres/compose.yml
+++ b/data/postgres/compose.yml
@@ -10,7 +10,10 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devpass}
       POSTGRES_DB: ${POSTGRES_DB:-dev}
     ports:
-      - "5432:5432"
+      # Loopback only. The ssh tunnel in `just urls` connects to localhost on
+      # this box, so it is unaffected; containers reach postgres by name over
+      # devnet and never touch this published port.
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/data/redis/compose.yml
+++ b/data/redis/compose.yml
@@ -7,7 +7,9 @@ services:
     restart: unless-stopped
     command: ["redis-server", "--appendonly", "yes"]
     ports:
-      - "6379:6379"
+      # Loopback only - this instance has no requirepass at all, so it must
+      # never be reachable beyond the box itself.
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
     healthcheck:


### PR DESCRIPTION
## What
- Publish Postgres, Redis and Kafka on `127.0.0.1` instead of `0.0.0.0`

## Why
`just urls` has been telling anyone who reads it that the databases are "loopback-bound" and reachable only
via an SSH tunnel. All three actually published on `0.0.0.0`, so they were open to the whole tailnet —
Postgres with the superuser account on a default password, and Redis with no password at all. This makes the
documentation true rather than aspirational.

## How
The documented SSH tunnel is unaffected: it connects to `localhost` on this box, which is exactly what the
new bind serves. Containers are unaffected too, since they reach each other across the `devnet` bridge by
container name rather than through a published host port. `ss` showed no established connection to any of the
three ports at the time of the change, so nothing is being cut off.

## Test plan
- [ ] `ss -ltn` shows 5432, 6379 and 9092 bound to 127.0.0.1, not 0.0.0.0
- [ ] `just psql` and `just redis` still work
- [ ] The exporters keep scraping, i.e. their Prometheus targets stay up
- [ ] Wiki.js reconnects to Postgres and `wiki.dev.test` still serves
- [ ] The documented `ssh -L 5432:localhost:5432 ...` tunnel still reaches the database

Generated by [Claude-Bot] of [@YehudaBriskman]
