### PR TITLE
docs: sync kb after postboot checker fixes

### DIFF
--- a/docs/kb/known-issues.md
+++ b/docs/kb/known-issues.md
@@ -6,7 +6,6 @@ _Status as of 2026-08-02. Things that look broken but aren't → bottom section.
 
 | Item | Detail | Impact |
 |---|---|---|
-| **Postboot checker hard-codes stale LAN IP** | `dev-box-postboot-check.ps1` probes `192.168.68.57`; host is now `.52` (DHCP). Verdict logic false-FAILs | Every post-reboot check cries wolf ([runbook-post-reboot.md](runbook-post-reboot.md)) |
 | **ThinkPad has no sshd running** | Confirmed 2026-08-02 (dev node got connection-refused at 13:19) | Can't SSH *to* the laptop; enable if wanted |
 | **WSLg crash-loop on the dev box** | weston `rdp-backend.so` segfaults ~every 2 min (170+ since boot). Harmless to services; spams dmesg | Fix: `[wsl2] guiApplications=false` in `C:\Users\devssh\.wslconfig`, restart the distro |
 | **Unattended tailscale upgrades on the laptop** | The 2026-08-02 incident came from a package upgrade without daemon restart | After any tailscale upgrade: restart tailscaled; heed the version-skew warning |
@@ -17,6 +16,13 @@ _Status as of 2026-08-02. Things that look broken but aren't → bottom section.
 | Grafana still `admin/admin`; some services rely on SSO only | Audit Phase 2.4 | Weak on-tailnet posture |
 | `zz-debug.conf` leaves dnsmasq `log-queries` on | Forever-growing query log | Minor disk/noise |
 | Host config partially outside git | dnsmasq/daemon.json/wsl.conf copies are in `host/` (PR #8), but the keepalive task + Windows-side state aren't scriptable-restorable | Rebuild requires this KB |
+
+## Fixed (kept for history)
+
+- **Postboot checker stale LAN IP + elevation false-FAIL** — fixed 2026-08-02:
+  `dev-box-postboot-check.ps1` now probes the stable tailnet IP `100.117.176.85`
+  instead of the hard-coded DHCP address, and reports "not elevated" instead of
+  `TASK MISSING` when it cannot read the keepalive task.
 
 ## Deliberate tradeoffs (don't "fix")
 

--- a/docs/kb/runbook-post-reboot.md
+++ b/docs/kb/runbook-post-reboot.md
@@ -20,12 +20,12 @@ Report lands in `C:\Users\yr055\dev-box-postboot-report.txt`. Healthy looks like
 vmmemWSL = 2 · `localhost`/`dev.test` → 401 · grafana → 302 · `yehuda-wsl` active ·
 ForceDaemon true.
 
-### Known checker defects (as of 2026-08-02)
+### Checker history
 
-1. **Hard-coded LAN IP `192.168.68.57` is stale** (now `.52`, DHCP — may change again).
-   Its `000` probe and the FAIL verdict logic keyed on it are wrong. Judge by the other
-   signals until the script is fixed to use the hostname/current IP.
-2. **`TASK MISSING` when run non-elevated** — access-denied misread as absence.
+Two defects were fixed 2026-08-02: it used to probe a hard-coded DHCP LAN IP
+(`192.168.68.57`, went stale → false FAIL) and reported `TASK MISSING` when run
+non-elevated. It now probes the stable tailnet IP `100.117.176.85` and warns
+about elevation instead. If it ever false-FAILs again, check those two first.
 
 ## If it genuinely failed
 


### PR DESCRIPTION
## What
- Move the postboot-checker defects from open issues to a fixed-with-history section
- Update runbook-post-reboot.md to describe the fixed checker behavior

## Why
The checker script on the Windows host was repaired (stable tailnet IP instead of a
stale hard-coded DHCP address; explicit non-elevated warning instead of a false
TASK MISSING). The KB must not keep telling readers to distrust a tool that now works.

## How
Documentation-only edits to two docs/kb files, mirrored from the maintained copy on
the Windows host.

## Test plan
- [ ] docs/kb/known-issues.md no longer lists the checker under open issues
- [ ] runbook-post-reboot.md describes the fixed behavior

Generated by [Claude-Bot] of [@YehudaBriskman]