### PR TITLE
docs: add dev box knowledge base

### DIFF
--- a/docs/kb/README.md
+++ b/docs/kb/README.md
@@ -1,0 +1,39 @@
+# dev-box knowledge base
+
+Everything known about the dev stack ("stack system dev", repo `YehudaBriskman/dev-box`)
+and the machines around it. Built 2026-08-02 from the July audit + the August incidents.
+
+> **Something is broken RIGHT NOW?** → open **[runbook-cant-reach.md](runbook-cant-reach.md)**
+> and follow the decision tree. Do not start debugging the box before step 0.
+
+## Map
+
+| File | What's in it |
+|---|---|
+| [topology.md](topology.md) | Every machine, user, IP, tailnet node, WSL instance, and how they connect |
+| [access.md](access.md) | Every way into the box: SSH paths, usernames, elevation tricks, visibility gotchas |
+| [dns.md](dns.md) | How `dev.test` / `*.dev.test` resolve: split DNS, dnsmasq, MagicDNS, client gotchas |
+| [always-on.md](always-on.md) | Why the box stays up unattended: keepalive task, ForceDaemon, cold-boot proof |
+| [architecture.md](architecture.md) | What runs inside: Traefik, SSO, portal, backups, monitoring — and the built-in traps |
+| [runbook-cant-reach.md](runbook-cant-reach.md) | **The** diagnosis decision tree for "can't reach the dev stack" |
+| [runbook-post-reboot.md](runbook-post-reboot.md) | What to do after the Windows host reboots |
+| [known-issues.md](known-issues.md) | Open items, deliberate tradeoffs, and things that look broken but aren't |
+| [lessons.md](lessons.md) | Debugging principles paid for in blood, incl. every wrong conclusion we corrected |
+| [incidents/2026-07-21-wsl-idle-timeout.md](incidents/2026-07-21-wsl-idle-timeout.md) | "Only works while SSH'd in" — WSL VM 60s idle kill |
+| [incidents/2026-08-01-ethernet-ndis.md](incidents/2026-08-01-ethernet-ndis.md) | Host NIC/NDIS pause-wedge, DHCP death, LAN IP change |
+| [incidents/2026-08-02-thinkpad-tailscale.md](incidents/2026-08-02-thinkpad-tailscale.md) | Laptop's half-upgraded tailscaled: tunnel green, all traffic dead |
+
+## Source documents (kept, not superseded for detail)
+
+- `C:\Users\yr055\dev-box-audit.md` — the full July audit: 25 findings, 14 PRs, all corrections
+- `C:\Users\yr055\dev-box-reboot-note.md` — original post-reboot instructions
+- `C:\Users\yr055\thinkpad-tailscale-incident-2026-08-02.md` — full Aug 2 incident report
+- `C:\Users\yr055\ts-log-copy\` — host tailscaled log copies from the Aug 2 investigation
+- `C:\Users\yr055\dev-box-postboot-check.ps1` / `-report.txt` — the post-boot checker and its last run
+
+## Keeping this useful
+
+After any incident or infra change: update the relevant topic file, add/append an
+incident file, and add one line to [lessons.md](lessons.md) if a new principle emerged.
+Stale knowledge caused real damage twice (stale repo → wrong audit findings; stale
+checker IP → false FAIL). Dates on claims matter — keep them.

--- a/docs/kb/access.md
+++ b/docs/kb/access.md
@@ -1,0 +1,66 @@
+# Access — every way into the dev box, and why the obvious ones fail
+
+_See [topology.md](topology.md) for what these machines are._
+
+## The front door (use this)
+
+```bash
+ssh devssh@100.117.176.85          # or devssh@yehuda-wsl.tail7e7e3b.ts.net, or devssh@dev.test
+```
+
+Lands in `~/stacks`. Rules that are not obvious:
+
+- **Port 22 on the dev box is Tailscale SSH, not OpenSSH.** `openssh-server` is not
+  installed in the distro; tailscaled itself serves the port (`RunSSH: true`). There is no
+  `sshd_config`, no `authorized_keys`, no host-key debugging to do — auth is tailnet
+  identity + ACL. Client keys are irrelevant; auth method is "none".
+- **The only user is `devssh`** (uid 1000, passwordless sudo). Any other username —
+  including `yr055` — fails with `unknown user` at user lookup. This burned us 2026-08-02
+  at 17:55: it looks like a server problem, it's a typo.
+- The client must be **on the tailnet with a working tunnel** — if `dev.test` doesn't
+  resolve either, suspect the client, not the box ([runbook-cant-reach.md](runbook-cant-reach.md)).
+- No check-mode in the SSH policy (verified from logs 2026-08-02) — a browser re-auth
+  prompt is not expected; access is granted directly.
+
+## The other port 22 — the Windows host
+
+```bash
+ssh devssh@100.93.197.10       # the HOST's Windows sshd, devssh's WINDOWS password
+```
+
+Historic path, still active (last used from the laptop 2026-08-02 12:38). It lands in
+Windows, not in the dev stack. Don't confuse the two 22s: same machine physically,
+different OS answering depending on which tailnet IP you dialed.
+
+## From yr055 on the host itself, without SSH
+
+devssh's WSL distro is registered in **devssh's registry hive** — `wsl -l` as yr055 will
+never list it, elevated or not. To run something inside it from another account, use an
+interactive-token scheduled task (no password needed while devssh is logged on):
+
+```powershell
+schtasks /create /TN "devbox-run" /TR "cmd /c wsl.exe -d Ubuntu -e bash /mnt/c/Users/Public/devbox/x.sh > C:\Users\Public\devbox\out.txt 2>&1" /SC ONCE /ST 23:59 /RU devssh /IT /F
+schtasks /run /TN "devbox-run"
+```
+
+Write the `.sh` with **LF endings** (`sed -i 's/\r$//'`) — CRLF breaks bash.
+(When devssh is *not* logged on, the `/IT` trick doesn't work — but Tailscale SSH does.)
+
+## Elevation map — what yr055 can and cannot see
+
+| Thing | Non-elevated yr055 | Elevated |
+|---|---|---|
+| `C:\Users\devssh\*` | access denied | readable |
+| `DevBox-WSL-Keepalive` task | **"Access is denied"** — looks MISSING but isn't | visible, incl. LastRunTime |
+| `C:\ProgramData\Tailscale\` (service logs) | ACL-locked | readable (copies from 2026-08-02 in `C:\Users\yr055\ts-log-copy\`) |
+| Owners of devssh's processes (vmmemWSL etc.) | blank/denied | visible |
+
+**Rule:** "Access is denied" ≠ "does not exist". The postboot checker reported
+`TASK MISSING` for exactly this reason when run non-elevated.
+
+## Web access
+
+All `*.dev.test` services go through Traefik on :80 with GitHub SSO in front of most of
+them ([architecture.md](architecture.md)). Expected codes: `dev.test` → **401** when not
+signed in (that means UP), grafana → 302. Test with `curl.exe`, never `Invoke-WebRequest`
+([lessons.md](lessons.md)).

--- a/docs/kb/always-on.md
+++ b/docs/kb/always-on.md
@@ -1,0 +1,46 @@
+# Always-on — why the box survives with nobody logged in
+
+## The original disease (2026-07-21, [incident](incidents/2026-07-21-wsl-idle-timeout.md))
+
+WSL2 destroys its utility VM **60 seconds after the last Windows-side client disconnects**
+(devssh's `.wslconfig` sets no `vmIdleTimeout`). An SSH session counts as a client — so the
+box only worked while someone was SSH'd in, then died 60s later, taking docker, all ~25
+containers and the in-WSL Tailscale node with it. That is why it looked "flaky" for weeks.
+
+## The cure — three pieces, all required
+
+1. **Scheduled task `DevBox-WSL-Keepalive`** (the core): runs as `devssh` with a stored
+   password (`LogonType=Password`, `RunLevel=Highest`), triggers *At startup* + *At logon
+   of devssh*, no execution time limit, `MultipleInstances=IgnoreNew`, restart 5×/1min.
+   Action: `powershell -NoProfile -WindowStyle Hidden -Command "wsl.exe -d Ubuntu -u root -e sleep infinity"`
+   — a permanent client that holds the VM open.
+2. **Inside the distro:** systemd is PID 1 and `docker.service` is enabled — once the
+   distro is up, the whole stack rises with it. `tailscale set --ssh=true` gives SSH access
+   with no sshd.
+3. **On the Windows host:** Tailscale **`ForceDaemon: true`** (unattended mode) — without
+   it the host's tailscale died on logout, which caused an earlier outage.
+
+## Proof status: PASSED ✅ (2026-08-01)
+
+The one untested piece — a genuine cold boot with nobody logging in as devssh — happened
+2026-08-01 14:06 (the [ethernet-incident](incidents/2026-08-01-ethernet-ndis.md) reboot):
+devssh's WSL VM started **16 seconds after boot**, and 28h later the containers, HTTP
+services, SSO and Tailscale node were all still up with only yr055 on console. Verified
+2026-08-02 via checker + event logs + tailscaled logs.
+
+## How it can still break (watch these)
+
+| Risk | Symptom | Detection / fix |
+|---|---|---|
+| **devssh's Windows password changes** | Task fails **silently** at next boot; box never comes up | After any password change: re-save the task credential. Post-reboot: run the checker ([runbook-post-reboot.md](runbook-post-reboot.md)) |
+| Task deleted/disabled | Same | `schtasks /query /TN "DevBox-WSL-Keepalive"` **from an elevated prompt** (non-elevated says "Access is denied", which is normal — see [access.md](access.md)) |
+| WSL update changes idle behavior | VM dies ~60s after last client despite task | `Get-Process vmmemWSL` count should be 2; check task is actually running |
+| Manual recovery, any time | — | Elevated: `schtasks /run /TN "DevBox-WSL-Keepalive"` — or log in as devssh once (always works) |
+
+## Quick health check (from yr055, any time)
+
+```powershell
+(Get-Process vmmemWSL -ErrorAction SilentlyContinue).Count   # want: 2
+curl.exe -s -o NUL -w "%{http_code}" http://dev.test/        # want: 401 (or 200/302)
+tailscale status | findstr yehuda-wsl                        # want: active or idle, not offline
+```

--- a/docs/kb/architecture.md
+++ b/docs/kb/architecture.md
@@ -1,0 +1,58 @@
+# Architecture — what actually runs inside the dev box
+
+_Condensed from the 2026-07 audit (full detail: `C:\Users\yr055\dev-box-audit.md`).
+Live tree: `~/stacks` in devssh's WSL distro, on `main`. Audit rule: **read the live box,
+never trust `origin/main` to describe it** — see [lessons.md](lessons.md)._
+
+## The front door
+
+**Traefik v3.6** (`edge/`) is the single entrypoint on :80, routing by Host header:
+`dev.test` → portal, `grafana|prometheus|portainer|dozzle|kafka|wiki|traefik|cvops.dev.test`
+→ their services, plus prio-100 `Path()` routers for the portal's own API
+(`/-/api/traefik/*`, `/-/api/docker/containers/json`), and a prio-1 `portal-fallback`
+catching everything else. Names resolve via [dns.md](dns.md).
+
+**GitHub SSO (oauth2-proxy, forwardAuth)** protects: dozzle, kafka-ui, prometheus,
+traefik dashboard, portal + fallback, and both `/-/api/*` routers → unauthenticated
+requests get **401 + sign-in page (this means UP, not broken)**. Grafana, wiki, portainer
+keep their own auth. Single GitHub account allowed; `--redirect-url` is pinned (one OAuth
+callback URL only).
+
+## The portal
+
+Live-discovery page: `portal.js` polls the Traefik API + docker container list every 10s
+through `portal-socket-proxy` (tecnativa docker-socket-proxy, `CONTAINERS=1` only,
+read-only socket, no published port). Health display fixed in PR #11
+(`container.Health?.Status` — Health is an object, not a string).
+
+## Also on the box
+
+- **cvops** project (5 containers, DBs on loopback, shifted ports 15432/16379)
+- **minikube** (own systemd unit)
+- **Backups** (`backup.sh`, systemd timer): postgres + redis + grafana + portainer + `.env`,
+  with `pg_isready` wait, empty-artifact discard, non-zero exit on failure. `doctor.sh`
+  fails loudly if the newest backup is `< 1000 bytes` or `> 48h` old — **that check is the
+  single most important alarm on the box** (backups were silently empty for 6 days once).
+- **Monitoring**: Prometheus (15d retention, 7 targets all up incl. docker-daemon :9323),
+  Loki (7-day retention since PR #7), promtail (positions in a volume, not /tmp), Grafana.
+
+## Traps that are DESIGNED IN (read before "fixing" anything)
+
+| Trap | Reality |
+|---|---|
+| `edge/dynamic` bind mount goes **stale after `git checkout`** | Bind mounts pin the inode; checkout recreates the dir. Traefik then serves an old in-memory config while `watch=true` silently does nothing. **After any branch switch:** `docker compose -f edge/compose.yml up -d --force-recreate` |
+| `docker compose` does **not** read `~/stacks/.env` | Only `just` loads it (`set dotenv-load`). Direct compose: `set -a; . ./.env; set +a` first — otherwise "required variable missing" |
+| `portal-fallback` returns **200 for any typo'd host** | A wrong hostname looks healthy. A 200 from an unexpected name proves nothing |
+| The `POST` protection on the docker API is in the **socket-proxy env** (`POST: 0`), not in the `Path()` rules | The comment in `portal-api.yml` claiming otherwise was corrected; don't trim the env block |
+| Traefik router priorities 16–27 are **defaulted from rule-string length** | A future rule >100 chars silently outranks the prio-100 API routers |
+| oauth2-proxy image is **distroless** | No shell → any docker healthcheck on it hangs in `starting` forever. It has none, on purpose |
+| `--skip-provider-button` + Traefik `errors` middleware | Incompatible (CSRF cookie dropped) — don't re-add the flag |
+
+## State of hardening (as of PRs #1–#14, 2026-07-21/22)
+
+Done: everything committed; backups real + validated; Kafka persistence
+(`KAFKA_LOG_DIRS`); 13 images pinned (tag or digest, each verified resolvable first);
+DBs bound to loopback; SSO everywhere that lacked auth; DNS-rebinding hole closed by SSO;
+Loki retention; portal health + error rendering; doctor.sh hardened; README rewritten.
+
+Open items → [known-issues.md](known-issues.md).

--- a/docs/kb/dns.md
+++ b/docs/kb/dns.md
@@ -1,0 +1,44 @@
+# DNS — how `dev.test` works, and every way it fools you
+
+## The chain (verified end-to-end 2026-07-21 from the phone)
+
+```
+client on tailnet → Tailscale split DNS: "test" → 100.117.176.85
+                  → dnsmasq on the dev box (authoritative for .test)
+                  → answers dev.test / *.dev.test = 100.117.176.85
+client connects   → Traefik on :80 routes by Host header → service
+```
+
+- MagicDNS is on tailnet-wide, suffix `tail7e7e3b.ts.net` (so `yehuda-wsl.tail7e7e3b.ts.net` also works).
+- Split DNS routes **the whole `.test` TLD** to the dev box, tailnet-wide.
+
+## The consequence that keeps causing false alarms
+
+**`.test` names only resolve for a client whose Tailscale tunnel + DNS are working.**
+When a client's tailscale degrades, `dev.test` breaks *first* (DNS), then SSH — which
+looks exactly like "the dev box is down". It never was, in any incident so far
+(2026-07-21 ×2, 2026-08-02). First question, always: **is this device actually on the
+tailnet, with a working tunnel?** → [runbook-cant-reach.md](runbook-cant-reach.md)
+
+## Box-side configuration (fixed 2026-07-21, audit Phase 1.1)
+
+- dnsmasq listens on `127.0.0.1` **and** `100.117.176.85`; authoritative for `.test`;
+  upstreams: `server=/ts.net/100.100.100.100` and the WSL NAT resolver.
+- `/etc/resolv.conf` points at local dnsmasq; **`generateResolvConf=false`** in
+  `/etc/wsl.conf` so WSL stops rewriting it every boot (it used to, destroying any fix).
+- **`accept-dns=false` must stay set on the WSL tailscale node** — enabling it lets
+  tailscaled rewrite resolv.conf and clobber the whole setup.
+- Side effect: dnsmasq has upstreams, so it answers non-`.test` queries for any tailnet
+  client — an open resolver confined to the tailnet. Known, accepted.
+- Config lives in `/etc/dnsmasq.d/dev.conf` — host config, tracked in the repo's `host/`
+  dir since PR #8, but the *live* file is what matters.
+
+## Client-side gotchas (all seen in real incidents)
+
+| Symptom | Actual cause |
+|---|---|
+| `Invoke-WebRequest` to `*.dev.test` times out | .NET Happy-Eyeballs quirk (A record only). **Use `curl.exe`.** The site is fine. |
+| Browser says NXDOMAIN, curl works | Chrome Secure DNS (DoH) bypasses the system resolver — it can never see `.test`. |
+| `dev.test` dead + SSH dead on ONE device, fine elsewhere | That device's tailscale — see [incidents/2026-08-02](incidents/2026-08-02-thinkpad-tailscale.md). |
+| `.test` doesn't resolve *inside* the dev box's own shell | Was finding #1 in the audit — fixed 2026-07-21; if it recurs, check resolv.conf + dnsmasq listen addresses. |
+| Windows host can't resolve `.test` | Host must have Tailscale DNS on (`tailscale dns status` → "Tailscale DNS: enabled"). |

--- a/docs/kb/incidents/2026-07-21-wsl-idle-timeout.md
+++ b/docs/kb/incidents/2026-07-21-wsl-idle-timeout.md
@@ -1,0 +1,27 @@
+# Incident 2026-07-21 — "the box only works while I'm SSH'd in"
+
+**Status: RESOLVED** (fix proven across a cold boot on 2026-08-01).
+
+## Symptom
+The dev stack worked during SSH sessions and died shortly after disconnecting. Looked like
+crashing services / flaky Traefik; weeks of intermittent "the site is down".
+
+## Root cause
+WSL2 destroys its utility VM **60 seconds after the last Windows-side client disconnects**
+(no `vmIdleTimeout` in devssh's `.wslconfig`). An SSH session was the only client holding
+it open — disconnect → 60s → VM gone, taking docker, ~25 containers and the in-WSL
+Tailscale node. Confirmed by kernel boot lines repeating every ~80s, once per probe.
+
+Contributing: the Windows host's Tailscale lacked unattended mode (`ForceDaemon`), so the
+host node also dropped when devssh's session ended.
+
+## Fix
+`DevBox-WSL-Keepalive` scheduled task (runs as devssh at boot + logon, holds
+`wsl … sleep infinity` forever) + `ForceDaemon: true` on the host + `tailscale set
+--ssh=true` in the distro. Full detail: [../always-on.md](../always-on.md).
+
+## What made it hard
+- The repo didn't describe reality (README still sold an SSH-tunnel model); auditing
+  `origin/main` produced wrong findings. → [../lessons.md](../lessons.md) #8.
+- Same audit surfaced 25 findings (empty backups, unpersisted Kafka, uncommitted working
+  system, SSO absence…) fixed across PRs #1–#14. Full record: `C:\Users\yr055\dev-box-audit.md`.

--- a/docs/kb/incidents/2026-08-01-ethernet-ndis.md
+++ b/docs/kb/incidents/2026-08-01-ethernet-ndis.md
@@ -1,0 +1,25 @@
+# Incident 2026-08-01 — host Ethernet dead (NDIS pause-wedge)
+
+**Status: RESOLVED** (suspected trigger removed; no recurrence as of 2026-08-02).
+
+## Symptom
+The Windows host (`Yehuda-HS`) lost Ethernet/DHCP entirely — with it, the LAN, and
+everything hosted on the machine.
+
+## Root cause
+An NDIS pause-wedge killed DHCP on the Realtek NIC; the NIC was found **admin-disabled**.
+Behind it: PnP storms from a **failing USB webcam**, which has since been physically
+unplugged. (Event logs on 2026-08-02 show zero Kernel-PnP events in 8h — the removal is
+holding.)
+
+## Resolution & side effects
+- Machine rebooted 2026-08-01 **14:06** — which doubled as the long-awaited **cold-boot
+  test of the keepalive fix: PASSED** ([../always-on.md](../always-on.md)).
+- The new DHCP lease moved the host's LAN IP **192.168.68.57 → 192.168.68.52** — which
+  later made the postboot checker false-FAIL (stale hard-coded IP,
+  [../known-issues.md](../known-issues.md)) and is a standing reminder that LAN IPs rot
+  ([../lessons.md](../lessons.md) #10).
+
+## Watch for recurrence
+Symptoms would be: NIC shows `Disabled`/no DHCP lease, NDIS warnings in the System event
+log, PnP event storms. If seen: check what USB device was recently attached.

--- a/docs/kb/incidents/2026-08-02-thinkpad-tailscale.md
+++ b/docs/kb/incidents/2026-08-02-thinkpad-tailscale.md
@@ -1,0 +1,40 @@
+# Incident 2026-08-02 — laptop can't reach the dev stack (tunnel green, traffic dead)
+
+**Status: RESOLVED** ~19:00 same day. Full report with complete timeline and evidence:
+`C:\Users\yr055\thinkpad-tailscale-incident-2026-08-02.md` · host tailscaled log copies:
+`C:\Users\yr055\ts-log-copy\`.
+
+## Symptom
+From the ThinkPad: `dev.test` stopped working, then SSH to the dev stack died and never
+came back — while `tailscale status` on the laptop looked fine and everything worked from
+the PC. Looked exactly like a dev-box failure. It wasn't; the box was healthy throughout.
+
+## Root cause
+**Half-upgraded Tailscale on the laptop**: the package on disk was upgraded (CLI 1.98.9)
+but the old daemon (1.98.2) kept running — visible as a version-skew warning at the top of
+every `tailscale` command. The stale daemon left `tailscale0` **without its IPv4 address**:
+
+- Tunnel-internal checks all passed (disco pong, TSMP pong) → status green.
+- Every kernel-level packet died, both directions (inbound dropped; outbound hung because
+  reply SYN-ACKs were dropped coming back).
+- `dev.test` broke first because `.test` DNS rides the same tunnel ([../dns.md](../dns.md)).
+- `sudo tailscale down && up` did **not** help (same broken daemon).
+
+## Fix
+```bash
+sudo systemctl restart tailscaled     # loads the upgraded binary, reprograms the interface
+```
+Note: the first pings after the restart still timed out for a few seconds (NAT-hairpin
+path rediscovery to the WSL node) — retry before concluding failure.
+
+## Ruled out along the way (all clean)
+Dev stack (up 28h, all services answering) · Windows host (event logs spotless) ·
+Tailscale keys/ACL/DERP · laptop ufw (inactive) / shields-up (false) / netfilter rules
+(present) / policy routing (intact).
+
+## What to remember
+1. The **layered-ping method** that cracked it → [../runbook-cant-reach.md](../runbook-cant-reach.md).
+2. **Version-skew warning ⇒ restart tailscaled before any other debugging.**
+3. A wrong-username red herring: `ssh yr055@…` → "unknown user" (only `devssh` exists).
+4. Found in passing: laptop's sshd not running; WSLg segfault loop on the dev box
+   ([../known-issues.md](../known-issues.md)).

--- a/docs/kb/known-issues.md
+++ b/docs/kb/known-issues.md
@@ -1,0 +1,32 @@
+# Known issues & open items
+
+_Status as of 2026-08-02. Things that look broken but aren't → bottom section._
+
+## Open — worth fixing
+
+| Item | Detail | Impact |
+|---|---|---|
+| **Postboot checker hard-codes stale LAN IP** | `dev-box-postboot-check.ps1` probes `192.168.68.57`; host is now `.52` (DHCP). Verdict logic false-FAILs | Every post-reboot check cries wolf ([runbook-post-reboot.md](runbook-post-reboot.md)) |
+| **ThinkPad has no sshd running** | Confirmed 2026-08-02 (dev node got connection-refused at 13:19) | Can't SSH *to* the laptop; enable if wanted |
+| **WSLg crash-loop on the dev box** | weston `rdp-backend.so` segfaults ~every 2 min (170+ since boot). Harmless to services; spams dmesg | Fix: `[wsl2] guiApplications=false` in `C:\Users\devssh\.wslconfig`, restart the distro |
+| **Unattended tailscale upgrades on the laptop** | The 2026-08-02 incident came from a package upgrade without daemon restart | After any tailscale upgrade: restart tailscaled; heed the version-skew warning |
+| Prometheus `rule_files` never declared | `./rules` is mounted but unused — dead config that looks live | Alerts defined there do nothing |
+| Traefik exports no metrics / no scrape job | The front door is the one unmonitored component | Blind spot |
+| Backups stay on the same disk they protect | Nothing copies them off the box | A disk loss takes data + backups |
+| Portainer has RW docker socket + own auth only | Undoes the socket-proxy design from inside the tailnet (audit finding #7; Phase 2.1 decision still pending) | Anyone on the tailnet + Portainer password = root on the box |
+| Grafana still `admin/admin`; some services rely on SSO only | Audit Phase 2.4 | Weak on-tailnet posture |
+| `zz-debug.conf` leaves dnsmasq `log-queries` on | Forever-growing query log | Minor disk/noise |
+| Host config partially outside git | dnsmasq/daemon.json/wsl.conf copies are in `host/` (PR #8), but the keepalive task + Windows-side state aren't scriptable-restorable | Rebuild requires this KB |
+
+## Deliberate tradeoffs (don't "fix")
+
+- dnsmasq answers non-`.test` queries for tailnet clients (open resolver, tailnet-scoped) —
+  side effect of the upstream config that fixed in-box DNS.
+- oauth2-proxy container has no healthcheck (distroless image — a check can never pass).
+- Portal-API routers have no `Host()` rule (bare-IP access works; rebinding risk closed by SSO).
+- prio-1 `portal-fallback` catches all unrouted hosts (that's its job; see the lookalikes list).
+
+## Looks broken, isn't
+
+Collected in [runbook-cant-reach.md](runbook-cant-reach.md) Step 3 — 401s, Invoke-WebRequest,
+Chrome DoH, fallback-200s, hairpin SSH hangs, non-elevated "TASK MISSING".

--- a/docs/kb/lessons.md
+++ b/docs/kb/lessons.md
@@ -1,0 +1,48 @@
+# Lessons — principles paid for in real debugging time
+
+_Each of these was learned by getting it wrong first._
+
+## Diagnosis
+
+1. **First question for any "dev.test is broken": is that device on the tailnet?**
+   Every false alarm and the real Aug-2 incident started here. Client-side tunnel/DNS
+   failure is indistinguishable from a dead box, from that client.
+2. **Prove which side is broken before touching the box** — layered pings
+   (`tailscale ping` → `--tsmp` → `--icmp` → real traffic) name the exact broken layer
+   in under a minute ([runbook-cant-reach.md](runbook-cant-reach.md)).
+3. **A green `tailscale status` does not mean traffic flows.** The daemon can be up with
+   its interface unprogrammed (no IP) — internal pings pong while everything real dies.
+4. **`client version != tailscaled server version` = stop and restart the daemon.**
+   A half-upgraded daemon caused a full day of outage; `down/up` doesn't fix it.
+5. **"Access is denied" ≠ "does not exist."** Non-elevated queries misread devssh's
+   scheduled task as MISSING and the Tailscale logs as absent ([access.md](access.md)).
+6. **Test with two clients before blaming the server** (PC *and* phone). One client is a
+   hypothesis, two are evidence.
+7. **Beware verification commands that cannot fail** — the portal-API "MUST print 404"
+   check printed 404 whether the boundary held or not; the fallback answers 200 to
+   anything. Verify with a probe that *can* distinguish the failure.
+
+## Auditing / changing this system
+
+8. **Audit the live box, never the repo.** `origin/main` ran ~a week behind and produced
+   several confidently-wrong findings (no reverse proxy, crash-looping traefik, no
+   auto-start — all false). Full corrections table: `dev-box-audit.md` §7.
+9. **Verify audit claims before acting on them.** Three findings were disproven only by
+   running the command live (Health field exists; cvops routed; docker-daemon target up).
+10. **Hard-coded addresses rot.** The checker's `192.168.68.57` false-FAILed the moment
+    DHCP moved the host. Prefer names; date-stamp any literal IP you must write.
+11. **After `git checkout`, force-recreate containers with bind mounts** — stale-inode
+    mounts made Traefik serve a 5-day-old config while claiming live-reload.
+12. **`docker compose` doesn't read the root `.env`** — only `just` does.
+13. **A silent success is worse than a loud failure.** Backups "succeeded" as 20-byte
+    gzips for six days; the timer was green. The fix that matters was making `doctor.sh`
+    check artifact **age and size**, not exit codes.
+14. **Write things down where the next debugging session will look.** The Aug-2 diagnosis
+    was fast *because* July's audit had recorded the topology (per-user WSL, Tailscale
+    SSH, split DNS). This KB exists to keep that compounding.
+
+## Client-side quirks (Windows)
+
+15. `Invoke-WebRequest` times out on `.test` names — use `curl.exe`.
+16. Chrome Secure DNS (DoH) can't resolve `.test` — looks like NXDOMAIN, isn't the box.
+17. WSL distros are **per-user**; `wsl -l` never shows another user's distro.

--- a/docs/kb/runbook-cant-reach.md
+++ b/docs/kb/runbook-cant-reach.md
@@ -1,0 +1,75 @@
+# RUNBOOK — "I can't reach the dev stack"
+
+_Every alarm so far (2026-07-21 ×2, 2026-08-02) was the **client**, not the box.
+Work the steps in order; each takes seconds._
+
+## Step 0 — Is the client on the tailnet? (the #1 cause)
+
+On the failing device: `tailscale status`. If it errors, shows logged-out, or shows the
+device offline — that's your problem, full stop. `dev.test` needs the tunnel for **DNS
+too** ([dns.md](dns.md)), so tunnel-down kills names *and* SSH together.
+
+**And check the top of that output for a version-skew warning:**
+
+```
+Warning: client version "X" != tailscaled server version "Y"
+```
+
+If present → the package was upgraded but the old daemon is still running. It can be
+subtly broken while showing green (2026-08-02: interface lost its IP).
+**`sudo systemctl restart tailscaled` FIRST, before any other debugging.**
+(`tailscale down && up` does NOT fix this — it cycles the same broken daemon.)
+
+## Step 1 — Layered pings from a known-good node (PC or phone)
+
+```
+tailscale ping 100.117.176.85            # disco: is a path findable?
+tailscale ping --tsmp 100.117.176.85     # through the tunnel, answered by tailscaled
+tailscale ping --icmp 100.117.176.85     # through the tunnel, answered by the OS kernel
+ping 100.117.176.85                      # normal traffic
+```
+
+| Result | Broken layer | Do |
+|---|---|---|
+| All pong | Nothing network-side | Check application: username `devssh@`? sshd vs Tailscale-SSH confusion? ([access.md](access.md)) |
+| disco+TSMP pong, ICMP dead | **Peer's kernel/interface/firewall** — tunnel is fine but the OS drops packets | On the peer: `ip -4 addr show tailscale0` (must show its 100.x/32 — **empty = the 2026-08-02 bug**, restart tailscaled); then ufw/nftables `ts-input` rules; `ip rule show` (5210/5230/5250/5270 + `lookup 52`) |
+| disco pongs, TSMP dead | WireGuard session broken | Restart tailscaled on the peer |
+| Nothing pongs | Node truly offline | Its machine/network/daemon is down — see below |
+| First pings time out, then work | **NAT-hairpin port rotation / idle handshake** — normal for the WSL node | Wait ~30s, retry. Self-heals ([topology.md](topology.md)) |
+
+## Step 2 — Is the box itself up? (rarely the answer, verify anyway)
+
+From yr055 on the PC:
+
+```powershell
+(Get-Process vmmemWSL -ErrorAction SilentlyContinue).Count    # want 2
+curl.exe -s -o NUL -w "%{http_code}" http://dev.test/         # want 401 (= up + SSO)
+tailscale status | findstr yehuda-wsl                         # want active/idle
+ssh -o ConnectTimeout=10 devssh@100.117.176.85 "docker ps --format '{{.Names}}' | wc -l"   # want ~24
+```
+
+If vmmemWSL count < 2 or the node is offline → [always-on.md](always-on.md) recovery:
+elevated `schtasks /run /TN "DevBox-WSL-Keepalive"`, or log in as devssh once.
+
+## Step 3 — Known lookalikes (do not chase these)
+
+- **401 or a sign-in page is SUCCESS** — SSO is in front of most services ([architecture.md](architecture.md)).
+- `ssh yr055@…` → "unknown user"; only `devssh@` exists on the dev box.
+- `Invoke-WebRequest` timing out on `*.dev.test` — .NET quirk; use `curl.exe`.
+- Browser NXDOMAIN with curl fine — Chrome DoH; it can't see `.test`.
+- A 200 from a weird hostname — `portal-fallback` answers everything; proves nothing.
+- SSH hangs to the dev box for a minute after long idle — hairpin port rotation; retry.
+- Checker says `TASK MISSING` / probes `000` on the old IP — run elevated; stale `.57` IP
+  ([runbook-post-reboot.md](runbook-post-reboot.md)).
+
+## The mindset (from three incidents)
+
+The box has survived every incident so far; the failing part was a client's tunnel, a
+client's DNS stack, or a stale assumption. **Prove which side is broken with layered
+pings before touching the box.** Diagnose from two vantage points (PC *and* phone) —
+if both fail identically, then believe it's the box.
+
+Incidents this runbook was distilled from:
+[2026-07-21](incidents/2026-07-21-wsl-idle-timeout.md) ·
+[2026-08-01](incidents/2026-08-01-ethernet-ndis.md) ·
+[2026-08-02](incidents/2026-08-02-thinkpad-tailscale.md)

--- a/docs/kb/runbook-post-reboot.md
+++ b/docs/kb/runbook-post-reboot.md
@@ -1,0 +1,45 @@
+# RUNBOOK — after the Windows host reboots
+
+The box is expected to come up **by itself, with nobody logged in as devssh** — proven on
+the 2026-08-01 cold boot ([always-on.md](always-on.md)). This runbook verifies it.
+
+## Fastest check
+
+From the phone (on tailnet): open **http://dev.test** → sign-in page or portal = PASS.
+
+## Proper check (from yr055 on the PC)
+
+Run **from an elevated terminal** (non-elevated cannot see the keepalive task and
+false-reports `TASK MISSING`):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File C:\Users\yr055\dev-box-postboot-check.ps1
+```
+
+Report lands in `C:\Users\yr055\dev-box-postboot-report.txt`. Healthy looks like:
+vmmemWSL = 2 · `localhost`/`dev.test` → 401 · grafana → 302 · `yehuda-wsl` active ·
+ForceDaemon true.
+
+### Known checker defects (as of 2026-08-02)
+
+1. **Hard-coded LAN IP `192.168.68.57` is stale** (now `.52`, DHCP — may change again).
+   Its `000` probe and the FAIL verdict logic keyed on it are wrong. Judge by the other
+   signals until the script is fixed to use the hostname/current IP.
+2. **`TASK MISSING` when run non-elevated** — access-denied misread as absence.
+
+## If it genuinely failed
+
+```powershell
+schtasks /run /TN "DevBox-WSL-Keepalive"     # elevated
+```
+
+- That brings it up → task fine, boot **trigger** didn't fire (small fix).
+- It doesn't → log in as devssh once (always works), then investigate the task.
+- **If devssh's password changed recently, that's the cause** — the stored task
+  credential broke silently. Re-save it.
+
+## Also affected by a reboot
+
+- Host LAN IP may change (DHCP) — anything hard-coding it lies ([topology.md](topology.md)).
+- WSL guest NAT IP rotates — irrelevant to normal access (Tailscale/names don't care).
+- First SSH to the dev box after boot may hang seconds while the tunnel path establishes.

--- a/docs/kb/topology.md
+++ b/docs/kb/topology.md
@@ -1,0 +1,63 @@
+# Topology — machines, users, addresses
+
+_Verified 2026-08-02. DHCP/NAT addresses rotate — trust names and tailnet IPs, not LAN IPs._
+
+## The one fact that explains everything
+
+**The "dev box" is not a separate machine.** It is a WSL2 Ubuntu distro on the Windows PC
+`Yehuda-HS`, registered under a **second Windows user `devssh`** — invisible to `wsl -l`
+from yr055, running in its own utility VM, with its own Tailscale node *inside* the distro.
+
+## Tailnet (tailnet suffix `tail7e7e3b.ts.net`, account YehudaBriskman@github)
+
+| Node | Tailscale IP | What it actually is | Key expiry |
+|---|---|---|---|
+| `yehuda-hs` | 100.93.197.10 | The Windows PC itself (host OS) | 2027-01-17 |
+| `yehuda-wsl` | **100.117.176.85** | **The dev box** — devssh's WSL distro on that same PC. Hostname override; internal hostname is also `Yehuda-HS` | 2027-01-12 |
+| `yehuda-thinkpad` | 100.108.35.26 | The Linux laptop | 2027-01-16 |
+| `iphone-14` | 100.101.204.32 | Phone (useful as an independent tailnet test client) | — |
+
+`dev.test` and `*.dev.test` all point at 100.117.176.85 — see [dns.md](dns.md).
+
+## The Windows PC (`Yehuda-HS`, Windows 11 Pro)
+
+- LAN: Realtek 2.5GbE, **DHCP — was `192.168.68.57` until 2026-08-01, now `192.168.68.52`**
+  (changed with the reboot after the [ethernet incident](incidents/2026-08-01-ethernet-ndis.md)).
+  Anything hard-coding a LAN IP will eventually lie — the postboot checker did.
+- Network is **double NAT**: TP-Link mesh `192.168.68.1` behind ISP router `192.168.1.x`.
+- Runs **two separate WSL2 utility VMs** (two `vmmemWSL` processes — the healthy count is 2):
+  - **devssh's VM** = the dev box. Ubuntu 24.04, systemd PID 1, docker + ~25 containers,
+    tailscaled with `RunSSH: true`. Starts 16s after boot via the keepalive task
+    ([always-on.md](always-on.md)).
+  - **yr055's VM** = `Ubuntu` + `docker-desktop` (Docker Desktop k8s, minikube, ollama, LXC).
+    Unrelated to the dev stack — auditing it finds nothing, by design.
+- WSL guest IPs live on the `WSL (Hyper-V firewall)` switch (`192.168.96.1/20` side) and
+  **rotate on every WSL restart** (devssh's was `.43` in July and again on 2026-08-02 — luck,
+  not stability).
+- The host also runs its own **Windows OpenSSH sshd on :22** (password auth) — distinct from
+  the dev box's port 22. See [access.md](access.md).
+
+## How the dev box reaches the internet / tailnet
+
+The WSL VM is NATed behind the Windows host, so `yehuda-wsl`'s tailnet endpoint is **the
+host's own LAN IP with a rotating UDP port** (a NAT hairpin, e.g. `192.168.68.52:51029`).
+Consequences:
+
+- When that NAT port rotates, peers keep sending to the stale port for a bit — SSH to the
+  dev box **hangs for seconds-to-minutes, then self-heals** once disco re-resolves. Seen
+  live 2026-08-02 17:55–18:06. Not a fault; retry before diagnosing.
+- After idle periods the first connection needs a fresh WireGuard handshake — same symptom,
+  same advice.
+- The wsl node also advertises useless Docker-bridge endpoints (172.17–21.x, 192.168.49.1),
+  which slows path discovery slightly.
+
+## The laptop (`yehuda-thinkpad`)
+
+- Linux, tailscale (had the 2026-08-02 [half-upgrade incident](incidents/2026-08-02-thinkpad-tailscale.md)).
+- LAN `192.168.68.59` when home (DHCP); roams to iPhone hotspot (172.20.10.x) outside.
+- **Its own sshd is NOT running** (confirmed 2026-08-02) — you cannot SSH *to* the laptop.
+
+## Related: see also
+
+[access.md](access.md) for how to reach each of these · [dns.md](dns.md) for names ·
+[always-on.md](always-on.md) for lifecycle · [architecture.md](architecture.md) for what's inside the box.


### PR DESCRIPTION
## What
- Add docs/kb: 13 cross-linked knowledge-base files for the whole system
- Topic files (topology, access, dns, always-on, architecture) + 2 runbooks + known-issues + lessons
- One incident file each for 2026-07-21, 2026-08-01, 2026-08-02

## Why
Three incidents in two weeks were diagnosed from memory and scattered notes on the
Windows host, none of it in git. Each outage so far was misattributed to the box at
first; the knowledge that resolved them (per-user WSL topology, split DNS, Tailscale SSH,
layered-ping diagnosis) had no durable home.

## How
Distilled from the July audit, the reboot note, and the three incident reports into
small single-topic files under docs/kb, linked to each other, with runbook-cant-reach.md
as the entry point for any future outage. Facts are date-stamped; volatile values (DHCP
IPs) are marked as rotating.

## Test plan
- [ ] docs/kb/README.md renders and all relative links resolve on GitHub
- [ ] runbook-cant-reach.md decision tree matches the 2026-08-02 diagnosis steps
- [ ] No secrets/credentials anywhere in docs/kb

Generated by [Claude-Bot] of [@YehudaBriskman]