### PR TITLE
fix: gate exporters on healthy dependencies

### DIFF
--- a/data/kafka/compose.yml
+++ b/data/kafka/compose.yml
@@ -61,7 +61,11 @@ services:
       KAFKA_CLUSTERS_0_NAME: local
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:19092
       DYNAMIC_CONFIG_ENABLED: "true"
-    depends_on: [kafka]
+    # KRaft startup takes the better part of a minute, so the short form lost
+    # this race on every reboot and produced a burst of false alerts.
+    depends_on:
+      kafka:
+        condition: service_healthy
     deploy:
       resources:
         limits:
@@ -73,7 +77,11 @@ services:
     container_name: kafka-exporter
     restart: unless-stopped
     command: ["--kafka.server=kafka:19092"]
-    depends_on: [kafka]
+    # KRaft startup takes the better part of a minute, so the short form lost
+    # this race on every reboot and produced a burst of false alerts.
+    depends_on:
+      kafka:
+        condition: service_healthy
     deploy:
       resources:
         limits:

--- a/data/postgres/compose.yml
+++ b/data/postgres/compose.yml
@@ -33,7 +33,12 @@ services:
     restart: unless-stopped
     environment:
       DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-dev}:${POSTGRES_PASSWORD:-devpass}@postgres:5432/${POSTGRES_DB:-dev}?sslmode=disable"
-    depends_on: [postgres]
+    # Short form waits only for the container to exist, not for the service
+    # to accept connections, so on a cold boot this started against a DB
+    # still initialising and crash-looped until the restart policy caught it.
+    depends_on:
+      postgres:
+        condition: service_healthy
     deploy:
       resources:
         limits:

--- a/data/redis/compose.yml
+++ b/data/redis/compose.yml
@@ -29,7 +29,12 @@ services:
     restart: unless-stopped
     environment:
       REDIS_ADDR: "redis://redis:6379"
-    depends_on: [redis]
+    # Short form waits only for the container to exist, not for the service
+    # to accept connections, so on a cold boot this started against a DB
+    # still initialising and crash-looped until the restart policy caught it.
+    depends_on:
+      redis:
+        condition: service_healthy
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## What
- Replace the short-form `depends_on` with `condition: service_healthy` for the four exporters

## Why
The short list form waits only for the container to be created, not for the service inside it to accept
connections. On a cold boot the exporters started against a database still running `initdb` and crash-looped
until `restart: unless-stopped` carried them through — generating a burst of false alerts on every reboot.
Kafka is the worst case, since its KRaft startup takes the better part of a minute, so `kafka-ui` and
`kafka-exporter` lost that race reliably.

## How
No new healthchecks were needed: postgres, redis and kafka — the three services that others depend on — are
exactly the three that already declare one. The fix is to actually use them.

## Test plan
- [ ] `just down && just up` brings the exporters up without any crash-loop
- [ ] `docker inspect -f '{{.RestartCount}}'` is 0 for all four exporters after a cold start
- [ ] All 7 Prometheus targets reach up without an intermediate down period
- [ ] Kafka-UI serves on first attempt rather than after retries

Generated by [Claude-Bot] of [@YehudaBriskman]
