### PR TITLE
One name per system, resolved once instead of at each render point

### DIFF
--- a/apps/portal-next/web/src/components/CommandPalette.tsx
+++ b/apps/portal-next/web/src/components/CommandPalette.tsx
@@ -56,7 +56,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
         id: `svc-${n.id}`,
         group: 'Services' as const,
         label: n.name,
-        sub: n.host || n.group,
+        sub: n.host || n.groupTitle,
         to: `/services/${encodeURIComponent(n.id)}`,
         status: n.status,
       }));

--- a/apps/portal-next/web/src/components/PortsTab.tsx
+++ b/apps/portal-next/web/src/components/PortsTab.tsx
@@ -51,7 +51,7 @@ export function PortsTab({
     const terms = [query, external].map((s) => s.toLowerCase().trim()).filter(Boolean);
     const matchText = (p: PortRow) =>
       terms.every((q) =>
-        `${p.hostPort} ${p.containerPort} ${p.container} ${p.group} ${p.image} ${p.scope}`
+        `${p.hostPort} ${p.containerPort} ${p.container} ${p.group} ${p.groupTitle} ${p.image} ${p.scope}`
           .toLowerCase()
           .includes(q),
       );
@@ -69,14 +69,19 @@ export function PortsTab({
     if (filter !== 'all') r = r.filter((p) => p.scope === filter);
     for (const q of terms)
       r = r.filter((p) =>
-        `${p.hostPort} ${p.containerPort} ${p.container} ${p.group} ${p.image} ${p.scope}`
+        `${p.hostPort} ${p.containerPort} ${p.container} ${p.group} ${p.groupTitle} ${p.image} ${p.scope}`
           .toLowerCase()
           .includes(q),
       );
     const { key, dir } = sort;
     r.sort((a, b) => {
-      const av = a[key] as string | number | undefined;
-      const bv = b[key] as string | number | undefined;
+      // Sort the Group column by what it DISPLAYS. Ordering by the hidden
+      // compose slug puts `auth` before `edge` while the screen reads
+      // "Identity · Keycloak" after "Edge · Traefik" - a sort that looks broken
+      // because the user cannot see the key it used.
+      const k = key === 'group' ? 'groupTitle' : key;
+      const av = a[k] as string | number | undefined;
+      const bv = b[k] as string | number | undefined;
       const cmp =
         typeof av === 'number' && typeof bv === 'number'
           ? av - bv
@@ -181,7 +186,7 @@ export function PortsTab({
                   </td>
                   <td className="mono">{r.containerPort}</td>
                   <td>{r.container}</td>
-                  {!compact && <td className="mono">{r.group}</td>}
+                  {!compact && <td>{r.groupTitle}</td>}
                   <td className="mono">{r.proto}</td>
                   <td>
                     <span className={`tag ${r.scope}`}>{r.scope === 'public' ? 'exposed' : 'loopback'}</span>

--- a/apps/portal-next/web/src/components/ServiceRow.tsx
+++ b/apps/portal-next/web/src/components/ServiceRow.tsx
@@ -34,7 +34,12 @@ export function ServiceRow({ node, showGroup = true }: { node: PortalNode; showG
           title={node.container?.statusText || unknownReason(node) || node.status}
         />
       </td>
-      {showGroup && <td className="mono">{node.group}</td>}
+      {/* The group's DISPLAY name, not its compose slug. This cell printed
+          `node.group` and so read `auth` while the Overview called the same
+          system `Identity · Keycloak` - the rename reached one surface out of
+          three. `groupTitle` is resolved once in discovery, so every surface
+          now agrees by construction rather than by remembering. */}
+      {showGroup && <td>{node.groupTitle}</td>}
       <td><span className={`tag ${kind.bad ? 'bad' : ''}`} title={kind.hint}>{kind.label}</span></td>
       <td className="mono">{node.ports.map((p) => p.hostPort).join(', ') || '-'}</td>
       <td className="mono svc-td-img">{node.container?.image || '-'}</td>

--- a/apps/portal-next/web/src/lib/discover.ts
+++ b/apps/portal-next/web/src/lib/discover.ts
@@ -295,6 +295,9 @@ export interface PortRow extends Port {
   container: string;
   image?: string;
   group: string;
+  /** The group's display name, same contract as PortalNode.groupTitle - the
+   *  Ports table is a third surface that was printing the raw slug. */
+  groupTitle: string;
   groupKind: string;
 }
 
@@ -442,6 +445,15 @@ export interface PortalNode {
   url: string | null;
   browsable: boolean;
   group: string;
+  /** The group's DISPLAY name - what a human should ever see. Resolved here, in
+   *  discovery, rather than at each render point, because the alternative is
+   *  what shipped: the Overview routed the group through a display-name lookup
+   *  and the Services and Access tables printed the raw compose slug, so one
+   *  system was called `Identity · Keycloak` on one page and `auth` on two
+   *  others. brand-core's "one word per concept" cannot hold if the word is
+   *  chosen per surface. Falls back to a title-cased slug, so it is never empty
+   *  and never needs a label to be correct. */
+  groupTitle: string;
   groupKind: string;
   parent: string | null;
   depth: number | null;
@@ -560,6 +572,16 @@ export function classify(container?: Container | null): Classification {
   }
   return { group: proj, groupKind: 'project' };
 }
+
+// Groups that are not systems and so cannot be named like one. `unmanaged` is
+// what classify() returns for a container with no compose labels - a `docker run`
+// nobody declared. It is not a system, it is *whatever did not match*, and
+// "Unmanaged" title-cased into a peer chip beside `Edge · Traefik` claims a
+// coherence it does not have. Named for what it is; systems.ts also sorts it last.
+export const RESIDUE_TITLES: Record<string, string> = {
+  unmanaged: 'Other containers',
+  host: 'Host processes',
+};
 
 const titleCase = (s: string): string =>
   String(s).replace(/[-_]+/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase());
@@ -968,6 +990,11 @@ function makeNode({
   const path = pick('path', '');
   const browsable = isBrowsable(host, container);
 
+  // Computed BEFORE the node literal because two fields need it: the slug the
+  // app keys everything by, and the name a human reads. Deriving the title at
+  // each render point instead is exactly the bug this replaces.
+  const group = pick('group', n.parent || (container ? cls.group : n.leaf || cls.group));
+
   const node: PortalNode = {
     id: route ? route.name : `container:${container?.Id?.slice(0, 12)}`,
     kind,
@@ -987,7 +1014,8 @@ function makeNode({
     // through to classify()'s 'host' sentinel - which filed Tals' own front-end
     // under a fabricated system, separate from api/auth/algo.tals.dev.test. Its
     // leaf IS its system name, so use that.
-    group: pick('group', n.parent || (container ? cls.group : n.leaf || cls.group)),
+    group,
+    groupTitle: names.get(group) || RESIDUE_TITLES[group] || titleCase(group),
     groupKind: pick('groupKind', n.parent ? 'project' : cls.groupKind),
     parent: n.parent,
     depth: n.depth,
@@ -1070,6 +1098,9 @@ export function portsOf(container?: Container | null): Port[] {
 // Every published port on the box, flattened - the collision map.
 export function allPorts(containers: Container[] = []): PortRow[] {
   const rows: PortRow[] = [];
+  // Same map merge() uses, so a port row and a service row can never disagree
+  // about what a system is called.
+  const names = projectNames(containers);
   for (const c of containers) {
     const cls = classify(c);
     for (const p of portsOf(c)) {
@@ -1078,6 +1109,7 @@ export function allPorts(containers: Container[] = []): PortRow[] {
         container: (c.Names?.[0] || '').replace(/^\//, ''),
         image: c.Image,
         group: cls.group,
+        groupTitle: names.get(cls.group) || RESIDUE_TITLES[cls.group] || titleCase(cls.group),
         groupKind: cls.groupKind,
       });
     }

--- a/apps/portal-next/web/src/lib/panels.ts
+++ b/apps/portal-next/web/src/lib/panels.ts
@@ -21,13 +21,16 @@ export interface Panel {
 export function panelize(nodes: PortalNode[], allNodes: PortalNode[] = nodes): Panel[] {
   const vis = nodes.filter((n) => !n.hidden);
 
-  // A project's display name comes from its own depth-1 node if labelled, so
-  // "cvops" can present as "CVOps" in breadcrumbs without a second label.
+  // A group's display name is read off the NODE. It used to be re-derived here
+  // from the labels - a third implementation of the same rule, after discover.ts
+  // and systems.ts - and three copies is how the Overview came to call a system
+  // `Identity · Keycloak` while two other pages called it `auth`.
+  //
+  // Built from `allNodes`, not `nodes`: the title has to survive a filter that
+  // excludes the one node carrying the label, which is the reason this function
+  // takes both lists in the first place.
   const nice = new Map<string, string>();
-  for (const n of allNodes) {
-    const L = n.container?.labels || {};
-    if (L['dev.portal.project']) nice.set(n.group, L['dev.portal.project']);
-  }
+  for (const n of allNodes) if (n.groupTitle) nice.set(n.group, n.groupTitle);
   const title = (g: string) =>
     nice.get(g) || g.replace(/[-_]/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase());
   const byOrder = (a: PortalNode, b: PortalNode) =>

--- a/apps/portal-next/web/src/lib/projects.ts
+++ b/apps/portal-next/web/src/lib/projects.ts
@@ -85,6 +85,10 @@ function nodeOf(project: CollectorProject, svc: CollectorService): PortalNode {
     url,
     browsable: url != null,
     group: project.key,
+    // A declared project brings its own display name, so it needs no lookup -
+    // which is the point of the field: every node carries the name a human
+    // should see, however that node came into existence.
+    groupTitle: project.name || project.key,
     groupKind: project.kind === 'stack' || project.kind === 'infra' ? project.kind : 'project',
     parent: null,
     depth: null,

--- a/apps/portal-next/web/src/lib/systems.ts
+++ b/apps/portal-next/web/src/lib/systems.ts
@@ -51,27 +51,21 @@ export interface System {
 
 const KIND_RANK: Record<SystemKind, number> = { project: 0, stack: 1, infra: 2 };
 
-// Groups that are not systems at all, and so cannot be named like one.
+// A system's display name now arrives ON THE NODE (`groupTitle`, resolved in
+// discover.ts) rather than being looked up again here. This function used to own
+// a second copy of that rule - label-or-title-case - and a third lived in
+// panels.ts, which is precisely how the Services and Access tables ended up
+// printing raw compose slugs while this page printed the pretty name.
 //
-// `unmanaged` is what classify() returns for a container with no compose labels
-// - a `docker run` that nobody declared. It is not a system, it is *whatever did
-// not match*, and "Unmanaged" title-cased into a peer chip beside Edge · Traefik
-// claims a coherence it does not have. Named for what it is, and sorted last.
-const RESIDUE: Record<string, string> = {
-  unmanaged: 'Other containers',
-  host: 'Host processes',
-};
-export const isResidue = (key: string) => key in RESIDUE;
+// The residue names (`unmanaged` -> "Other containers") moved with it. What
+// stays here is the SORT: residue belongs last, because it is not a system
+// competing for position, it is the remainder.
+import { RESIDUE_TITLES } from './discover';
 
-// A project's display name comes from its own labelled node if present, else a
-// title-cased group slug - same rule as panelize/discover, kept in one place.
-function niceTitle(group: string, nodes: PortalNode[]): string {
-  const labelled = nodes.find((n) => n.container?.labels?.['dev.portal.project']);
-  return (
-    labelled?.container?.labels?.['dev.portal.project'] ||
-    RESIDUE[group] ||
-    group.replace(/[-_]/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase())
-  );
+export const isResidue = (key: string) => key in RESIDUE_TITLES;
+
+function niceTitle(_group: string, nodes: PortalNode[]): string {
+  return nodes[0]?.groupTitle || _group;
 }
 
 // The system's kind = the kind of the MAJORITY of its nodes. They agree in

--- a/apps/portal-next/web/src/pages/Services.tsx
+++ b/apps/portal-next/web/src/pages/Services.tsx
@@ -51,7 +51,16 @@ export function Services() {
   };
 
   const projectOptions = useMemo(
-    () => [...new Set(data.nodes.filter((n) => !n.hidden).map((n) => n.group))].sort(),
+    // [slug, display name]. The VALUE stays the compose slug - it is the filter
+    // key, and `?project=` in the URL must keep working - but the LABEL reads
+    // like every other surface. A dropdown offering `auth` next to a table
+    // saying "Identity · Keycloak" is the same one-name-per-system failure in
+    // miniature.
+    () => {
+      const seen = new Map<string, string>();
+      for (const n of data.nodes) if (!n.hidden) seen.set(n.group, n.groupTitle || n.group);
+      return [...seen.entries()].sort((a, b) => a[1].localeCompare(b[1]));
+    },
     [data.nodes],
   );
 
@@ -62,7 +71,7 @@ export function Services() {
     const vis = data.nodes.filter((n) => !n.hidden);
     const needle = q.trim().toLowerCase();
     const mText = (n: PortalNode) =>
-      !needle || `${n.name} ${n.host ?? ''} ${n.group} ${n.container?.image ?? ''}`.toLowerCase().includes(needle);
+      !needle || `${n.name} ${n.host ?? ''} ${n.group} ${n.groupTitle} ${n.container?.image ?? ''}`.toLowerCase().includes(needle);
     const mProject = (n: PortalNode) => project === 'all' || n.group === project;
     const mStatus = (n: PortalNode) => statusFilter.size === 0 || statusFilter.has(n.status);
     const isHost = (n: PortalNode) => n.route?.provider === 'file';
@@ -161,7 +170,7 @@ export function Services() {
           <span>Project</span>
           <select value={project} onChange={(e) => setProject(e.target.value)}>
             <option value="all">All ({projectAll})</option>
-            {projectOptions.map((p) => <option key={p} value={p}>{p} ({projectCounts.get(p) ?? 0})</option>)}
+            {projectOptions.map(([slug, label]) => <option key={slug} value={slug}>{label} ({projectCounts.get(slug) ?? 0})</option>)}
           </select>
         </label>
         <label className="filter-select">


### PR DESCRIPTION
A renamed system was called two different things on two pages. The Overview said
`Identity · Keycloak`; the Services table, the Access ports table and the project
filter dropdown all said `auth`. `brand-core.md` asks for *"one word per concept"*,
and that cannot hold while each surface decides the word for itself.

## The cause was three copies of one rule

`label-or-title-case` was implemented in `systems.ts` (Overview cards), again in
`panels.ts` (breadcrumbs), and **not at all** in `ServiceRow` / `PortsTab`, which
simply printed the compose slug. So the `Role · Vendor` rename reached one surface
out of three — and nothing about that was visible in a diff.

## The fix

Resolve the display name where the node is **built**. `PortalNode` and `PortRow`
now carry `groupTitle` beside `group`, filled in `discover.ts` from the same
`projectNames()` map `defaultName()` already used. Every consumer reads it; none
re-derives it.

| Surface | Before | After |
|---|---|---|
| `systems.ts` | own copy of the rule | reads the node |
| `panels.ts` | third copy | deleted |
| `ServiceRow` | `{node.group}` → `auth` | `{node.groupTitle}` |
| `PortsTab` | `{r.group}` → `auth` | `{r.groupTitle}` |
| `Services` filter | `auth` | labels by name, still **filters by slug** so `?project=` links keep working |
| `CommandPalette` | slug subtitle | display name |

`ServiceRow` also loses `className="mono"` on that cell — a display name is prose;
monospace was styling chosen for a slug.

`RESIDUE_TITLES` moved to `discover.ts` too, so `unmanaged` renders as **"Other
containers"** everywhere rather than only on the Overview.

## Two things that had to move with it

Both would have turned this into a regression:

- **Search.** The ports and services filters matched the slug. Once a column shows
  a name, typing what you can see has to find it — so both haystacks now hold the
  slug *and* the title. Searching `auth` still works.
- **Sort.** The Group column sorted by the hidden slug, which orders `auth` before
  `edge` while the screen reads "Identity · Keycloak" after "Edge · Traefik" — a
  sort that looks broken because the key is invisible.

## Verification

Measured in the browser across all three surfaces — **zero raw slugs remain in any
Group column**:

```
Services  Group: CVOps · Shvil TV · Monorepo Inherited · Thales ·
                 Edge · Traefik · Identity · Keycloak · Monitoring · Grafana ·
                 Containers · Portainer · Database · Postgres · Bothy
Access    Ports: Edge · Traefik · Monitoring · Grafana · Database · Postgres ·
                 Containers · Portainer · Identity · Keycloak · Thales
```

`tsc -b --noEmit` clean · portal checks 48 pass / 0 fail · rebuilt and deployed.

This is the last of the naming work. The remaining item from that review is
separate: Bothy still has a card in its own inventory, whose status cell carries
no information by construction — you are reading the page through Bothy.