### PR TITLE
docs: update all docs for pure ip model

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@ Security vulnerabilities do not belong in a pull request either — see SECURITY
 - [ ] `just doctor` still passes
 - [ ] Portal typechecks and builds if touched — `cd apps/portal-next/web && npx tsc -b --noEmit && npm run build`
 - [ ] Every compose file I changed still parses — `docker compose -f <file> config -q`
-- [ ] Nothing a browser reaches gained a published host port; it got a `*.dev.test` hostname through Traefik instead
+- [ ] New browser-reachable services follow the access model: a published port listed in `just urls` (current pure-IP model) **and** the dormant `*.dev.test` router labels for when names return
 - [ ] New or changed behaviour is reflected in the README, SECURITY.md or the relevant comment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,10 @@ Two things to read before you change anything:
 ## Running it locally
 
 **You need:** Linux (or WSL2), Docker Engine with the Compose plugin,
-[`just`](https://github.com/casey/just), and — for the `*.dev.test` names to
-resolve — a local resolver that is authoritative for `.test`. `host/dnsmasq/`
-holds the configuration used here. Node 24 is only needed if you are working on
+[`just`](https://github.com/casey/just). (*Only for the dormant name layer:*
+a local resolver authoritative for `.test` — `host/dnsmasq/` holds the
+configuration used here. Since 2026-08-08 access is by `IP:port` and no
+resolver is required; `just urls` prints the port table.) Node 24 is only needed if you are working on
 the portal front-end. `jq` and `tailscale` are optional; `just urls` degrades
 gracefully without them.
 
@@ -83,6 +84,11 @@ them will be sent back.
 
 ### Add a service with two Traefik labels and a name — never a published port
 
+> **Status 2026-08-08: the name layer is dormant** (no client resolves
+> `.test`), so today a browser-facing service **does** publish a host port and
+> gets listed in `just urls`. Still add the router labels below — they cost
+> nothing and light up again the moment the split-DNS route returns.
+
 Host ports are a flat namespace of 65,535 that every project collides in;
 everyone reaches for 3000, 8080, 5432. Names are infinite. Traefik owns `:80`
 and routes by `Host` header, so a new service publishes **no** host port:
@@ -100,9 +106,10 @@ networks: [devnet]
 ```
 
 `edge/compose.yml` is the only container that should ever publish `:80`.
-Legitimate exceptions to the no-ports rule are databases bound to `127.0.0.1`
-(see below) and a handful of pre-Traefik services that still carry a published
-port for backwards compatibility — do not add to that list.
+Databases stay bound to `127.0.0.1` (see below). While the name layer is
+dormant, published service ports are the access path rather than a legacy
+exception — pick a free port, document it in `just urls`, and keep the labels
+for the future.
 
 Naming nests: `<service>.dev.test` for a stack service, `<project>.dev.test` for
 a project, `<sub>.<project>.dev.test` for a project's own pieces. This is not
@@ -116,7 +123,10 @@ loads at all.
 
 ### If it has no login of its own, it gets the SSO middleware pair
 
-`sso-errors@file,sso@file`, in that order. See
+**(Parked while SSO is dormant — do not attach the pair today; give the service
+its own login using the `DEV_LOGIN_*` credential from `.env` instead, like
+kafka-ui/dozzle/prometheus do.)** When SSO returns: `sso-errors@file,sso@file`,
+in that order. See
 [SECURITY.md](SECURITY.md#1-every-dashboard-sits-behind-oauth2-proxy-sso) for why
 the order matters.
 
@@ -188,8 +198,8 @@ Useful checks:
 
 ```sh
 # data plane
-curl -s http://dev.test/-/api/traefik/http/routers | jq length
-curl -s http://dev.test/-/api/docker/containers/json | jq length
+curl -s http://<node-ip>/-/api/traefik/http/routers | jq length
+curl -s http://<node-ip>/-/api/docker/containers/json | jq length
 
 # the security gate — MUST NOT return a container body (404, or 401 from SSO)
 curl -s -o /dev/null -w '%{http_code}\n' \

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # dev-box
 
-**A self-hosted developer environment that you reach by name, not by port.** Docker
-Compose stacks for routing, SSO, observability, dev data services and management
+**A self-hosted developer environment on a private WireGuard tailnet.** Docker
+Compose stacks for routing, observability, dev data services and management
 UIs — fronted by a homepage that discovers what is running instead of listing it.
+
+> **Access model (since 2026-08-08): plain `http://<node-ip>:<port>`.** The
+> name-based layer this repo was built around (`*.dev.test` wildcard DNS + SSO)
+> is **dormant, not deleted**: `just urls` prints the live port table, and
+> [`docs/kb/dns.md`](docs/kb/dns.md) is the re-enable manual. Sections below that
+> describe names or SSO document that dormant design.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![docker compose](https://img.shields.io/badge/docker-compose-2496ED?logo=docker&logoColor=white)
 ![just](https://img.shields.io/badge/just-task%20runner-EF5A29)
-![Traefik](https://img.shields.io/badge/Traefik-v3.6-24A1C1?logo=traefikproxy&logoColor=white)
+![Traefik](https://img.shields.io/badge/Traefik-v3.7-24A1C1?logo=traefikproxy&logoColor=white)
 ![Grafana](https://img.shields.io/badge/Grafana-observability-F46800?logo=grafana&logoColor=white)
 ![React 19](https://img.shields.io/badge/React%2019-%2B%20Vite-61DAFB?logo=react&logoColor=000)
 ![WSL2](https://img.shields.io/badge/WSL2-Ubuntu%2024.04-E95420?logo=ubuntu&logoColor=white)
@@ -40,8 +46,9 @@ Not a production platform, and not a template to deploy anywhere public:
   WireGuard tailnet. On a LAN or the internet, it is not.
 - **Dev credentials.** `.env.example` ships `devpass` / `admin`. Redis has no
   password at all; that is why it binds loopback only.
-- **Single node, single user.** One GitHub account is allowed through SSO. There
-  is no HA, no TLS, no multi-tenancy, and backups sit on the disk they protect.
+- **Single node, single user.** Access control is tailnet membership plus one
+  shared dev login on the dashboards (the GitHub SSO is parked). There is no HA,
+  no TLS, no multi-tenancy, and backups sit on the disk they protect.
 - **A helper, not a dependency.** A project keeps its own Postgres so it stays
   self-contained. If Traefik is down, your project still runs — you just lose the
   pretty hostname.
@@ -51,6 +58,12 @@ Not a production platform, and not a template to deploy anywhere public:
 ## The two ideas worth stealing
 
 ### 1. Nothing publishes a port. Everything gets a name.
+
+> **Status: dormant since 2026-08-08.** The wildcard DNS that made these names
+> resolve was retired in favour of direct tailnet-IP access, so today services
+> *do* publish ports and the labels below route nothing until the split-DNS
+> route returns. The design stays documented because the collision problem it
+> solves is real, and re-enabling it is a single admin-console change.
 
 Host ports are a flat global namespace with no allocator, so every project reaches
 for 3000/8080/5432 and collides with whatever squatted there first — and the
@@ -100,7 +113,10 @@ unreachable from inside a container and the route 502s.)
 
 ### 2. The portal discovers what is running. It is never a hand-written list.
 
-`dev.test` is a React 19 + Vite app served as a static build. It renders by joining
+The portal — Traefik's catch-all on `:80`; `dev.test` when names are enabled —
+is a React 19 + Vite app served as a static build. Its service links navigate by
+published port on whichever host you opened it from, so they work identically
+via tailnet IP, MagicDNS name or localhost. It renders by joining
 **two read-only APIs**, both proxied under its own origin so there is zero CORS:
 
 | Path | Backend | Gives |
@@ -146,17 +162,18 @@ container and its dot goes red just as fast.
   with the Compose plugin. Traefik must be **≥ v3.6** — older builds hardcode
   Docker API v1.24 and silently load zero routes against a modern daemon.
 - [`just`](https://github.com/casey/just), plus `jq` and `curl` for `just doctor`.
-- A resolver that answers `*.test` — see [DNS](#dns-how-test-names-resolve).
-- A GitHub OAuth App for SSO, callback `http://auth.dev.test/oauth2/callback`.
+- *(only for the dormant name layer)* a resolver that answers `*.test` — see
+  [DNS](#dns-how-test-names-resolve) — and a GitHub OAuth App for the parked
+  SSO (callback `http://auth.dev.test/oauth2/callback`).
 
 ```sh
-cp .env.example .env      # then fill in OAUTH2_* and WIKI_DB_PASSWORD
+cp .env.example .env      # fill in DEV_LOGIN_* and WIKI_DB_PASSWORD (OAUTH2_* only for the parked SSO)
 just up                   # bring everything up, in dependency order
 just urls                 # print every address
 just doctor               # health-check the whole box
 ```
 
-Then open **http://dev.test**.
+Then open **`http://<this-node's-tailnet-IP>/`** — `just urls` prints every address.
 
 > **Always use `just`, never `docker compose` directly.** `just` loads the root
 > `.env` via `set dotenv-load`. `docker compose` looks for a `.env` beside the
@@ -169,16 +186,16 @@ Then open **http://dev.test**.
 
 | Path | What lives there |
 |---|---|
-| `edge/` | **Traefik** — the single front door on `:80`, the only container publishing a browser-facing port. Also exports Prometheus metrics on an internal entrypoint with no host port. |
+| `edge/` | **Traefik** — the front door on `:80`: serves the portal catch-all and the `/-/api/*` data plane; Host-name routing is dormant. Also exports Prometheus metrics on an internal entrypoint with no host port. |
 | `edge/dynamic/` | Watched file-provider routes for things the Docker provider cannot see: `auth.yml` (the SSO middleware chain), `portal-api.yml` (the portal's read-only data plane), `host-services.yml` and per-project files for host processes. |
-| `auth/` | **oauth2-proxy** — GitHub SSO, used by Traefik as a `forwardAuth` target. |
+| `auth/` | **oauth2-proxy** — GitHub SSO, **parked**; `edge/dynamic/auth.yml` carries the re-enable recipe. |
 | `monitoring/` | Prometheus, Grafana, Loki + Promtail, cAdvisor, node-exporter. `provisioning/` wires datasources, dashboards and email alert rules; `dashboards/` holds six provisioned dashboards; `rules/` is for Prometheus rules. |
 | `data/postgres/`, `data/redis/`, `data/kafka/` | Each datastore plus its Prometheus exporter. Kafka is single-node KRaft. All three bind **loopback only** and are never routed by name. |
 | `mgmt/` | Portainer and Dozzle. |
 | `apps/portal-next/` | The live portal at `dev.test` — React 19 + Vite + TypeScript, built by a multi-stage image and served static by nginx. Pages: Overview, Services, Ports, Routes, Topology (a lazy-loaded react-three-fiber 3D rack view). |
 | `apps/portal/` | The retired pure-HTML portal, kept as a one-line rollback — **and the owner of `portal-socket-proxy`**, which the live portal still depends on. Do not `compose down` this directory. |
 | `apps/docs/` | MkDocs Material rendering every markdown file on the box, kept in sync by an rsync sidecar. Read-only; edits to the source files show up within ~15s. |
-| `apps/wiki/` | Wiki.js — superseded by `apps/docs/`, kept until its content is migrated. |
+| `apps/wiki/` | Wiki.js — superseded by `apps/docs/`; currently stopped, kept until its content is migrated. |
 | `host/` | Copies of the host configuration git cannot see: dnsmasq, `daemon.json`, `wsl.conf`, the systemd units, and the Windows keepalive task. Required to rebuild the box. See [`host/README.md`](host/README.md). |
 | `scripts/` | `backup.sh` and `doctor.sh`. |
 | `justfile` | Every operation. Start here. |
@@ -186,6 +203,10 @@ Then open **http://dev.test**.
 ---
 
 ## Architecture
+
+_The diagram shows the **full design, including the dormant layer** (wildcard
+DNS names, SSO). Live traffic today goes browser → `http://<node-ip>:<port>`
+straight to each service, or `:80` for the portal._
 
 ```mermaid
 flowchart TB
@@ -230,6 +251,12 @@ Two Docker networks, deliberately:
 
 ### Single sign-on
 
+> **Parked since 2026-08-08** — the OAuth callback is pinned to a name that no
+> longer resolves. In its place every dashboard runs its own login with one
+> shared dev credential (`DEV_LOGIN_*` in `.env`): Grafana, Portainer, Dozzle,
+> Kafka-UI and Prometheus (basic auth, carried by its self-scrape and the
+> Grafana datasource too). What follows documents the dormant design.
+
 Services with no login of their own — Dozzle, Kafka-UI, Prometheus, the docs, the
 Traefik dashboard and the portal — sit behind GitHub SSO via oauth2-proxy as a
 Traefik `forwardAuth` target. The session cookie is scoped to `.dev.test`, so one
@@ -273,6 +300,11 @@ but nothing else has an ordering requirement.
 ---
 
 ## DNS: how `*.test` names resolve
+
+> **Dormant since 2026-08-08:** the tailnet split-DNS route was removed, so no
+> client resolves `.test` any more. dnsmasq itself still runs — it is the box's
+> own resolver — and everything below becomes true again the moment the route
+> is re-added (admin console → DNS → Nameservers → `test` → this node).
 
 A local dnsmasq is authoritative for `.test` and answers a wildcard at **any
 depth**, so a brand-new name at any level needs no DNS work at all — only a
@@ -358,15 +390,21 @@ Backups sit on the same disk they protect. Copying them off the box is not solve
   Windows' DNS configuration changes. `sudo chattr -i` to edit, `+i` when done.
 - **`systemctl reload dnsmasq` does not re-read the config.** SIGHUP re-reads
   `/etc/hosts` and clears the cache, nothing more. A config edit needs a restart.
-- **A name that 404s** → check `http://traefik.dev.test` first; it shows exactly
-  which routers are registered.
+- **A name that 404s** → the router table is served at
+  `http://<node-ip>/-/api/traefik/http/routers`; it shows exactly which routers
+  are registered. (`traefik.dev.test` works when names are enabled.)
+- **Tunnel pings pong but pages stall, or SSH hangs at key exchange** — the
+  large-packet blackhole. Restart tailscaled on the box; recipe in
+  [`docs/kb/incidents/2026-08-08-wsl-node-large-packet-blackhole.md`](docs/kb/incidents/2026-08-08-wsl-node-large-packet-blackhole.md).
 
 ---
 
 ## Deeper docs
 
-- **`http://docs.dev.test`** — MkDocs Material, rendering every markdown file on
-  the box, auto-synced from the source files.
+- **Docs on `:8085`** (`docs.dev.test` when names are enabled) — MkDocs
+  Material, rendering every markdown file on the box, auto-synced.
+- [`docs/kb/`](docs/kb/README.md) — the operational knowledge base: topology,
+  access paths, runbooks, incident files and the lessons they paid for.
 - **The compose files themselves.** Every non-obvious setting has a comment
   explaining what broke without it — `edge/compose.yml`, `auth/compose.yml` and
   `edge/dynamic/portal-api.yml` are the three worth reading in full.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,20 +16,24 @@ touching `edge/dynamic/portal-api.yml`, `apps/portal/compose.yml` or `auth/`.
 
 ## Threat model
 
-**What this is.** One developer's workstation. Every service listens inside
-Docker networks; exactly one container (Traefik) publishes port 80 on the host.
-Names under `*.dev.test` resolve through a local dnsmasq that is authoritative
-for `.test`, published to a **private Tailscale tailnet** by split DNS.
+**What this is.** One developer's workstation on a **private Tailscale
+tailnet**. Since 2026-08-08 services are reached at `tailnet-IP:port` (published
+host ports); Traefik on `:80` serves the portal and its data plane. The name
+layer (`*.dev.test` via dnsmasq + split DNS) and the SSO in front of it are
+**dormant** — the sections below that describe them document that dormant design.
 
 **Who can reach it.** Only devices on that tailnet. The tailnet is WireGuard, so
 the transport is encrypted even though every URL is plain `http://`. A device not
-joined to the tailnet gets `NXDOMAIN` and cannot route to the box at all.
-Nothing here is exposed to the LAN or to the internet.
+joined to the tailnet cannot route to the box at all; the Windows-host port
+mirrors bind `127.0.0.1` + the host's tailnet IP only, so nothing is exposed to
+the LAN or to the internet.
 
 **What is therefore in scope.**
 
 - Anything reachable from the tailnet without authenticating (a dashboard that
-  lost its SSO middleware, a router rule that matches more than it should).
+  lost its login — the shared `DEV_LOGIN_*` credential guards Grafana,
+  Portainer, Dozzle, Kafka-UI and Prometheus — or a router rule that matches
+  more than it should).
 - Anything that discloses a secret to a party who *has* authenticated — the
   container-`Env` leak described below is the canonical example.
 - Anything that converts read access into write access on the Docker socket,
@@ -88,6 +92,11 @@ Every rule here has a reason written next to it in the source. Changing one is a
 security change, and should be reviewed as one.
 
 ### 1. Every dashboard sits behind oauth2-proxy SSO
+
+> **Parked since 2026-08-08** — the OAuth callback is pinned to a dormant name.
+> Interim control: each dashboard's native login with the shared `DEV_LOGIN_*`
+> credential. Everything below documents the dormant design and its re-enable
+> constraints.
 
 `auth/compose.yml` runs [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy)
 pinned to an exact version, because it is the authentication boundary.

--- a/apps/portal-next/DESIGN_BRIEF.md
+++ b/apps/portal-next/DESIGN_BRIEF.md
@@ -61,8 +61,8 @@ Rebuild the Overview as a manager's mission-control, top to bottom:
 1. **Quick links strip (top-upper).** A prominent horizontal strip of the most-used
    web UIs, Docs + Grafana FIRST and visually primary, then Prometheus, Dozzle,
    Portainer, Traefik, Kafka UI (pull from `data.nodes` browsable UIs by
-   host/name; hardcode Docs=`http://docs.dev.test`, Grafana=`http://grafana.dev.test`
-   as guaranteed anchors). Each opens in a new tab. This is the first thing on the page.
+   host/name; Docs and Grafana are guaranteed anchors built with `hostUrl()` —
+   port-based links on the current hostname, since names are dormant). Each opens in a new tab. This is the first thing on the page.
 2. **Needs attention** — keep the existing behaviour (down/orphan via `needsAttention`);
    collapse to a slim "all clear" when empty.
 3. **Systems grid** — the centrepiece. `runningSystems(systemsOf(data.nodes))`,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,10 +9,17 @@ The whole design follows from one decision:
 > **Host ports are a flat global namespace with no allocator. Names are
 > unlimited. So nothing here gets a port — it gets a name.**
 
-Every service is reached at `<something>.dev.test`. Traefik owns `:80` and routes
-by `Host` header; a local dnsmasq answers `*.test` at any depth; Tailscale split
-DNS points `test` queries at this node. Adding a service is two Traefik labels
-and a hostname — no DNS entry, no port allocation, no restart of anything else.
+> **Status 2026-08-08: the name layer below is dormant.** The tailnet
+> split-DNS route was removed; live access is `http://<node-ip>:<port>` per the
+> table in `just urls`, with Traefik `:80` serving the portal catch-all. This
+> document keeps describing the full design — it all lights up again when the
+> route is re-added.
+
+Every service is reached at `<something>.dev.test` (when names are enabled).
+Traefik owns `:80` and routes by `Host` header; a local dnsmasq answers `*.test`
+at any depth; Tailscale split DNS points `test` queries at this node. Adding a
+service is two Traefik labels and a hostname — no DNS entry, no port allocation,
+no restart of anything else.
 
 **The stack is a helper, not a platform.** It provides what projects *don't*
 ship — routing, DNS, dashboards, log aggregation. It never provides what projects
@@ -92,7 +99,7 @@ The rule is that nothing browser-facing publishes a port. What exists today:
 | Container | Host bind | Status |
 |---|---|---|
 | `traefik` | `0.0.0.0:80` | **The front door.** The one intentional publish. |
-| `grafana` `prometheus` `dozzle` `kafka-ui` `portainer` `loki` `cadvisor` `node-exporter` | `0.0.0.0:3000` `9090` `8080` `8081` `9000` `3100` `8082` `9100` | Legacy — these predate the edge and kept their old ports. Fully redundant with their `.dev.test` names; removing them is a safe incremental cleanup. |
+| `grafana` `prometheus` `dozzle` `kafka-ui` `portainer` `loki` `cadvisor` `node-exporter` `docs` | `0.0.0.0:3000` `9090` `8080` `8081` `9000` `3100` `8082` `9100` `8085` | **The live access path while names are dormant** (2026-08-08) — no longer a legacy remnant. If the name layer returns as the primary path, retiring these becomes cleanup again. |
 | `postgres` `redis` `kafka` | `127.0.0.1:5432` `6379` `9092` | **Loopback only, and legitimate.** These speak no `Host` header, so they cannot be routed. Reached over an SSH tunnel, or by name over devnet from another container. |
 | `portal-next` `docs` `docs-sync` `oauth2-proxy` `portal-socket-proxy` `promtail` and every exporter | none | The correct pattern. |
 

--- a/host/README.md
+++ b/host/README.md
@@ -12,7 +12,7 @@ instead of vanishing. After editing a real file, copy it back here.
 
 | Copy | Real location | Why it exists |
 |---|---|---|
-| `dnsmasq/dev.conf` | `/etc/dnsmasq.d/dev.conf` | Wildcard `*.test` → this box's tailnet IP. Tailscale split DNS routes `test` here, which is what makes every `<name>.dev.test` resolve across the tailnet. |
+| `dnsmasq/dev.conf` | `/etc/dnsmasq.d/dev.conf` | Wildcard `*.test` → this box's tailnet IP. **Dormant since 2026-08-08** (the tailnet split-DNS route was removed); dnsmasq itself still runs as the box's own resolver. Re-add the route and every `<name>.dev.test` resolves again. |
 | `docker/daemon.json` | `/etc/docker/daemon.json` | Log rotation (10m × 3) and `metrics-addr` on :9323, which `monitoring/prometheus.yml` scrapes as its `docker-daemon` job. Without it that target is permanently down. |
 | `wsl/wsl.conf` | `/etc/wsl.conf` (in the distro) | `systemd=true` — the reason `docker.service` can be enabled and every stack comes up with the distro. Also `generateResolvConf=false`. |
 | `wsl/wslconfig` | `C:\Users\devssh\.wslconfig` | Memory, CPU and nested virtualisation for the WSL VM. |


### PR DESCRIPTION
## What
- README: pure-IP access model leads; name/DNS/SSO sections marked dormant with re-enable pointers
- CONTRIBUTING, SECURITY, ARCHITECTURE, host/README, PR template: same treatment (status notes, updated commands, port table as the live path)
- portal DESIGN_BRIEF quick-links note aligned with the hostUrl() port links

## Why
After PR #42 the box is reached by tailnet-IP:port, but every top-level document still taught
the name-based model as current — including a PR checklist that forbade publishing ports and a
threat model built around SSO. Docs that contradict the running system are worse than no docs.

## How
Dated status banners mark the dormant layer instead of deleting its documentation, since the
name layer is intended to return with a future DNS phase. Live-path facts (ports, logins,
verification commands) were rewritten in place. The claude-notes on the box got the same
treatment in their own repo.

## Test plan
- [ ] README renders correctly on GitHub (banners, tables, mermaid)
- [ ] just urls matches the ports named in the docs
- [ ] docs site (:8085) shows the updated pages after sync

Generated by [Claude-Bot] of [@YehudaBriskman]