### PR TITLE
fix: harden doctor checks and guard nuke

### DIFF
--- a/justfile
+++ b/justfile
@@ -59,7 +59,10 @@ down:
     -docker compose -f monitoring/compose.yml down
 
 # Stop everything AND delete all data volumes (DESTRUCTIVE)
+# Sits one keystroke from `down` in the recipe list and deletes all seven data
+# volumes: postgres, redis, kafka, prometheus, grafana, loki, portainer.
 nuke:
+    @printf "This deletes ALL data volumes. Type yes to continue: " && read ans && [ "$ans" = yes ] || (echo aborted; exit 1)
     -docker compose -f auth/compose.yml down -v
     -docker compose -f edge/compose.yml down -v
     -docker compose -f apps/portal/compose.yml down -v

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -5,26 +5,67 @@ green() { printf '  \033[32m✓\033[0m %s\n' "$*"; }
 red()   { printf '  \033[31m✗\033[0m %s\n' "$*"; }
 
 echo "== containers =="
-expected="prometheus grafana loki promtail cadvisor node-exporter postgres postgres-exporter redis redis-exporter kafka kafka-ui kafka-exporter portainer dozzle wiki portal"
+# traefik, oauth2-proxy and portal-socket-proxy are the front door and the login
+# for everything else, and were missing from this list entirely.
+expected="traefik oauth2-proxy portal-socket-proxy prometheus grafana loki promtail cadvisor node-exporter postgres postgres-exporter redis redis-exporter kafka kafka-ui kafka-exporter portainer dozzle wiki portal"
 for c in $expected; do
   st=$(docker inspect -f '{{.State.Status}}' "$c" 2>/dev/null || echo missing)
   [ "$st" = running ] && green "$c" || red "$c ($st)"
 done
 
 echo "== prometheus targets =="
-curl -s 'http://localhost:9090/api/v1/targets?state=active' 2>/dev/null \
-  | jq -r '.data.activeTargets[] | "\(.labels.job) \(.health)"' 2>/dev/null | sort -u \
-  | while read -r j h; do [ "$h" = up ] && green "$j" || red "$j ($h)"; done
+# Without this guard a missing jq piped its failure into a loop that never
+# iterated, so an absent dependency read exactly like a clean bill of health.
+if ! command -v jq >/dev/null 2>&1; then
+  red "jq is not installed - cannot read prometheus targets"
+else
+  targets=$(curl -s --max-time 5 'http://localhost:9090/api/v1/targets?state=active' 2>/dev/null \
+    | jq -r '.data.activeTargets[] | "\(.labels.job) \(.health)"' 2>/dev/null | sort -u)
+  if [ -z "$targets" ]; then
+    red "prometheus returned no targets - is it up?"
+  else
+    echo "$targets" | while read -r j h; do
+      [ "$h" = up ] && green "$j" || red "$j ($h)"
+    done
+  fi
+fi
 
 echo "== kubernetes =="
-kubectl get nodes --no-headers 2>/dev/null | awk '{print $1, $2}' \
-  | while read -r n s; do [ "$s" = Ready ] && green "node $n" || red "node $n ($s)"; done \
-  || red "minikube unreachable"
+# The old form attached || to a while loop, whose exit status is zero even when
+# kubectl fails, so an unreachable cluster could never actually be reported.
+if ! command -v kubectl >/dev/null 2>&1; then
+  red "kubectl is not installed"
+else
+  nodes=$(kubectl get nodes --no-headers 2>/dev/null || true)
+  if [ -z "$nodes" ]; then
+    red "minikube unreachable"
+  else
+    echo "$nodes" | awk '{print $1, $2}' | while read -r n st; do
+      [ "$st" = Ready ] && green "node $n" || red "node $n ($st)"
+    done
+  fi
+fi
 
 echo "== disk / memory =="
 df -h / | awk 'NR==2{printf "  / used %s (%s free)\n", $5, $4}'
 free -h | awk '/Mem:/{printf "  mem used %s / %s\n", $3, $2}'
 
 echo "== backups =="
+# Existence alone is not health. Six days of 20-byte empty dumps passed the old
+# check unnoticed, because a failed pg_dumpall still leaves behind a perfectly
+# valid gzip of nothing. Age and size are what separate a backup from a file
+# that is merely named like one.
 latest=$(ls -1t /home/devssh/backups/postgres/*.sql.gz 2>/dev/null | head -1)
-[ -n "$latest" ] && green "latest pg dump: $(basename "$latest")" || red "no postgres backups yet"
+if [ -z "$latest" ]; then
+  red "no postgres backups yet"
+else
+  size=$(wc -c < "$latest")
+  age_h=$(( ( $(date +%s) - $(stat -c %Y "$latest") ) / 3600 ))
+  if [ "$size" -lt 1000 ]; then
+    red "latest pg dump is ${size}B - almost certainly empty: $(basename "$latest")"
+  elif [ "$age_h" -gt 48 ]; then
+    red "latest pg dump is ${age_h}h old: $(basename "$latest")"
+  else
+    green "latest pg dump: $(basename "$latest") (${size}B, ${age_h}h old)"
+  fi
+fi


### PR DESCRIPTION
## What
- Check traefik, oauth2-proxy and the socket proxy in the container roll-call
- Fail loudly when `jq` or `kubectl` are missing instead of printing nothing
- Validate backup age and size, not merely existence
- Require confirmation before `just nuke`

## Why
`doctor` was capable of reporting a healthy box while telling you nothing: without `jq` the Prometheus
section piped a failure into a loop that never iterated, and the kubernetes guard was attached to a `while`,
whose exit status is zero even when `kubectl` fails. The roll-call also predated the edge and auth stacks, so
the front door and the login for everything else were never checked. Most importantly the backup check only
asked whether a file existed — which is exactly why six days of 20-byte empty dumps went unnoticed.

## How
The backup check now fails if the newest dump is older than 48 hours or smaller than 1 KB, either of which
would have caught the boot-race failure the day it started. `nuke` deletes all seven data volumes and sat one
keystroke from `down` in the recipe list, so it now prompts.

## Test plan
- [ ] `just doctor` lists traefik, oauth2-proxy and portal-socket-proxy
- [ ] Temporarily renaming `jq` makes doctor report the missing dependency instead of printing nothing
- [ ] Touching a 20-byte fake dump makes the backup check fail
- [ ] `just nuke` prompts and aborts on anything other than an explicit yes

Generated by [Claude-Bot] of [@YehudaBriskman]
