### PR TITLE
Control section, Settings, and a config service that splices instead of serialising

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ edge/dynamic/portal-prom.yml
 # from git. The portal treats an absent file as a supported configuration and
 # renders normally without it (see lib/api.ts).
 apps/portal-next/data/projects.json
+
+# Agent worktrees. Real git checkouts under the repo - never content of it.
+.claude/worktrees/

--- a/apps/bothy-config/.gitignore
+++ b/apps/bothy-config/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+# The patch log, bind-mounted from compose.yml. It is a record of what happened
+# on THIS box, not part of the box's description.
+audit/
+# Built by checks/run.sh when no interpreter on the host has ruamel.yaml. The
+# pin lives in requirements.txt; this is a cache of it.
+.venv/

--- a/apps/bothy-config/Dockerfile
+++ b/apps/bothy-config/Dockerfile
@@ -1,0 +1,39 @@
+# Alpine + python3 + one pinned dependency.
+#
+# There is a pip install step here and there is none in apps/portal-files -
+# that difference is the whole reason these are two services rather than one
+# endpoint. See requirements.txt.
+FROM python:3.13-alpine
+
+WORKDIR /app
+
+# Dependencies before source, so editing app.py does not re-resolve the pin.
+COPY requirements.txt ./
+# --no-cache-dir keeps the wheel cache out of the image; --only-binary=:all:
+# means a source distribution is a BUILD FAILURE rather than a silent compile
+# from tarball. This image has no compiler, so a sdist would fail anyway - it
+# fails here with a readable message instead of a page of gcc output.
+RUN pip install --no-cache-dir --only-binary=:all: -r requirements.txt
+
+COPY safepath.py yamlpatch.py app.py policy.toml ./
+
+# No git in this image, unlike portal-files. This service does not commit; a
+# patch is a file write and the repository's history is made with `git` in a
+# terminal. Installing it "in case" would put a binary that can rewrite history
+# in a container holding a writable mount on the stack repo.
+
+# Runs as a NON-ROOT user whose uid matches the host's devssh (1000), because the
+# root is bind-mounted from the host and the files it rewrites must stay owned by
+# the human who owns the repo. Running as root would leave root-owned files in
+# ~/stacks that then need sudo to edit by hand - the classic bind-mount
+# ownership trap.
+RUN adduser -D -u 1000 app
+USER app
+
+ENV PORT=8098
+EXPOSE 8098
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD python3 -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8098/healthz',timeout=2).status==200 else 1)"
+
+CMD ["python3", "-u", "app.py"]

--- a/apps/bothy-config/app.py
+++ b/apps/bothy-config/app.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""bothy-config - the typed-lens API behind Bothy's config forms.
+
+A form is a typed lens over a file. It is never a second store. Every
+configurable thing on this box is a file in git; if a form wrote to a database
+instead, the repository would stop describing the box, `git log` would stop being
+its history, and a `git pull` would silently revert somebody's change. Everything
+below follows from refusing that.
+
+── why this is a SEPARATE service from portal-files ────────────────────────
+
+`apps/portal-files/app.py` states at the top that it has no third-party
+dependencies, "because this container holds read-write bind mounts on two git
+repositories, and every dependency is something that can ship a vulnerability
+into that position". A YAML round-tripper is a third-party dependency.
+
+So the parser lives here, with its own smaller mount - one repository instead of
+four roots - and its own network. portal-files keeps its property; this service
+carries the dependency and pays for it with a narrower blast radius. See
+docs/plans/editing-model.md §2.
+
+── it authenticates NOBODY ─────────────────────────────────────────────────
+
+Authorisation happens at the edge: Traefik's forwardAuth asks oauth2-proxy
+`/oauth2/auth?allowed_groups=editor`, and a request that fails never reaches this
+process. Putting authz here as well would mean two places to get it right and two
+places to get it wrong.
+
+The consequence is the rule the socket-proxy taught and portal-files repeats:
+**reachability IS authorisation.** This publishes no host port and sits on
+`confignet`, which holds two containers - Traefik and this. If it is ever put on
+devnet, ~20 containers including third-party images get the ability to rewrite
+this box's compose files, and nothing will warn you.
+
+Identity headers are for ATTRIBUTION, not permission. X-Auth-Request-Email names
+the author in the audit line. If it were spoofable the worst case is a wrong name
+in a log, not unauthorised access, because the decision was already made
+upstream - and the edge strips client-supplied X-Auth-Request-* anyway.
+
+── what it inherits rather than reinvents ──────────────────────────────────
+
+Everything portal-files already proved, on purpose and by copy where importing
+was not possible:
+
+  resolve()     the path boundary, resolve-first-compare-after   safepath.py
+  baseMtime     the conflict check                               do_POST below
+  snapshot()    the undo net taken before the overwrite          safepath.py
+  audit()       one line per write, with who and what            below
+  the role gate the edge, not here            edge/dynamic/bothy-config.yml
+
+The one thing it does NOT inherit is the writer. portal-files takes a whole file
+of text from a human who can see it; this takes one value from a form. The
+difference is yamlpatch.py, and its header explains why a round-tripper was
+measured and rejected.
+
+── editing is not applying ─────────────────────────────────────────────────
+
+A patch here changes a FILE. It does not change a running container: a compose
+label is fixed at container-creation time, so `dev.portal.project` does not move
+on screen until the container is recreated. That is `operator` work and it is not
+this service's. The response says so - `applied: false` with a reason - so the UI
+can render config drift in the language the collector already uses for
+declared-versus-observed, rather than a spinner that lies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import safepath
+import yamlpatch
+
+PORT = int(os.environ.get("PORT", "8098"))
+AUDIT_PATH = os.environ.get("AUDIT_LOG", "/audit/patches.log")
+_AUDIT_LOCK = threading.Lock()
+
+# Whitespace at either end of a plain YAML scalar is stripped by the parser, so a
+# value ending in a space would read back short and yamlpatch would refuse the
+# write with "the value changed the document's structure" - which is true and
+# tells nobody anything. Caught here for the message, not for the guarantee.
+_EDGE_SPACE = re.compile(r"^\s|\s$")
+
+
+def audit(who: str, action: str, res, field: str, service: str,
+          old: str | None = None, new: str | None = None) -> None:
+    """Append-only record of every change this service makes.
+
+    One line, tab-separated, `tail`-able, no rotation logic to get wrong and no
+    format anything else has to parse.
+
+    It carries the OLD value as well as the new, which the file tier's log does
+    not, and that difference is the point of it. portal-files logs that a file
+    was written and how many bytes; the file itself is the record of what it
+    says, and a person can read the diff. A form write is one value inside a
+    file nobody looked at, so "what did this say before" has no other answer
+    short of digging the snapshot out of the trash.
+
+    A failure to LOG must never fail the write - losing the record of a save is
+    bad, refusing a legitimate save because the log is full is worse - so this
+    swallows its own errors and reports them to stderr.
+    """
+    # Every field is flattened to one line before it is written.
+    #
+    # The log is tab-separated, one record per line, so a newline in ANY field
+    # forges a record: a value containing
+    #   "\n<timestamp>\tsomeone@else\tPATCHED\t..."
+    # produces a syntactically perfect entry attributing a change to another
+    # user. The patched VALUE comes from a form and is the obvious vector;
+    # relpath is the same one, because newlines are legal in Linux filenames.
+    #
+    # The point of this log is that a change is always attributable; a record
+    # anyone can forge attributes nothing.
+    def flat(v: object) -> str:
+        return re.sub(r"[\r\n\t]+", " ", str(v)).strip()
+
+    line = (f"{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\t{flat(who)}\t"
+            f"{flat(action)}\t{flat(res.root_key)}/{flat(res.relpath)}\t"
+            f"{flat(service)}\t{flat(field)}")
+    if old is not None or new is not None:
+        line += f"\t{flat(old)!r} -> {flat(new)!r}"
+    sys.stderr.write(line + "\n")
+    try:
+        with _AUDIT_LOCK:
+            os.makedirs(os.path.dirname(AUDIT_PATH), exist_ok=True)
+            with open(AUDIT_PATH, "a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+    except OSError as e:
+        sys.stderr.write(f"AUDIT LOG UNWRITABLE ({e}) - the write itself was fine\n")
+
+
+def read_text(res) -> tuple[str, int]:
+    """The file's text and its mtime, through the same guarded open as everything.
+
+    safe_open rather than open(): O_NOFOLLOW closes the window between realpath()
+    and open() in which the final component could be swapped for a symlink, and
+    the size is checked on the same fd whose bytes we then read, so there is no
+    size TOCTOU.
+    """
+    fd, st = safepath.safe_open(res.abspath)
+    if st.st_size > safepath.MAX_BYTES:
+        os.close(fd)
+        raise safepath.PathRefused("file too large to patch")
+    with os.fdopen(fd, "rb") as fh:
+        raw = fh.read()
+    try:
+        return raw.decode("utf-8"), int(st.st_mtime)
+    except UnicodeDecodeError as e:
+        raise safepath.PathRefused("file is not valid UTF-8") from e
+
+
+def validate(field: str, value: object) -> str:
+    """Refuse a value the policy does not allow. Returns it unchanged.
+
+    Refuses rather than sanitising, on the same reasoning as resolve(): silently
+    trimming a hostile value into a legal one means an attack and a typo produce
+    the same quiet success.
+    """
+    cfg = safepath.FIELDS.get(field)
+    if cfg is None:
+        # The message names the allowlist rather than the field, so a caller
+        # guessing at field names learns what exists instead of learning which
+        # of their guesses is close.
+        raise safepath.PathRefused(
+            f"{field!r} is not a patchable field - the policy declares "
+            + ", ".join(sorted(safepath.FIELDS)))
+    if not isinstance(value, str):
+        raise safepath.PathRefused("value must be a string")
+    limit = min(int(cfg.get("max_length", safepath.MAX_VALUE_LENGTH)),
+                safepath.MAX_VALUE_LENGTH)
+    if len(value) > limit:
+        raise safepath.PathRefused(f"value is longer than {limit} characters")
+    if not value:
+        # An empty label is legal YAML and meaningless configuration: compose
+        # would keep the key with an empty value, and Bothy would render a card
+        # with no title. Deleting a field is a different act from changing it and
+        # it is not one this service offers.
+        raise safepath.PathRefused("value must not be empty")
+    for ch in ("\n", "\r", "\t", "\0"):
+        if ch in value:
+            raise safepath.PathRefused(
+                "value must not contain newlines, tabs or null bytes")
+    if _EDGE_SPACE.search(value):
+        raise safepath.PathRefused(
+            "value must not start or end with whitespace - YAML would strip it")
+
+    # ── the two sequences a PLAIN YAML scalar cannot carry ──────────────────
+    #
+    # yamlpatch is the guarantee: it re-parses its own output and refuses if the
+    # value does not read back exactly. These two checks exist because that
+    # refusal, on its own, says "the value changed the document's structure",
+    # which is true and tells a person nothing about what to type instead.
+    #
+    #   " #"   opens a COMMENT. `title=a # b` parses as the scalar `title=a`
+    #          with `b` as a comment, so the value silently reads back short.
+    #   ": "   opens a MAPPING. `- title=a: b` is not a string at all - it is a
+    #          one-key map, and the label disappears entirely.
+    #
+    # A trailing colon is the same case with the space supplied by the newline.
+    # A leading `#` is NOT refused: in the `key=value` label shape it is never
+    # preceded by whitespace, so it is an ordinary character.
+    #
+    # The obvious alternative is to QUOTE the value instead of refusing it, and
+    # it is rejected on purpose: quoting rewrites the whole label item rather
+    # than the value inside it, so the span the locator proved literal is no
+    # longer the span being written. That is a real feature and it needs its own
+    # locator, not a special case bolted onto this one.
+    if " #" in value:
+        raise safepath.PathRefused(
+            "value must not contain ' #' - YAML would read the rest as a comment")
+    if ": " in value or value.endswith(":"):
+        raise safepath.PathRefused(
+            "value must not contain ': ' or end with ':' - YAML would read it "
+            "as a key")
+    return value
+
+
+def fields_in(res) -> dict:
+    """What is patchable in this file, what it says now, and when it last changed.
+
+    The mtime is returned WITH the values, in one response, and that is not
+    incidental. A client that fetched the values and the mtime separately could
+    read a file, have it change, then read the newer mtime and send a patch that
+    passes the conflict check while carrying the older value. One read, one
+    stat, one answer.
+    """
+    text, mtime = read_text(res)
+    sites = yamlpatch.locate(text, safepath.FIELDS)
+    return {
+        "root": res.root_key,
+        "path": res.relpath,
+        "mtime": mtime,
+        "fields": [
+            {"field": s.field, "service": s.service, "value": s.value,
+             "line": s.line, "kind": s.kind,
+             "maxLength": min(
+                 int(safepath.FIELDS[s.field].get("max_length",
+                                                  safepath.MAX_VALUE_LENGTH)),
+                 safepath.MAX_VALUE_LENGTH)}
+            for s in sites
+        ],
+        # Named here rather than left for the client to know, so a UI can say
+        # "nothing on this page is a form field" without a hardcoded list.
+        "patchable": sorted(safepath.FIELDS),
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "bothy-config"
+
+    def _send(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _query(self) -> dict:
+        return {k: v[0] for k, v in parse_qs(urlparse(self.path).query).items()}
+
+    def log_message(self, fmt, *args):  # noqa: A003
+        sys.stderr.write("%s - %s\n" % (self.address_string(), fmt % args))
+
+    # ── read ────────────────────────────────────────────────────────────────
+    def do_GET(self) -> None:  # noqa: N802
+        route = urlparse(self.path).path
+        q = self._query()
+        try:
+            if route == "/healthz":
+                return self._send(200, {"ok": True,
+                                        "roots": sorted(safepath.ROOTS),
+                                        "fields": sorted(safepath.FIELDS)})
+
+            if route == "/config/fields":
+                res = safepath.resolve(q.get("root", ""), q.get("path", ""),
+                                       for_write=True)
+                # for_write on a READ, deliberately. This endpoint answers "what
+                # can a form change here", so a file the write path would refuse
+                # must not be listed as though it had editable fields - a form
+                # that renders and then 403s on submit is worse than one that
+                # never rendered.
+                return self._send(200, fields_in(res))
+
+            return self._send(404, {"error": "no such endpoint"})
+        except safepath.PathRefused as e:
+            return self._send(403, {"error": str(e)})
+        except yamlpatch.RewriteRefused as e:
+            return self._send(422, {"error": str(e)})
+        except FileNotFoundError:
+            return self._send(404, {"error": "no such file"})
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write(f"ERROR {route}: {type(e).__name__}: {e}\n")
+            return self._send(500, {"error": "internal error"})
+
+    # ── write ───────────────────────────────────────────────────────────────
+    def do_POST(self) -> None:  # noqa: N802
+        route = urlparse(self.path).path
+        if route != "/config/patch":
+            return self._send(404, {"error": "no such endpoint"})
+
+        # ── CSRF ────────────────────────────────────────────────────────────
+        #
+        # Same shape as portal-files' /write, and needed for the same reason: the
+        # oauth2-proxy session cookie is sent to every port on this host, so a
+        # page on the sandbox origin (:8100) is SAME-SITE with the portal and
+        # SameSite=lax does not block a POST from there to here.
+        #
+        # Requiring JSON is the load-bearing half. This handler calls json.loads
+        # on the body regardless of content type, so a text/plain POST - a
+        # CORS-"simple" request, which skips the preflight entirely - would
+        # otherwise be accepted. Demanding application/json forces a preflight
+        # cross-origin, and the preflight fails because this service sends no
+        # CORS headers at all.
+        ctype = (self.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+        if ctype != "application/json":
+            return self._send(415, {"error": "Content-Type must be application/json"})
+        site_hdr = self.headers.get("Sec-Fetch-Site")
+        if site_hdr and site_hdr not in ("same-origin", "none"):
+            return self._send(403, {
+                "error": f"cross-origin writes are refused (Sec-Fetch-Site: {site_hdr})"})
+
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+            if length <= 0 or length > 64_000:
+                # A patch body is a path, a field name and one form value. Sixty
+                # kilobytes is already absurd for that, and the ceiling is here
+                # rather than at MAX_BYTES because this endpoint has no reason to
+                # accept a file-sized body at all.
+                return self._send(413, {"error": "body missing or too large"})
+            body = json.loads(self.rfile.read(length))
+
+            res = safepath.resolve(body.get("root", ""), body.get("path", ""),
+                                   for_write=True)
+            field = body.get("field", "")
+            value = validate(field, body.get("value"))
+            want_service = body.get("service")
+
+            # Attribution only. Falls back rather than failing: a missing header
+            # means a misconfigured edge, and losing the author name is not a
+            # reason to refuse a legitimate edit.
+            who = (self.headers.get("X-Auth-Request-Email")
+                   or self.headers.get("X-Auth-Request-User") or "unknown")
+
+            text, current = read_text(res)
+
+            # ── THE CONFLICT CHECK ───────────────────────────────────────────
+            #
+            # Two edit paths on one file is the ORDINARY case here, not the
+            # exotic one: a form in one tab, Bothy Files in another, and `vim` on
+            # the box. The file tier already solved it, and the form path sends
+            # the same baseMtime and gets the same 409 rather than inventing a
+            # second policy.
+            #
+            # It is REQUIRED here, where portal-files makes it optional. That is
+            # a deliberate divergence. In Files a missing baseMtime means a
+            # script or curl, and the human sent the whole file so they at least
+            # saw what they were replacing. A form sends one value for a file it
+            # never showed anybody - so a patch with no baseMtime is a patch
+            # against a version nobody can name, and there is no version of that
+            # which is safe to accept quietly.
+            base_mtime = body.get("baseMtime")
+            if base_mtime is None:
+                return self._send(400, {
+                    "error": "baseMtime is required - GET /config/fields returns it"})
+            try:
+                base_mtime = int(base_mtime)
+            except (TypeError, ValueError):
+                return self._send(400, {"error": "baseMtime must be a number"})
+            if base_mtime != current:
+                return self._send(409, {
+                    "error": "the file changed on disk since the form was loaded",
+                    "path": res.relpath,
+                    "baseMtime": base_mtime, "currentMtime": current,
+                    # The CURRENT state of the field, so the UI can offer
+                    # keep/take/compare rather than making someone guess what
+                    # they would lose. The file tier returns both whole texts;
+                    # here the values are the whole of what a form knows.
+                    "yours": value,
+                    "theirs": [
+                        {"field": s.field, "service": s.service, "value": s.value}
+                        for s in yamlpatch.locate(text, safepath.FIELDS)
+                        if s.field == field
+                    ],
+                })
+
+            # ── which site ───────────────────────────────────────────────────
+            #
+            # A compose file may declare several services, and more than one can
+            # carry the same label. An ambiguous patch is REFUSED rather than
+            # applied to the first match: guessing which service the form meant
+            # is exactly the kind of quiet wrongness this whole design exists to
+            # avoid, and the caller already knows the answer.
+            sites = [s for s in yamlpatch.locate(text, safepath.FIELDS)
+                     if s.field == field
+                     and (want_service is None or s.service == want_service)]
+            if not sites:
+                return self._send(404, {
+                    "error": f"{field} is not declared in this file"
+                             + (f" on service {want_service!r}" if want_service else ""),
+                    "path": res.relpath})
+            if len(sites) > 1:
+                return self._send(409, {
+                    "error": f"{field} is declared on more than one service here - "
+                             f"name one with `service`",
+                    "services": sorted(s.service for s in sites)})
+            site = sites[0]
+
+            if site.value == value:
+                # A patch that changes nothing writes nothing. Not an
+                # optimisation: writing would move the mtime, which would 409
+                # every other tab holding a baseMtime that is still correct.
+                return self._send(200, {
+                    "ok": True, "path": res.relpath, "field": field,
+                    "service": site.service, "value": value,
+                    "mtime": current, "changed": False, "snapshot": False,
+                    "applied": False,
+                    "appliedNote": "nothing changed, so nothing to apply"})
+
+            # Raises RewriteRefused - never writes a file it cannot verify.
+            new_text = yamlpatch.splice(text, site, value)
+
+            # ── THE UNDO NET ─────────────────────────────────────────────────
+            #
+            # Taken BEFORE the rename, while the outgoing bytes are still
+            # reachable. After os.replace the old content has no name.
+            kept = safepath.snapshot(res.root_key, res.relpath, res.abspath,
+                                     new_text.encode())
+
+            # Write to a temp file in the same directory, then rename. rename is
+            # atomic within a filesystem, so a crash mid-write leaves the old
+            # file intact rather than a truncated one.
+            #
+            # A UNIQUE temp name per write: this is a threaded server, so two
+            # patches to one file could both open a fixed `<path>.tmp`,
+            # interleave their writes, and the first rename would move the
+            # SECOND's partial content into place. The mtime check does not help
+            # - both requests can legitimately hold the same baseMtime.
+            tmpfd, tmp = tempfile.mkstemp(
+                dir=os.path.dirname(res.abspath),
+                prefix=f".{os.path.basename(res.abspath)}.", suffix=".tmp")
+            try:
+                with os.fdopen(tmpfd, "w", encoding="utf-8", newline="") as fh:
+                    # newline="" so that a file with CRLF endings keeps them.
+                    # The default translates every "\n" to os.linesep on write,
+                    # which would rewrite every line ending in the file - the
+                    # exact class of invisible whole-file change this service
+                    # exists to not make.
+                    fh.write(new_text)
+                os.replace(tmp, res.abspath)
+            except BaseException:
+                if os.path.exists(tmp):
+                    os.unlink(tmp)
+                raise
+            mtime = int(os.stat(res.abspath).st_mtime)
+
+            audit(who, "PATCHED", res, field, site.service, site.value, value)
+            # A patch whose previous version was NOT kept is worth a line of its
+            # own. It is rare, and it is the moment the net was missing.
+            if kept is None:
+                audit(who, "NOSNAPSHOT", res, field, site.service)
+
+            return self._send(200, {
+                "ok": True, "path": res.relpath, "field": field,
+                "service": site.service, "value": value,
+                "previous": site.value, "mtime": mtime, "changed": True,
+                "author": who,
+                # Reported rather than assumed, so "there is an undo net" is
+                # never something the UI claims on the service's behalf.
+                "snapshot": bool(kept),
+                # ── EDITING IS NOT APPLYING ──────────────────────────────────
+                #
+                # Said in the response rather than left for the UI to know. A
+                # compose label is fixed at container-creation time: this box was
+                # already bitten by that when the `Role · Vendor` rename changed
+                # six labels and nothing on screen moved until every affected
+                # container was recreated. The file now says one thing and the
+                # running container another, which is config drift - the same
+                # shape as "declared but not running" - and it should render in
+                # that language rather than as a spinner that lies.
+                "applied": False,
+                "appliedNote": (
+                    "written to the file. A compose label is read at "
+                    "container-creation time, so this takes effect when the "
+                    "service is recreated - that is operator work, not this "
+                    "service's."),
+            })
+        except safepath.PathRefused as e:
+            return self._send(403, {"error": str(e)})
+        except yamlpatch.RewriteRefused as e:
+            # 422, not 400 and not 500. The request was well-formed and the
+            # caller is not at fault: the FILE is in a shape this service will
+            # not change. The message says so, and the answer is Bothy Files.
+            return self._send(422, {"error": str(e)})
+        except FileNotFoundError:
+            return self._send(404, {"error": "no such file"})
+        except json.JSONDecodeError:
+            return self._send(400, {"error": "body must be JSON"})
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write(f"ERROR /config/patch: {type(e).__name__}: {e}\n")
+            return self._send(500, {"error": "internal error"})
+
+
+def main() -> None:
+    sys.stderr.write(
+        f"bothy-config on :{PORT} - roots {sorted(safepath.ROOTS)}, "
+        f"fields {sorted(safepath.FIELDS)}\n")
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/bothy-config/checks/api.py
+++ b/apps/bothy-config/checks/api.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""The HTTP surface, over a throwaway copy of this repository's real files.
+
+Run: python3 checks/api.py
+
+Needs nothing running. It starts the REAL handler from app.py on a loopback port
+and drives it with urllib, so every assertion goes through the same request
+parsing, the same policy load, the same resolve() and the same write path a
+browser reaches - not through a function called directly with tidy arguments.
+The parent integrates and deploys; this must be runnable before either.
+
+It runs against a COPY of the repo's own compose files rather than a fixture,
+for the reason noop_bytes.py gives: a fixture is written by the same person who
+wrote the code and agrees with it by construction.
+
+It uses the SHIPPED policy.toml, with only the two paths rewritten - the root and
+the snapshot directory, both of which are container paths that do not exist on a
+host. Everything that matters (the field allowlist, the deny lists, the suffix
+list) is the real thing, so a widening in policy.toml shows up here.
+
+── what it asserts ─────────────────────────────────────────────────────────
+
+  fields          GET returns the current value and an mtime
+  patch           the happy path, and the file changes by exactly one line
+  UNKNOWN FIELD   a field not in the policy is refused             403
+  OUTSIDE ROOT    a path that escapes is refused                   403
+  STALE MTIME     a baseMtime that no longer matches               409
+  MISSING MTIME   a patch with no baseMtime at all                 400
+  AMBIGUOUS       the same field on two services, unqualified      409
+  SNAPSHOT        the outgoing bytes are kept before the overwrite
+  AUDIT           one line, naming who, the field, and old -> new
+  CLASS C         edge/dynamic is unreachable, read and write      403
+  NOT YAML        a .md file is not patchable                      403
+"""
+import http.client
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SVC = os.path.dirname(HERE)
+REPO = os.path.dirname(os.path.dirname(SVC))
+sys.path.insert(0, SVC)
+
+# ── a throwaway box ─────────────────────────────────────────────────────────
+TMP = tempfile.mkdtemp(prefix="bothy-config-api-")
+ROOT = os.path.join(TMP, "stacks")
+TRASH = os.path.join(TMP, "trash")
+AUDIT = os.path.join(TMP, "audit", "patches.log")
+os.makedirs(ROOT)
+os.makedirs(TRASH)
+
+# The real compose files, copied. Only the ones carrying a patchable label plus
+# one that must stay unreachable.
+for rel in ("edge/compose.yml", "auth/compose.yml", "monitoring/compose.yml",
+            "data/kafka/compose.yml", "edge/dynamic/portal-files.yml",
+            "README.md"):
+    src = os.path.join(REPO, rel)
+    if not os.path.exists(src):
+        continue
+    dst = os.path.join(ROOT, rel)
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    shutil.copy2(src, dst)
+
+# A file with the SAME field on two services, which the repo does not have and
+# which the ambiguity refusal exists for. Written by hand because it is the one
+# case no real file demonstrates.
+with open(os.path.join(ROOT, "twins.yml"), "w") as fh:
+    fh.write("services:\n"
+             "  alpha:\n"
+             "    image: nginx\n"
+             "    labels:\n"
+             "      - dev.portal.project=Alpha · Nginx\n"
+             "  beta:\n"
+             "    # a comment that must survive every patch below\n"
+             "    image: nginx\n"
+             "    labels:\n"
+             "      - dev.portal.project=Beta · Nginx\n")
+
+# The shipped policy, with only the container paths rewritten.
+POLICY_SRC = open(os.path.join(SVC, "policy.toml"), encoding="utf-8").read()
+for want, got in (('path = "/repos/stacks"', f'path = "{ROOT}"'),
+                  ('path = "/var/lib/bothy/config-trash"', f'path = "{TRASH}"')):
+    if want not in POLICY_SRC:
+        sys.exit(f"checks/api.py cannot find {want!r} in policy.toml - the check "
+                 f"rewrites those two paths and has gone out of step with it")
+    POLICY_SRC = POLICY_SRC.replace(want, got)
+POLICY = os.path.join(TMP, "policy.toml")
+open(POLICY, "w", encoding="utf-8").write(POLICY_SRC)
+
+os.environ["POLICY_FILE"] = POLICY
+os.environ["AUDIT_LOG"] = AUDIT
+os.environ["PORT"] = "0"
+
+import app  # noqa: E402
+from http.server import ThreadingHTTPServer  # noqa: E402
+
+srv = ThreadingHTTPServer(("127.0.0.1", 0), app.Handler)
+threading.Thread(target=srv.serve_forever, daemon=True).start()
+ADDR = srv.server_address
+
+bad = 0
+
+
+def say(ok: bool, label: str, detail: str = "") -> None:
+    global bad
+    if not ok:
+        bad += 1
+    print(f"{'PASS' if ok else 'FAIL'}  {label:<52} {detail}")
+
+
+def call(method: str, path: str, body: dict | None = None,
+         ctype: str = "application/json") -> tuple[int, dict]:
+    c = http.client.HTTPConnection(*ADDR, timeout=10)
+    headers = {"X-Auth-Request-Email": "devssh@example.test"}
+    payload = None
+    if body is not None:
+        payload = json.dumps(body).encode()
+        headers["Content-Type"] = ctype
+    c.request(method, path, payload, headers)
+    r = c.getresponse()
+    raw = r.read()
+    c.close()
+    try:
+        return r.status, json.loads(raw)
+    except json.JSONDecodeError:
+        return r.status, {"raw": raw[:200].decode(errors="replace")}
+
+
+def comment_lines(rel: str) -> int:
+    text = open(os.path.join(ROOT, rel), encoding="utf-8").read()
+    return sum(1 for ln in text.splitlines() if ln.lstrip().startswith("#"))
+
+
+print("── it starts, and says what it can do ──────────────────────────────")
+code, doc = call("GET", "/healthz")
+say(code == 200 and doc.get("fields") == ["dev.portal.project"],
+    "healthz names the one patchable field", f"{code} {doc}")
+
+print()
+print("── reading what is patchable ───────────────────────────────────────")
+code, doc = call("GET", "/config/fields?root=stacks&path=edge/compose.yml")
+say(code == 200, "GET /config/fields on a real compose file", str(code))
+fields = doc.get("fields", [])
+say(len(fields) == 1 and fields[0]["field"] == "dev.portal.project",
+    "it finds exactly the declared label", str(fields))
+say(fields and fields[0]["value"] == "Edge · Traefik",
+    "and reads its value, middle dot intact",
+    repr(fields[0]["value"]) if fields else "-")
+say(isinstance(doc.get("mtime"), int), "and returns the mtime to patch against",
+    str(doc.get("mtime")))
+EDGE_MTIME = doc.get("mtime")
+
+code, doc = call("GET", "/config/fields?root=stacks&path=README.md")
+say(code == 403, "a .md file is not patchable", f"{code} {doc.get('error')}")
+
+code, doc = call("GET", "/config/fields?root=stacks&path=edge/dynamic/portal-files.yml")
+say(code == 403, "edge/dynamic is unreachable even for READING",
+    f"{code} {doc.get('error')}")
+
+print()
+print("── the refusals ────────────────────────────────────────────────────")
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "edge/compose.yml",
+    "field": "image", "value": "nginx", "baseMtime": EDGE_MTIME})
+say(code == 403 and "not a patchable field" in doc.get("error", ""),
+    "a field NOT in the policy is refused", f"{code} {doc.get('error')}")
+
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "edge/compose.yml",
+    "field": "privileged", "value": "true", "baseMtime": EDGE_MTIME})
+say(code == 403, "a class C field is refused like any other",
+    f"{code} {doc.get('error')}")
+
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "../../../etc/passwd",
+    "field": "dev.portal.project", "value": "x", "baseMtime": 1})
+say(code == 403 and "escapes" in doc.get("error", ""),
+    "a path outside the roots is refused", f"{code} {doc.get('error')}")
+
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "edge/dynamic/portal-files.yml",
+    "field": "dev.portal.project", "value": "x", "baseMtime": 1})
+say(code == 403, "and so is anything under edge/dynamic",
+    f"{code} {doc.get('error')}")
+
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "edge/compose.yml",
+    "field": "dev.portal.project", "value": "Renamed · By A Form"})
+say(code == 400 and "baseMtime" in doc.get("error", ""),
+    "a patch with NO baseMtime is refused", f"{code} {doc.get('error')}")
+
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "edge/compose.yml",
+    "field": "dev.portal.project", "value": "Renamed · By A Form",
+    "baseMtime": EDGE_MTIME - 500})
+say(code == 409 and doc.get("currentMtime") == EDGE_MTIME,
+    "a STALE baseMtime gets a 409", f"{code} {doc.get('error')}")
+say(bool(doc.get("theirs")), "...carrying what the file says now, for the UI",
+    str(doc.get("theirs")))
+
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "edge/compose.yml",
+    "field": "dev.portal.project", "value": "a value with a: colon in it",
+    "baseMtime": EDGE_MTIME})
+say(code == 403 and "key" in doc.get("error", ""),
+    "a value YAML cannot carry is refused, not mangled",
+    f"{code} {doc.get('error')}")
+
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "edge/compose.yml",
+    "field": "dev.portal.project", "value": "x", "baseMtime": EDGE_MTIME},
+    ctype="text/plain")
+say(code == 415, "a non-JSON content type is refused (CSRF)", str(code))
+
+print()
+print("── the ambiguous case ──────────────────────────────────────────────")
+code, doc = call("GET", "/config/fields?root=stacks&path=twins.yml")
+TWIN_MTIME = doc.get("mtime")
+say(len(doc.get("fields", [])) == 2,
+    "two services, two sites, both reported", str(len(doc.get("fields", []))))
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "twins.yml",
+    "field": "dev.portal.project", "value": "Ambiguous", "baseMtime": TWIN_MTIME})
+say(code == 409 and doc.get("services") == ["alpha", "beta"],
+    "an unqualified patch is refused, not applied to the first",
+    f"{code} {doc.get('error')}")
+
+before = open(os.path.join(ROOT, "twins.yml"), encoding="utf-8").read()
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "twins.yml", "service": "beta",
+    "field": "dev.portal.project", "value": "Beta · Renamed",
+    "baseMtime": TWIN_MTIME})
+after = open(os.path.join(ROOT, "twins.yml"), encoding="utf-8").read()
+say(code == 200 and doc.get("service") == "beta",
+    "naming the service resolves it", f"{code} {doc.get('error', '')}")
+changed = [i for i, (a, b) in enumerate(zip(before.splitlines(),
+                                            after.splitlines())) if a != b]
+say(len(changed) == 1, "and changes exactly one line", str(changed))
+say("# a comment that must survive every patch below" in after,
+    "the comment between the two services survives")
+
+print()
+print("── the happy path, on a real file ──────────────────────────────────")
+before = open(os.path.join(ROOT, "edge/compose.yml"), encoding="utf-8").read()
+before_comments = comment_lines("edge/compose.yml")
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "edge/compose.yml",
+    "field": "dev.portal.project", "value": "Edge · Renamed By A Form",
+    "baseMtime": EDGE_MTIME})
+after = open(os.path.join(ROOT, "edge/compose.yml"), encoding="utf-8").read()
+say(code == 200 and doc.get("changed") is True, "the patch applies",
+    f"{code} {doc.get('error', '')}")
+say(doc.get("previous") == "Edge · Traefik",
+    "the response names the old value as well as the new",
+    repr(doc.get("previous")))
+say(doc.get("applied") is False and bool(doc.get("appliedNote")),
+    "and says the FILE changed but the container did not")
+say(doc.get("snapshot") is True, "the outgoing bytes were kept")
+changed = [i for i, (a, b) in enumerate(zip(before.splitlines(),
+                                            after.splitlines())) if a != b]
+say(len(changed) == 1, "exactly one line differs", str(changed))
+say(comment_lines("edge/compose.yml") == before_comments,
+    f"all {before_comments} comment lines are still there",
+    str(comment_lines("edge/compose.yml")))
+say(len(before.splitlines()) == len(after.splitlines()),
+    "the line count is unchanged")
+
+# The undo net actually holds the previous bytes, not just a file.
+kept = []
+for dirpath, _d, filenames in os.walk(TRASH):
+    kept += [os.path.join(dirpath, f) for f in filenames if f != ".last-sweep"]
+say(any(open(k, encoding="utf-8").read() == before for k in kept),
+    "and the snapshot is byte-identical to what was overwritten",
+    f"{len(kept)} snapshot(s)")
+
+# Patching again with the SAME value must not write, so other tabs holding the
+# current mtime do not get a spurious 409.
+code, doc = call("GET", "/config/fields?root=stacks&path=edge/compose.yml")
+m2 = doc["mtime"]
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "edge/compose.yml",
+    "field": "dev.portal.project", "value": "Edge · Renamed By A Form",
+    "baseMtime": m2})
+say(code == 200 and doc.get("changed") is False and doc.get("mtime") == m2,
+    "a patch that changes nothing writes nothing", f"{code} {doc}")
+
+print()
+print("── the audit line ──────────────────────────────────────────────────")
+log = open(AUDIT, encoding="utf-8").read().splitlines() if os.path.exists(AUDIT) else []
+hit = [ln for ln in log if "edge/compose.yml" in ln and "PATCHED" in ln]
+say(len(hit) == 1, "exactly one line for the one write", str(len(hit)))
+if hit:
+    parts = hit[0].split("\t")
+    say("devssh@example.test" in parts, "it names WHO, from X-Auth-Request-Email")
+    say("dev.portal.project" in parts, "and WHAT field")
+    say("Edge · Traefik" in hit[0] and "Edge · Renamed By A Form" in hit[0],
+        "and the old value -> the new one")
+
+# A newline in a value must never forge a second record. The value is refused
+# outright, which is the strongest version of that - assert the log is untouched.
+n_before = len(open(AUDIT, encoding="utf-8").read().splitlines())
+code, doc = call("POST", "/config/patch", {
+    "root": "stacks", "path": "edge/compose.yml",
+    "field": "dev.portal.project",
+    "value": "x\n2026-01-01T00:00:00Z\tvictim@example.test\tPATCHED\tstacks/x",
+    "baseMtime": m2})
+n_after = len(open(AUDIT, encoding="utf-8").read().splitlines())
+say(code == 403 and n_after == n_before,
+    "a value carrying a newline forges no audit record", f"{code}")
+
+srv.shutdown()
+shutil.rmtree(TMP, ignore_errors=True)
+print()
+print("PASS: the API behaves" if not bad else f"FAIL: {bad} assertion(s)")
+sys.exit(1 if bad else 0)

--- a/apps/bothy-config/checks/naive_dump_damage.py
+++ b/apps/bothy-config/checks/naive_dump_damage.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""The evidence for the design: what load-and-dump does to this repository.
+
+Run: python3 checks/naive_dump_damage.py
+
+yamlpatch.py refuses to re-serialise a document, and that refusal costs something
+real - it means this service can only change values that already exist, never add
+a key or reorder anything. A cost that size needs a measurement behind it rather
+than an opinion, and it needs one that stays true: `ruamel.yaml` is a dependency
+that gets upgraded, and "we tried that once and it was lossy" is not a thing
+anybody can check.
+
+So this runs the round-trip that yamlpatch does NOT do - with the SAME parser
+configuration, not a straw man with default settings - and reports the damage.
+
+── it fails when the damage reaches ZERO ───────────────────────────────────
+
+Which looks backwards, so it is worth stating plainly. A green run here means
+"the reasoning in yamlpatch.py's header still holds". A ruamel that round-trips
+this repository losslessly would be good news and would also mean the header now
+argues from a measurement that is no longer true - which is exactly the sort of
+stale comment this repo's whole style is against. Failing sends someone to
+re-read it and decide, rather than leaving a paragraph of confident prose that
+quietly stopped being right.
+
+It does NOT fail when the damage grows, and does not carry a baseline of which
+files are damaged. Nothing here depends on WHICH files a round-tripper would
+break, because nothing ever round-trips them; a baseline would be a file to keep
+in step with no property behind it.
+"""
+import difflib
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
+
+import yamlpatch  # noqa: E402
+
+from noop_bytes import yaml_files  # noqa: E402
+
+
+def comment_lines(text: str) -> int:
+    return sum(1 for ln in text.splitlines() if ln.lstrip().startswith("#"))
+
+
+def main() -> int:
+    damaged = 0
+    lost_comments = 0
+    lost_bytes = 0
+    worst = []
+
+    for path in yaml_files():
+        rel = os.path.relpath(path, REPO)
+        text = open(path, encoding="utf-8").read()
+        try:
+            out = yamlpatch.naive_dump(text)
+        except Exception as e:  # noqa: BLE001
+            print(f"      {rel}: round-trip raised {type(e).__name__}: {e}")
+            damaged += 1
+            continue
+        if out == text:
+            continue
+        damaged += 1
+        dc = comment_lines(text) - comment_lines(out)
+        db = len(text.encode()) - len(out.encode())
+        lost_comments += max(dc, 0)
+        lost_bytes += max(db, 0)
+        changed = sum(1 for ln in difflib.unified_diff(
+            text.splitlines(True), out.splitlines(True), n=0)
+            if ln.startswith(("+", "-")) and not ln.startswith(("+++", "---")))
+        worst.append((dc, db, changed, rel))
+
+    for dc, db, changed, rel in sorted(worst, reverse=True):
+        note = (f"{dc} comment lines destroyed" if dc
+                else "comments kept, but reformatted")
+        print(f"  {rel:<44} {changed:>4} lines rewritten, {db:>6} bytes lost"
+              f"  ({note})")
+
+    total = len(yaml_files())
+    print()
+    print(f"load-and-dump damages {damaged} of {total} YAML files: "
+          f"{lost_comments} comment lines and {lost_bytes} bytes destroyed")
+    if damaged == 0:
+        print("FAIL: the round-tripper is now lossless on this corpus.")
+        print("      That is good news and it makes yamlpatch.py's header stale.")
+        print("      Re-read it and decide whether the splice is still the right")
+        print("      design before deleting this check.")
+        return 1
+    print("PASS: the naive approach still destroys content, so yamlpatch.py's")
+    print("      refusal to re-serialise is still buying something.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/bothy-config/checks/noop_bytes.py
+++ b/apps/bothy-config/checks/noop_bytes.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""THE GATE. A patch that changes nothing must change no bytes.
+
+Run: python3 checks/noop_bytes.py
+
+This is the first check written and the one every other property depends on. If
+it does not pass across the whole repository, no field is safe to edit and the
+service should not ship - so it runs first in run.sh and it fails hard.
+
+── what it actually asserts, and why that is not the obvious thing ─────────
+
+The naive version of this test - "load it, dump it, diff it" - would be testing
+the round-tripper. This service does not have a round-tripper; it has a locator
+and a splice, and the failure mode that matters is a locator reporting the wrong
+SPAN. A span one character short leaves a stray quote; a span one character long
+eats the following character. Both produce a file that still parses, and neither
+shows up as an exception.
+
+So the assertion is: for every patchable value in every YAML file in the repo,
+splice the value back over itself and require the result to be byte-identical to
+the original. That exercises locate() and splice() together over real content,
+and a wrong span cannot survive it.
+
+The corpus is the repository, not a fixture. A fixture would be written by the
+same person who wrote the locator and would agree with it.
+
+── it also asserts that reading everything is harmless ─────────────────────
+
+Every YAML file under the root is opened and parsed, including the ones policy
+refuses to patch. A parse failure on one of them is reported rather than ignored:
+this service must be able to answer "what is patchable here" for any file the UI
+might ask about, and "it crashed" is not an answer.
+"""
+import difflib
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))  # checks -> svc -> apps -> repo
+
+import yamlpatch  # noqa: E402
+
+# The policy's field table is loaded via safepath, which needs its roots to
+# exist as container paths - they do not on the host. This check is about the
+# LOCATOR and the SPLICE, not about access control, so it brings its own field
+# table. Keep it in step with policy.toml by hand; checks/api.py exercises the
+# real one.
+FIELDS = {
+    "dev.portal.project": {"kind": "compose-label"},
+    "dev.portal.name": {"kind": "compose-label"},
+    "dev.portal.desc": {"kind": "compose-label"},
+}
+
+
+def yaml_files() -> list[str]:
+    out = []
+    for dirpath, dirnames, filenames in os.walk(REPO):
+        dirnames[:] = [d for d in dirnames
+                       if d not in (".git", "node_modules", ".venv", "dist",
+                                    "build", ".next", "__pycache__")]
+        for fn in filenames:
+            if fn.endswith((".yml", ".yaml")):
+                out.append(os.path.join(dirpath, fn))
+    return sorted(out)
+
+
+def main() -> int:
+    bad = 0
+    files = yaml_files()
+    composes = [f for f in files if os.path.basename(f).startswith("compose")]
+    sites_total = 0
+
+    for path in files:
+        rel = os.path.relpath(path, REPO)
+        raw = open(path, "rb").read()
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            print(f"FAIL  {rel}: not UTF-8")
+            bad += 1
+            continue
+
+        try:
+            sites = yamlpatch.locate(text, FIELDS)
+        except yamlpatch.RewriteRefused as e:
+            # A refusal is a legitimate answer for a file this service will not
+            # touch - but it must be a REFUSAL, with a message, not a traceback.
+            print(f"skip  {rel}: {e}")
+            continue
+        except Exception as e:  # noqa: BLE001
+            print(f"FAIL  {rel}: {type(e).__name__}: {e}")
+            bad += 1
+            continue
+
+        sites_total += len(sites)
+        for s in sites:
+            try:
+                out = yamlpatch.splice(text, s, s.value)
+            except yamlpatch.RewriteRefused as e:
+                print(f"FAIL  {rel}: splicing {s.field} back over itself was "
+                      f"refused: {e}")
+                bad += 1
+                continue
+            if out.encode("utf-8") != raw:
+                bad += 1
+                print(f"FAIL  {rel}: a no-op patch of {s.field} on "
+                      f"{s.service} changed the bytes")
+                d = difflib.unified_diff(text.splitlines(True),
+                                         out.splitlines(True),
+                                         "before", "after", n=1)
+                sys.stdout.write("".join(list(d)[:20]))
+
+    print()
+    print(f"{len(files)} YAML files, {len(composes)} of them compose files, "
+          f"{sites_total} patchable values")
+    if bad:
+        print(f"FAIL: {bad} problem(s). No field is safe to edit until this passes.")
+    else:
+        print("PASS: every no-op patch left the file byte-identical")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/bothy-config/checks/patch_one_line.py
+++ b/apps/bothy-config/checks/patch_one_line.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""A patch changes ONE line, and the comments survive it.
+
+Run: python3 checks/patch_one_line.py
+
+noop_bytes.py proves a patch that changes nothing changes nothing. This proves
+the other half: a patch that DOES change something changes exactly one thing.
+
+The corpus is every real compose file in the repository that declares a patchable
+label, so the assertions are made against files written by people rather than
+against a fixture written alongside the code.
+
+Four assertions per patch, and each catches something the others cannot:
+
+  the diff is exactly one line       a whole-file rewrite is the failure mode
+  the comment count is unchanged     754 comment lines are the thing at risk
+  every comment's TEXT is unchanged  a count survives "# a" becoming "# b"
+  the value reads back exactly       the splice landed where the locator said
+
+The third is the one worth spelling out. Counting comments would pass a
+round-tripper that kept every comment and re-indented all of them, or one that
+moved a trailing comment to its own line - both of which are whole-file diffs
+nobody would read. Comparing the text catches that; the count alone does not.
+"""
+import difflib
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
+
+import yamlpatch  # noqa: E402
+
+from noop_bytes import FIELDS, yaml_files  # noqa: E402
+
+# Values chosen to be awkward rather than convenient.
+#
+#   the middle dot   every real value on this box uses one (`Edge · Traefik`), so
+#                    a byte-offset bug shows up as mojibake or a broken span the
+#                    moment the value stops being pure ASCII;
+#   the long one     crosses the emitter's default 80-column wrap point, which is
+#                    what a re-serialising implementation would reflow;
+#   the brackets     YAML flow-sequence indicators, harmless inside a plain
+#                    scalar that does not START with one - which is exactly the
+#                    kind of thing an over-eager blocklist would refuse.
+EXPRESSIBLE = [
+    "Renamed · By A Form",
+    "Edge · Traefik (v3)",
+    "Database · Postgres [primary]",
+    "a considerably longer value than anything in this repository today, well "
+    "past the point at which an emitter would wrap it",
+]
+
+# Values a PLAIN YAML scalar cannot carry, which must be REFUSED rather than
+# written as something shorter. This half of the check is the more valuable one:
+# §8 of docs/plans/editing-model.md refuses "a form that silently drops what it
+# did not understand", and these are the two ways a value silently shrinks.
+#
+#   " #"   opens a comment, so `a # b` reads back as `a`
+#   ": "   opens a mapping, so the label stops being a string at all
+#
+# The failure being guarded against is not an exception - it is a 200 with a file
+# on disk saying something the person did not type.
+MUST_REFUSE = [
+    "a value with a # hash in it",
+    "a value with a: colon in it",
+    "a value ending in a colon:",
+]
+
+
+def comments(text: str) -> list[str]:
+    """Every comment LINE, stripped, in order.
+
+    Whole-line comments only. A trailing comment on a value line cannot be
+    compared this way - the line it sits on is the line a patch is allowed to
+    change - and comparing it would make a legitimate patch of a labelled value
+    with a trailing comment fail. Every one of the 754 lines this exists to
+    protect is a whole-line comment.
+    """
+    return [ln.strip() for ln in text.splitlines() if ln.lstrip().startswith("#")]
+
+
+def main() -> int:
+    bad = 0
+    checked = 0
+
+    for path in yaml_files():
+        rel = os.path.relpath(path, REPO)
+        text = open(path, encoding="utf-8").read()
+        try:
+            sites = yamlpatch.locate(text, FIELDS)
+        except yamlpatch.RewriteRefused:
+            continue
+        if not sites:
+            continue
+
+        before_comments = comments(text)
+        for site in sites:
+            # The refusals first, because a silent shrink is the worse failure.
+            for value in MUST_REFUSE:
+                checked += 1
+                label = f"{rel} {site.field} on {site.service} -> {value[:28]!r}"
+                try:
+                    out = yamlpatch.splice(text, site, value)
+                except yamlpatch.RewriteRefused:
+                    continue
+                back = [s for s in yamlpatch.locate(out, FIELDS)
+                        if s.service == site.service and s.field == site.field]
+                print(f"FAIL  {label}: written rather than refused, and reads "
+                      f"back as {[s.value for s in back]!r}")
+                bad += 1
+
+            for value in EXPRESSIBLE:
+                checked += 1
+                label = f"{rel} {site.field} on {site.service} -> {value[:28]!r}"
+                try:
+                    out = yamlpatch.splice(text, site, value)
+                except yamlpatch.RewriteRefused as e:
+                    print(f"FAIL  {label}: refused - {e}")
+                    bad += 1
+                    continue
+
+                d = [ln for ln in difflib.unified_diff(
+                    text.splitlines(True), out.splitlines(True), n=0)
+                    if ln.startswith(("+", "-")) and not ln.startswith(("+++", "---"))]
+                if len(d) != 2:                      # one removal, one addition
+                    print(f"FAIL  {label}: the diff is {len(d) // 2} lines, not 1")
+                    bad += 1
+                    continue
+
+                after_comments = comments(out)
+                if after_comments != before_comments:
+                    lost = len(before_comments) - len(after_comments)
+                    print(f"FAIL  {label}: comments changed "
+                          f"({len(before_comments)} -> {len(after_comments)}, "
+                          f"{lost} lost)")
+                    bad += 1
+                    continue
+
+                back = [s for s in yamlpatch.locate(out, FIELDS)
+                        if s.service == site.service and s.field == site.field]
+                if len(back) != 1 or back[0].value != value:
+                    print(f"FAIL  {label}: reads back as "
+                          f"{[s.value for s in back]!r}")
+                    bad += 1
+                    continue
+
+    print()
+    print(f"{checked} patches across the repository's real compose files")
+    if bad:
+        print(f"FAIL: {bad} of them changed more than the one value")
+        return 1
+    print("PASS: every patch changed exactly one line and left every comment "
+          "byte-identical")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/bothy-config/checks/run.sh
+++ b/apps/bothy-config/checks/run.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Checks for the config tier.
+#
+# EVERY ONE OF THESE RUNS WITH THE STACK DOWN. Nothing here needs docker, a
+# network, a credential or a running edge - the parent integrates and deploys,
+# and a check that cannot run before that is a check nobody runs first. The one
+# thing they need is the YAML parser this service is built on, which is the whole
+# point of the tier.
+#
+# Four layers, deliberately, because each catches what the others cannot:
+#
+#   noop_bytes.py         THE GATE. A patch that changes nothing changes no
+#                         bytes, for every patchable value in every YAML file in
+#                         the repository. If this fails, no field is safe to edit
+#                         and nothing below it means anything - so it runs first
+#                         and everything after it is skipped.
+#   naive_dump_damage.py  The measurement behind the design: what load-and-dump
+#                         would have done to these same files. It is what keeps
+#                         yamlpatch.py's header from becoming a claim nobody
+#                         checks after a dependency bump.
+#   patch_one_line.py     A patch that DOES change something changes exactly one
+#                         line, and every comment survives byte-identical.
+#   test_safepath.py      The path boundary as a pure unit, with real planted
+#                         symlinks. This service's safepath.py is a COPY of
+#                         portal-files'; this is what notices when they drift.
+#   api.py                The whole thing through HTTP, against the SHIPPED
+#                         policy and a throwaway copy of the repo's real files:
+#                         refusals, the 409, the snapshot, the audit line.
+#
+# The unit tests alone would pass with the API wide open; api.py alone would pass
+# with the splice replaced by a round-tripper that quietly reformats. All of them
+# have to run.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE/.."
+
+# ── finding a python that can parse YAML ────────────────────────────────────
+#
+# The system python3 does not have ruamel and should not: this is a container's
+# dependency, not the box's. Rather than fail with an ImportError, look for an
+# interpreter that has it and make one if `uv` is available - which it is, since
+# it is this box's declared Python tool.
+#
+# Never `pip install --user` into the system interpreter. That is how a check
+# ends up depending on state nobody declared, and it is exactly the thing the
+# pinned requirements.txt exists to avoid.
+have_yaml() { "$1" -c 'import ruamel.yaml' >/dev/null 2>&1; }
+
+PY=""
+for candidate in "${PYTHON:-}" "$HERE/../.venv/bin/python" python3; do
+  [ -n "$candidate" ] && command -v "$candidate" >/dev/null 2>&1 || continue
+  if have_yaml "$candidate"; then PY="$candidate"; break; fi
+done
+
+if [ -z "$PY" ]; then
+  if command -v uv >/dev/null 2>&1; then
+    echo "── no interpreter here has ruamel.yaml; building ./.venv with uv ──"
+    uv venv "$HERE/../.venv" >/dev/null 2>&1 || exit 1
+    uv pip install --quiet --python "$HERE/../.venv/bin/python" \
+      -r "$HERE/../requirements.txt" || exit 1
+    PY="$HERE/../.venv/bin/python"
+  else
+    echo "FAIL: these checks need ruamel.yaml and no interpreter here has it."
+    echo "      uv venv apps/bothy-config/.venv"
+    echo "      uv pip install --python apps/bothy-config/.venv/bin/python \\"
+    echo "          -r apps/bothy-config/requirements.txt"
+    echo "      ...or set PYTHON=/path/to/one that already does."
+    exit 1
+  fi
+fi
+echo "python: $PY  ($("$PY" -c 'import ruamel.yaml as r; print("ruamel.yaml", ".".join(map(str, r.version_info)))'))"
+
+fail=0
+
+echo
+echo "── THE GATE: a no-op patch must not change a byte ──────────────"
+if ! "$PY" checks/noop_bytes.py; then
+  echo
+  echo "STOPPING. Every check below assumes the writer is byte-clean, so running"
+  echo "them now would report passes that mean nothing."
+  exit 1
+fi
+
+echo
+echo "── the measurement behind refusing to re-serialise ─────────────"
+"$PY" checks/naive_dump_damage.py || fail=1
+
+echo
+echo "── a real patch changes ONE line, and no comment ───────────────"
+"$PY" checks/patch_one_line.py || fail=1
+
+echo
+echo "── path safety (unit, with real symlinks) ──────────────────────"
+"$PY" checks/test_safepath.py || fail=1
+
+echo
+echo "── the API: refusals, the 409, the snapshot, the audit line ────"
+"$PY" checks/api.py || fail=1
+
+echo
+if [ "$fail" = 0 ]; then
+  echo "all checks passed"
+else
+  echo "FAILURES above"
+fi
+exit $fail

--- a/apps/bothy-config/checks/test_safepath.py
+++ b/apps/bothy-config/checks/test_safepath.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Truth table for the config tier's path boundary.
+
+Run: python3 checks/test_safepath.py
+
+safepath.py here is a COPY of apps/portal-files/safepath.py, and its header says
+so. A copy's real risk is drift: someone closes a hole in the original and not in
+this one, and nothing anywhere notices. This file is the thing that notices - it
+runs the same class of cases portal-files' own truth table runs, so a case added
+there and not here is a case that fails here.
+
+Every case is an attack that must be REFUSED, or a legitimate patch that must be
+ALLOWED. The symlink cases matter most, because they are the ones a
+string-inspecting implementation passes cleanly. They are built on a REAL
+filesystem with REAL symlinks rather than mocked, since mocking the thing under
+test would prove only that the mock behaves as written.
+"""
+import os
+import shutil
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+
+# The policy is loaded at import and validates that every root is a real
+# directory - so importing safepath on the HOST, where /repos/stacks does not
+# exist, fails by design. That is the fail-closed behaviour working; it just
+# means this file has to bring its own policy.
+#
+# Which it should anyway. A unit test of the boundary that depends on the
+# PRODUCTION policy tests two things at once and fails for the wrong reason when
+# somebody edits a root.
+_BOOT = tempfile.mkdtemp(prefix="bothy-config-boot-")
+_POLICY = os.path.join(_BOOT, "policy.toml")
+with open(_POLICY, "w") as _f:
+    _f.write(
+        f'[roots.stacks]\npath = "{_BOOT}"\nwritable = true\n'
+        f'[roots.readonly]\npath = "{_BOOT}"\n'
+        f'[patch]\nsuffixes = [".yml", ".yaml"]\n'
+        f'deny_prefixes = ["edge/dynamic/"]\n'
+        f'deny_relpaths = ["monitoring/prometheus-web.yml"]\n'
+        f'[fields]\n"dev.portal.project" = {{ kind = "compose-label" }}\n'
+        f'[deny]\n'
+        f'components = [".git", ".ssh", ".gnupg", "node_modules", ".venv",'
+        f' "venv", "__pycache__", ".mypy_cache", ".pytest_cache", "dist",'
+        f' "build", ".next", ".turbo", ".cache", "target"]\n'
+        f'file_patterns = [".env", ".env.*", "*.env", "*.pem", "*.key",'
+        f' "*.p12", "*.pfx", "*.jks", "*.keystore", "*.kdbx", "*.gpg", "*.asc",'
+        f' ".netrc", ".pgpass", ".htpasswd", ".git-credentials", "credentials",'
+        f' "credentials.*", "*secret*", "*password*", "realm-*.json",'
+        f' "*-realm.json", "realm.json", "dozzle-users.yml"]\n'
+        f'[snapshots]\npath = "{_BOOT}"\n')
+os.environ["POLICY_FILE"] = _POLICY
+
+import safepath  # noqa: E402
+
+bad = 0
+
+
+def check(label, fn, *, expect_refused):
+    global bad
+    try:
+        fn()
+        ok = not expect_refused
+        detail = "allowed"
+    except safepath.PathRefused as e:
+        ok = expect_refused
+        detail = f"refused ({e})"
+    except Exception as e:  # noqa: BLE001
+        ok = False
+        detail = f"UNEXPECTED {type(e).__name__}: {e}"
+    if not ok:
+        bad += 1
+    want = "refuse" if expect_refused else "allow"
+    print(f"{'PASS' if ok else 'FAIL'}  {label:<50} want={want:<7} {detail}")
+
+
+tmp = tempfile.mkdtemp(prefix="bothy-config-")
+root = os.path.join(tmp, "stacks")
+outside = os.path.join(tmp, "outside")
+for d in (root, outside,
+          os.path.join(root, "edge", "dynamic"),
+          os.path.join(root, "monitoring"),
+          os.path.join(root, ".git")):
+    os.makedirs(d, exist_ok=True)
+
+open(os.path.join(root, "compose.yml"), "w").write("services: {}\n")
+open(os.path.join(root, "edge", "dynamic", "portal-files.yml"), "w").write("http: {}\n")
+open(os.path.join(root, "monitoring", "prometheus-web.yml"), "w").write("basic_auth_users: {}\n")
+open(os.path.join(root, ".git", "config.yml"), "w").write("x: 1\n")
+open(os.path.join(root, "notes.md"), "w").write("# not yaml\n")
+open(os.path.join(root, "db-password.yml"), "w").write("x: 1\n")
+open(os.path.join(outside, "compose.yml"), "w").write("services: {}\n")
+
+# REAL symlinks, because the whole point is that a string check cannot see them.
+os.symlink(outside, os.path.join(root, "link-out"))
+os.symlink(os.path.join(outside, "compose.yml"),
+           os.path.join(root, "innocent.yml"))
+os.symlink(os.path.join(root, "edge", "dynamic", "portal-files.yml"),
+           os.path.join(root, "shortcut.yml"))
+
+safepath.ROOTS["stacks"] = root
+safepath.ROOTS["readonly"] = root
+safepath.WRITABLE_ROOTS = frozenset({"stacks"})
+
+W = dict(for_write=True)
+
+print("── the ordinary case ──────────────────────────────────────────────")
+check("a compose file in the root",
+      lambda: safepath.resolve("stacks", "compose.yml", **W), expect_refused=False)
+check("a nested compose file",
+      lambda: safepath.resolve("stacks", "./compose.yml", **W), expect_refused=False)
+
+print()
+print("── climbing out ───────────────────────────────────────────────────")
+check("dot-dot to the parent",
+      lambda: safepath.resolve("stacks", "../outside/compose.yml", **W),
+      expect_refused=True)
+check("dot-dot after a legitimate prefix",
+      lambda: safepath.resolve("stacks", "edge/../../outside/compose.yml", **W),
+      expect_refused=True)
+check("an absolute path",
+      lambda: safepath.resolve("stacks", "/etc/passwd", **W), expect_refused=True)
+check("an absolute path to a real yaml",
+      lambda: safepath.resolve("stacks", os.path.join(outside, "compose.yml"), **W),
+      expect_refused=True)
+check("a null byte",
+      lambda: safepath.resolve("stacks", "compose.yml\x00.md", **W),
+      expect_refused=True)
+check("an empty path",
+      lambda: safepath.resolve("stacks", "", **W), expect_refused=True)
+check("an unknown root",
+      lambda: safepath.resolve("nowhere", "compose.yml", **W), expect_refused=True)
+
+print()
+print("── symlinks: refused for where they POINT, not what they are called ")
+check("a symlinked DIRECTORY out of the root",
+      lambda: safepath.resolve("stacks", "link-out/compose.yml", **W),
+      expect_refused=True)
+check("a symlinked FILE out of the root",
+      lambda: safepath.resolve("stacks", "innocent.yml", **W), expect_refused=True)
+check("a symlink INTO a denied directory",
+      lambda: safepath.resolve("stacks", "shortcut.yml", **W), expect_refused=True)
+check("...and reading through it is refused too",
+      lambda: safepath.resolve("stacks", "shortcut.yml"), expect_refused=True)
+
+print()
+print("── policy: what may be patched at all ─────────────────────────────")
+check("a markdown file",
+      lambda: safepath.resolve("stacks", "notes.md", **W), expect_refused=True)
+check("anything under edge/dynamic",
+      lambda: safepath.resolve("stacks", "edge/dynamic/portal-files.yml", **W),
+      expect_refused=True)
+check("a file denied by exact path",
+      lambda: safepath.resolve("stacks", "monitoring/prometheus-web.yml", **W),
+      expect_refused=True)
+check("a filename matching the secret patterns",
+      lambda: safepath.resolve("stacks", "db-password.yml", **W), expect_refused=True)
+check("anything inside .git",
+      lambda: safepath.resolve("stacks", ".git/config.yml", **W), expect_refused=True)
+check("a read-only root",
+      lambda: safepath.resolve("readonly", "compose.yml", **W), expect_refused=True)
+check("...which is still READABLE",
+      lambda: safepath.resolve("readonly", "compose.yml"), expect_refused=False)
+
+print()
+print("── the prefix trap ────────────────────────────────────────────────")
+# Without the trailing separator in the startswith() comparison, a sibling
+# directory sharing a name prefix passes: "/tmp/x/stacks-secret" starts with
+# "/tmp/x/stacks".
+sibling = root + "-secret"
+os.makedirs(sibling, exist_ok=True)
+open(os.path.join(sibling, "compose.yml"), "w").write("services: {}\n")
+check("a sibling directory sharing the root's name prefix",
+      lambda: safepath.resolve("stacks", "../stacks-secret/compose.yml", **W),
+      expect_refused=True)
+
+shutil.rmtree(tmp, ignore_errors=True)
+shutil.rmtree(_BOOT, ignore_errors=True)
+print()
+print("PASS: the boundary refuses everything it should" if not bad
+      else f"FAIL: {bad} case(s) went the wrong way")
+sys.exit(1 if bad else 0)

--- a/apps/bothy-config/compose.yml
+++ b/apps/bothy-config/compose.yml
@@ -1,0 +1,102 @@
+name: bothy-config
+
+# The config tier's backend: the service that lets a form change one declared
+# field in a file without destroying the file. Everything below is shaped by
+# that, and by the fact that it is the second service on this box able to change
+# anything.
+#
+# NETWORK ISOLATION IS THE PRIMARY CONTROL, and it is the lesson the socket-proxy
+# taught and portal-files repeated: a service with no auth of its own is
+# protected by exactly one thing - who can reach it. This sits on `confignet`,
+# which holds two containers (traefik and this), and publishes NO host port.
+# Authorisation happens at the edge, so anything that can reach :8098 directly
+# has already bypassed it.
+#
+#   DO NOT put this on devnet. ~20 containers live there, including third-party
+#   images, and every one of them would get the ability to rewrite this box's
+#   compose files. Nothing would warn you; the service would work perfectly.
+#
+# The write path is: browser -> Traefik (exact Path + forwardAuth requiring the
+# `editor` role) -> here. See edge/dynamic/bothy-config.yml.
+#
+# WHY THIS IS NOT AN ENDPOINT ON portal-files. That service states at the top of
+# app.py that it has no third-party dependencies, because it holds read-write
+# bind mounts on two git repositories and "every dependency is something that can
+# ship a vulnerability into that position". A YAML round-tripper is a dependency.
+# So it lives here, carrying the parser and paying for it with a much narrower
+# mount: one repository instead of four roots.
+
+services:
+  bothy-config:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: bothy-config
+    restart: unless-stopped
+    # Never root, and never able to become root: this process holds a writable
+    # handle on the repository that describes this box.
+    user: "1000:1000"
+    security_opt:
+      - no-new-privileges:true
+    read_only: true          # its own filesystem; the root below is separate
+    tmpfs:
+      - /tmp
+    environment:
+      PORT: 8098
+      AUDIT_LOG: /audit/patches.log
+    volumes:
+      # ONE mount, and the narrowness is the point.
+      #
+      # portal-files mounts four roots because a file explorer over three of them
+      # is not a file explorer. This service exists to patch the files that
+      # DECLARE this box, and every one of those is in the stack repo - so
+      # nothing else is mounted, and ~/projects, ~/claude-notes and $HOME are
+      # simply not reachable from this container at any policy setting.
+      #
+      # The mount is the whole repo rather than a subdirectory because the
+      # patchable compose files are scattered across it (edge/, auth/, data/*,
+      # monitoring/, mgmt/, apps/*). policy.toml is what narrows it from there,
+      # and it narrows it hard: .yml and .yaml only, edge/dynamic/ excluded
+      # outright, and exactly one field name patchable in any of them.
+      - /home/devssh/stacks:/repos/stacks:rw
+      # The patch log. Mounted so it outlives a container rebuild - an audit
+      # trail that a `docker compose up --build` erases is not an audit trail.
+      - ./audit:/audit:rw
+      # The undo net: the previous version of every file this service overwrites.
+      #
+      # A SEPARATE directory from portal-files' trash. Sharing would give the box
+      # one undo net instead of two, which is nicer - and it would have two
+      # containers pruning one tree under different policies. See policy.toml.
+      #
+      # CREATE IT BEFORE FIRST RUN - `mkdir -p ~/.local/state/bothy/config-trash`.
+      # Docker creates a missing bind source as ROOT, and this container runs as
+      # uid 1000, so it would be mounted and unwritable. safepath refuses to start
+      # in that case rather than running with a net that silently drops
+      # everything.
+      - /home/devssh/.local/state/bothy/config-trash:/var/lib/bothy/config-trash:rw
+    networks:
+      - confignet
+    labels:
+      # No traefik.* router labels ON PURPOSE. The docker provider would give
+      # this a router derived from the container name; the routes are declared in
+      # edge/dynamic/bothy-config.yml instead, because they need the exact Path()
+      # rules and the auth middleware, and a stray auto-generated router would be
+      # an unauthenticated way to rewrite this repo's compose files.
+      - traefik.enable=false
+      # Deliberately NO dev.portal.project label, and the omission is on purpose
+      # rather than an oversight. That label is the one field this service can
+      # patch; giving itself one would make it the first thing a form offers to
+      # rename, and a service that can rewrite its own card title is a needless
+      # loop to explain. It appears on the Bothy card through its compose project
+      # name like anything else.
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8098/healthz',timeout=2).status==200 else 1)"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+networks:
+  confignet:
+    name: confignet
+    external: true

--- a/apps/bothy-config/policy.toml
+++ b/apps/bothy-config/policy.toml
@@ -1,0 +1,185 @@
+# What a form may change, and where.
+#
+# This file IS the allowlist. On the apps/portal-files/policy.toml precedent, and
+# for the same reason: a rule expressed as a Python constant needs a code change
+# and a redeploy to widen, which is how something gets missed - and it puts the
+# rules, and the reasons for them, in a file most people never open.
+#
+# THREE RULES ABOUT EDITING IT
+#
+#   1. It fails CLOSED. A missing file, a parse error, a root whose path does not
+#      exist, an unwritable snapshot directory, or an empty [fields] table stops
+#      the service from starting. There is no fallback default, because the only
+#      safe default is "patch nothing", and a service that patches nothing looks
+#      broken in a way people work around.
+#
+#   2. checks/run.sh lints it, offline and with the stack down. Run that after
+#      any change here.
+#
+#   3. It is not patchable by the thing it governs. `.toml` is not in
+#      [patch].suffixes, so the file that declares what may be written cannot be
+#      rewritten through the API it declares.
+#
+# The paths below are CONTAINER paths. They are mounted in compose.yml, and a
+# root declared here but not mounted there is a startup error rather than an
+# empty directory.
+#
+# WHAT IS NOT HERE, and deliberately. There is no list of forbidden CHARACTERS.
+# Which bytes may appear in a YAML plain scalar is a property of the format, not
+# an access decision, and expressing it in TOML means writing escape sequences
+# into a file whose whole job is to be read by a person. yamlpatch guarantees
+# correctness by re-parsing its own output; app.py rejects the obvious cases
+# early only so the error message is readable. Neither is policy.
+
+# ── roots ───────────────────────────────────────────────────────────────────
+#
+# ONE root, and that is the design rather than a starting point. portal-files
+# mounts four (the stack repo, the notes, every project, and the whole home
+# directory) because a file explorer is only useful over everything. A config
+# patcher is useful over exactly the files that declare THIS box, and every one
+# of those is in the stack repo.
+#
+# Nothing in ~/projects is here on purpose: those repos have their own review and
+# CI, and a form that edited them would bypass both.
+
+[roots.stacks]
+path = "/repos/stacks"
+writable = true
+
+# ── what may be opened at all ───────────────────────────────────────────────
+
+[patch]
+# YAML only, because a YAML parser is the only thing this service knows how to
+# splice safely. This is a blast-radius limit and not a parsing convenience:
+# without it, "rename a project" would also mean "rewrite a shell script that
+# cron runs".
+#
+# `.toml` is deliberately absent - see rule 3 above.
+suffixes = [".yml", ".yaml"]
+
+# Directories nothing may patch, matched as a prefix on the path relative to the
+# root. A directory rather than a list of the files in it, which would go stale.
+#
+# `edge/dynamic/` is CLASS C in docs/plans/editing-model.md, and it is the one
+# place on this box where a plausible edit takes everything down quietly. Traefik
+# renders that directory as a Go template BEFORE parsing the YAML, and does not
+# skip comments - so a doubled brace anywhere, including inside a comment, voids
+# the whole file: no routers, no middlewares, while the file on disk looks
+# perfect. Traefik then keeps serving its last-good config, so nothing looks
+# wrong until the next restart, when every @file router disappears at once.
+#
+# §6 of the plan says routes are GENERATED from a template and verified against
+# the live router table afterwards, with a rollback from the snapshot if the rule
+# does not appear. This service does neither yet, so it does not touch them.
+#
+# It is also the corpus where the naive YAML round-trip does its worst damage -
+# three of those files are ENTIRELY comments, and a round-tripper turns 1,702
+# bytes of explanation into 9. See yamlpatch.py's header.
+deny_prefixes = [
+  "edge/dynamic/",
+]
+
+# Files excluded even though their suffix and directory allow them, by exact path
+# from the root.
+#
+# `monitoring/prometheus-web.yml` carries a bcrypt hash. It is a credential file
+# whose name matches none of the deny patterns below, which is exactly the class
+# of miss that put `dozzle-users.yml` in portal-files' list by name. A bcrypt
+# hash IS a credential, just a slow one.
+#
+# The field allowlist already makes this unreachable - it carries no
+# `dev.portal.*` label - so this is the second, independent control. The first is
+# the one that would have to be widened by mistake.
+deny_relpaths = [
+  "monitoring/prometheus-web.yml",
+]
+
+# ── the fields ──────────────────────────────────────────────────────────────
+#
+# ONE LINE PER FIELD. That is the property this format exists for: adding
+# `dev.portal.name`, `dev.portal.desc`, `dev.portal.icon` and `dev.portal.order`
+# is four more lines here and no Python at all, because they are the same SHAPE -
+# a docker-compose label carrying a plain string.
+#
+# `kind` names a locator in yamlpatch.LOCATORS. A new kind - an env var's value,
+# a published port, a key in project.dev.yml - is a new function there as well as
+# a line here, and that is the right amount of friction. A new shape is a new set
+# of ways to be wrong about where a value ends, and being wrong about that
+# corrupts a file rather than rejecting a request.
+#
+# ── why exactly one field to begin with ─────────────────────────────────────
+#
+# §3 of docs/plans/editing-model.md sorts configuration into three classes, and
+# this is the safest member of the safest one. `dev.portal.project` is the card
+# title Bothy shows in its Overview. It changes what Bothy DISPLAYS and nothing
+# else: no container behaviour, no route, no credential. The worst possible
+# outcome of a wrong value is a card with the wrong title, which makes it the
+# right field to prove the whole chain on - form to patch to file to git to a
+# visible change - before anything with a blast radius is added.
+#
+# What must NOT appear here, at any point, is class C: `volumes`, `privileged`,
+# `cap_add`, `command`, `entrypoint`, `network_mode`, anything mounting a socket.
+# A wrong value in those is arbitrary code on the box or a credential leak. They
+# are edited as a diff, by someone who has read the comment above them.
+
+[fields]
+"dev.portal.project" = { kind = "compose-label", max_length = 80 }
+
+# ── validation ──────────────────────────────────────────────────────────────
+
+[validate]
+# A ceiling on any value, whatever its field's own limit says. A form field is a
+# form field; a megabyte in one is not a long project name.
+max_length = 500
+
+# ── snapshots ───────────────────────────────────────────────────────────────
+#
+# THE UNDO NET. Every overwrite copies the outgoing bytes here first.
+#
+# It matters more here than in the file tier, which is worth saying rather than
+# inheriting silently: a person editing text in Files can SEE what they are about
+# to overwrite. A person typing into a form cannot see the file at all, so this
+# copy is the only evidence that a patch landed somewhere unintended.
+#
+# A SEPARATE directory from portal-files' trash, not a shared one. Sharing would
+# give the box one undo net instead of two, which is nicer - and it would have
+# two containers pruning one tree under different policies, where the loser is
+# whichever service's snapshots the other evicted. Two nets that each work beat
+# one that mostly does.
+#
+# CREATE IT BEFORE FIRST RUN - `mkdir -p ~/.local/state/bothy/config-trash`.
+# Docker creates a missing bind source as ROOT and this container runs as uid
+# 1000, so it would be mounted and unwritable; the loader refuses to start in
+# that case rather than running with a net that silently drops everything.
+[snapshots]
+path = "/var/lib/bothy/config-trash"
+keep = 20
+max_age_days = 30
+
+# ── deny ────────────────────────────────────────────────────────────────────
+#
+# Inherited wholesale from portal-files. Most of it is unreachable here - this
+# service opens only `.yml` files under one root - and it is carried anyway
+# because the cost is a list and the alternative is discovering that a `.yml`
+# symlink pointed at something inside `.git`.
+
+[deny]
+components = [
+  ".git", ".ssh", ".gnupg", "node_modules", ".venv", "venv",
+  "__pycache__", ".mypy_cache", ".pytest_cache", "dist", "build",
+  ".next", ".turbo", ".cache", "target",
+]
+
+# Matched on the FILENAME, because a component-only list cannot see `.env` or
+# `key.pem` - both are files. `dozzle-users.yml` and `realm-*.json` are the two
+# that prove the point: nothing in either name matches "secret", "password" or
+# "credentials", and both carry a live credential.
+file_patterns = [
+  ".env", ".env.*", "*.env",
+  "*.pem", "*.key", "*.p12", "*.pfx", "*.jks", "*.keystore",
+  "*.kdbx", "*.gpg", "*.asc",
+  ".netrc", ".pgpass", ".htpasswd", ".git-credentials",
+  "credentials", "credentials.*", "*secret*", "*password*",
+  "realm-*.json", "*-realm.json", "realm.json",
+  "dozzle-users.yml",
+]

--- a/apps/bothy-config/requirements.txt
+++ b/apps/bothy-config/requirements.txt
@@ -1,0 +1,19 @@
+# THE dependency, and the reason this is a separate service.
+#
+# apps/portal-files/app.py has no third-party dependencies at all, on purpose:
+# "this container holds read-write bind mounts on two git repositories, and every
+# dependency is something that can ship a vulnerability into that position".
+# A YAML parser is a dependency, so the parser lives here instead - with one
+# repository mounted instead of four roots, and its own network.
+#
+# PINNED EXACTLY, not floored. This is the code that decides where a value ends
+# inside somebody's compose file; a minor release changing how `lc` reports a
+# column would move every span by one character, and the failure would be a
+# corrupted file rather than an ImportError. checks/noop_bytes.py is what proves
+# a given version is safe, so the version it proved is the version that ships.
+#
+# ruamel.yaml.clib is deliberately NOT installed. It is an optional C accelerator
+# and 0.19 on CPython 3.13 does not pull it in; the pure-Python round-trip parser
+# is what the checks were run against, and a native extension in a process that
+# writes to this repository is surface bought with speed nobody asked for.
+ruamel.yaml==0.19.1

--- a/apps/bothy-config/safepath.py
+++ b/apps/bothy-config/safepath.py
@@ -1,0 +1,412 @@
+"""Resolve a client-supplied path to a real file, or refuse.
+
+DERIVED FROM apps/portal-files/safepath.py, deliberately and with attribution.
+
+Why a copy rather than an import. The two services do not share a build context:
+`apps/bothy-config/compose.yml` builds with `context: .`, and Docker will not
+follow a symlink or a `../` COPY out of it. Widening the context to `apps/` to
+reach one module would put every other service's source into this image's build
+context - which is a larger and less obvious change than a copy. The alternative,
+publishing safepath as a package, is a build system this repo does not have.
+
+So: a copy, trimmed to what the config tier actually needs (resolve, safe_open,
+snapshot, the name deny-list). The archive walk, the secret content scanner and
+the content-type tables are NOT here - this service serves no bytes to a browser
+and walks no trees, so carrying them would be surface with no user.
+
+THE DRIFT RISK IS REAL AND IS HANDLED BY A TEST, not by discipline.
+checks/test_safepath.py runs the same truth table portal-files runs, including
+real planted symlinks. If someone fixes a hole there and not here, the case they
+added is the case that fails here.
+
+── the threats, unchanged from the original ────────────────────────────────
+
+    ../../../../etc/passwd          climbing out with dot-dot
+    /etc/passwd                     an absolute path that ignores the root
+    docs/link -> /etc               a symlink planted inside the root
+    docs/../../.ssh/id_ed25519      dot-dot after a legitimate prefix
+    .git/config                     inside the root, but not content
+
+The defence is to resolve FIRST and compare AFTER. Checking the string for ".."
+before resolving is the classic mistake: it cannot see a symlink, and it rejects
+legitimate names that merely contain the characters. os.path.realpath() collapses
+dot-dot AND follows every symlink, so the comparison happens on the real
+destination - which is the only thing that matters.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import os
+import stat
+import time
+import tomllib
+from dataclasses import dataclass
+
+# ── the policy is DECLARED, not coded ───────────────────────────────────────
+#
+# Same precedent, same reason: widening what this service may touch must be a
+# reviewable diff in a file people open, not a Python constant nobody reads.
+#
+# It FAILS CLOSED. A missing file, a parse error, a root whose directory does not
+# exist, or an unwritable snapshot directory raises at import and the service
+# does not start. There is no built-in default, because the only safe default is
+# "patch nothing", and a service that patches nothing looks broken in a way
+# people work around by disabling the check.
+POLICY_PATH = os.environ.get("POLICY_FILE",
+                             os.path.join(os.path.dirname(__file__), "policy.toml"))
+
+
+class PolicyError(Exception):
+    """The policy could not be loaded. Fatal on purpose."""
+
+
+class PathRefused(Exception):
+    """A path was not proven safe. The message is safe to show a user."""
+
+
+def _load_policy(path: str) -> dict:
+    try:
+        with open(path, "rb") as fh:
+            doc = tomllib.load(fh)
+    except FileNotFoundError as e:
+        raise PolicyError(f"no policy at {path} - refusing to start") from e
+    except tomllib.TOMLDecodeError as e:
+        raise PolicyError(f"policy at {path} does not parse: {e}") from e
+
+    roots = doc.get("roots")
+    if not isinstance(roots, dict) or not roots:
+        raise PolicyError("policy declares no roots")
+    for name, cfg in roots.items():
+        if not isinstance(cfg, dict) or not cfg.get("path"):
+            raise PolicyError(f"root {name!r} has no path")
+        # A declared-but-unmounted root presents as an empty directory, which
+        # reads as "nothing to patch here" rather than "misconfigured".
+        if not os.path.isdir(cfg["path"]):
+            raise PolicyError(
+                f"root {name!r} points at {cfg['path']}, which is not a directory "
+                f"- is it mounted in compose.yml?")
+
+    if not isinstance(doc.get("deny", {}).get("components"), list):
+        raise PolicyError("policy is missing [deny].components")
+    if not isinstance(doc.get("deny", {}).get("file_patterns"), list):
+        raise PolicyError("policy is missing [deny].file_patterns")
+    if not isinstance(doc.get("patch", {}).get("suffixes"), list):
+        raise PolicyError("policy is missing [patch].suffixes")
+
+    # The field allowlist is the whole point of this service, so an empty one is
+    # a configuration error rather than a quiet no-op. A service that accepts
+    # every request with "that field is not patchable" is indistinguishable from
+    # a broken one, and the difference matters when someone is debugging at 3am.
+    fields = doc.get("fields")
+    if not isinstance(fields, dict) or not fields:
+        raise PolicyError("policy declares no [fields] - nothing would be patchable")
+    for fname, cfg in fields.items():
+        if not isinstance(cfg, dict) or not cfg.get("kind"):
+            raise PolicyError(f"field {fname!r} declares no kind")
+
+    # Checked exactly like a root: declared but not mounted is a startup error.
+    # A missing undo net that nobody notices until they need it is worse than no
+    # undo net at all, because the whole point of it is that it is there without
+    # being thought about.
+    snaps = doc.get("snapshots")
+    if not isinstance(snaps, dict) or not snaps.get("path"):
+        raise PolicyError("policy declares no [snapshots].path")
+    if not os.path.isdir(snaps["path"]):
+        raise PolicyError(
+            f"snapshot directory {snaps['path']} is not a directory "
+            f"- is it mounted in compose.yml?")
+    if not os.access(snaps["path"], os.W_OK | os.X_OK):
+        raise PolicyError(
+            f"snapshot directory {snaps['path']} is not writable by uid "
+            f"{os.getuid()} - a bind mount docker created will be root-owned")
+    return doc
+
+
+POLICY = _load_policy(POLICY_PATH)
+
+ROOTS: dict[str, str] = {k: v["path"] for k, v in POLICY["roots"].items()}
+WRITABLE_ROOTS = frozenset(
+    k for k, v in POLICY["roots"].items() if v.get("writable") is True)
+
+DENY_COMPONENTS = frozenset(POLICY["deny"]["components"])
+DENY_FILE_PATTERNS = tuple(POLICY["deny"]["file_patterns"])
+PATCHABLE_SUFFIXES = frozenset(POLICY["patch"]["suffixes"])
+
+# Whole files and whole directories that are never patched even though their
+# suffix says they could be. See policy.toml for what is on each list and why -
+# `edge/dynamic/` in particular is not a formatting preference.
+DENY_RELPATHS = frozenset(POLICY["patch"].get("deny_relpaths", []))
+DENY_PREFIXES = tuple(POLICY["patch"].get("deny_prefixes", []))
+
+# The field allowlist, as the rest of the service sees it: {name: {kind, ...}}.
+# Nothing outside this table is patchable, and there is no wildcard.
+FIELDS: dict[str, dict] = dict(POLICY["fields"])
+
+# The ceiling on any value, whatever its own field's limit says.
+MAX_VALUE_LENGTH = int(POLICY.get("validate", {}).get("max_length", 500))
+
+SNAPSHOT_DIR: str = POLICY["snapshots"]["path"]
+SNAPSHOT_KEEP = int(POLICY["snapshots"].get("keep", 20))
+SNAPSHOT_MAX_AGE = int(POLICY["snapshots"].get("max_age_days", 30)) * 86400
+SNAPSHOT_MAX_BYTES = 4 * 1024 * 1024
+SNAPSHOT_UNCHANGED = ""
+_SWEEP_EVERY = 3600
+
+# A compose file is a page of YAML. Anything above this is not one, and reading
+# it into memory to splice one label would be the wrong shape of mistake.
+MAX_BYTES = 1_000_000
+
+
+def is_denied_name(basename: str) -> bool:
+    """True if this filename must never be opened.
+
+    Case-insensitive, because the filesystem here is case-sensitive but the
+    person who named `Key.PEM` did not mean something different by it.
+    """
+    name = basename.lower()
+    return any(fnmatch.fnmatch(name, pat) for pat in DENY_FILE_PATTERNS)
+
+
+def safe_open(abspath: str) -> tuple[int, os.stat_result]:
+    """Open a regular file, closing three races at once. Caller must os.close().
+
+    O_NOFOLLOW  - closes the window between realpath() and open() in which the
+                  final component could be swapped for a symlink.
+    O_NONBLOCK  - stops open() blocking FOREVER on a FIFO.
+    fstat on fd - the size checked and the bytes read are the same inode, so
+                  there is no size TOCTOU.
+    """
+    try:
+        fd = os.open(abspath, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    except OSError as e:
+        raise PathRefused(f"cannot open: {e.strerror}") from e
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise PathRefused("not a regular file")
+    except Exception:
+        os.close(fd)
+        raise
+    return fd, st
+
+
+@dataclass(frozen=True)
+class Resolved:
+    root_key: str
+    root_dir: str      # the real directory the root names
+    abspath: str       # the real, resolved location on disk
+    relpath: str       # path relative to root_dir - what a human sees
+
+
+def resolve(root_key: str, rel: str, *, for_write: bool = False) -> Resolved:
+    """Return a Resolved, or raise PathRefused.
+
+    Deliberately refuses rather than sanitising. Silently "fixing" a hostile path
+    into a nearby legal one means an attack and a typo produce the same quiet
+    success, and neither shows up anywhere.
+    """
+    root_dir = ROOTS.get(root_key)
+    if root_dir is None:
+        raise PathRefused(f"unknown root {root_key!r}")
+
+    if not isinstance(rel, str) or not rel.strip():
+        raise PathRefused("empty path")
+
+    # A NUL truncates the path in any C-level call underneath us, so the check
+    # above it could inspect one string while open() acts on a shorter one.
+    if "\x00" in rel:
+        raise PathRefused("path contains a null byte")
+
+    # An absolute path would make os.path.join discard the root entirely -
+    # join("/repos/stacks", "/etc/passwd") == "/etc/passwd". Refuse before joining.
+    if os.path.isabs(rel):
+        raise PathRefused("path must be relative to the root")
+
+    real_root = os.path.realpath(root_dir)
+    candidate = os.path.realpath(os.path.join(real_root, rel))
+
+    # THE check. Compare resolved-to-resolved, with a trailing separator so that
+    # a sibling directory sharing a name prefix cannot pass: without it,
+    # "/repos/stacks-secret" starts with "/repos/stacks" and would be accepted.
+    if candidate != real_root and not candidate.startswith(real_root + os.sep):
+        raise PathRefused("path escapes its root")
+
+    relpath = os.path.relpath(candidate, real_root)
+
+    # Components of the RESOLVED path, so a symlink that lands inside .git is
+    # caught by where it points rather than by what it is called.
+    if set(relpath.split(os.sep)) & DENY_COMPONENTS:
+        raise PathRefused("path is in a denied directory")
+
+    # Then the FILENAME, for the same reason: a symlink named `compose.yml`
+    # pointing at `.env` must be refused for what it reaches, not what it is
+    # called.
+    if is_denied_name(os.path.basename(candidate)):
+        raise PathRefused("this file is excluded as a possible secret")
+
+    # The two policy lists, applied on READ as well as on write.
+    #
+    # They were under `for_write` first, and checks/test_safepath.py caught it:
+    # a symlink pointing into a denied path was refused for patching and
+    # cheerfully READABLE, so `monitoring/prometheus-web.yml` - which exists on
+    # the list because it carries a bcrypt hash - could be fetched through
+    # /config/fields by naming a link to it. A deny list that half of the service
+    # honours is a deny list nobody should rely on.
+    #
+    # Making them unconditional costs nothing real. This service has exactly one
+    # read endpoint and its whole purpose is to describe what a form may change;
+    # a file no form may change has nothing to say through it.
+    #
+    # Both checked on the RESOLVED relpath, so a symlink named
+    # `apps/x/compose.yml` that lands in edge/dynamic/ is refused for where it
+    # points rather than for what it is called.
+    slashed = relpath.replace(os.sep, "/")
+    if slashed in DENY_RELPATHS:
+        raise PathRefused("this file is excluded by policy")
+    if any(slashed.startswith(p) for p in DENY_PREFIXES):
+        raise PathRefused(
+            "this directory is excluded - see policy.toml for why edge/dynamic "
+            "is edited as a diff and not as a form")
+
+    if for_write:
+        if root_key not in WRITABLE_ROOTS:
+            raise PathRefused(f"the {root_key!r} root is read-only")
+        if os.path.splitext(candidate)[1].lower() not in PATCHABLE_SUFFIXES:
+            raise PathRefused(
+                "only " + ", ".join(sorted(PATCHABLE_SUFFIXES)) + " files may be patched")
+        # Writing THROUGH a symlink would let someone plant a link inside the
+        # root and have us overwrite its target. The realpath check above already
+        # proves the destination is inside the root, so this only forbids the
+        # confusing case where the name and the target differ.
+        if os.path.islink(os.path.join(real_root, rel)):
+            raise PathRefused("refusing to write through a symlink")
+
+    return Resolved(root_key=root_key, root_dir=real_root,
+                    abspath=candidate, relpath=relpath)
+
+
+def snapshot(root: str, relpath: str, abspath: str,
+             incoming: bytes | None = None) -> str | None:
+    """Keep the bytes a write is about to destroy. Returns the copy, or None.
+
+    THE ONE QUESTION THIS ANSWERS is "what did this file say before the form
+    changed it?" It is not version control and must not grow into it: no
+    ordering, no messages, no merging. git is for history; this is for the ten
+    seconds after a mistake.
+
+    It matters MORE here than in the file tier, and that is worth saying. A
+    person editing text in Files can see what they are about to overwrite. A
+    person typing in a form cannot see the file at all, so the only evidence that
+    a patch went somewhere unintended is the copy taken before it did.
+
+    BEST EFFORT, DELIBERATELY. A failure here returns None and the write still
+    happens - the opposite of how everything else in this module fails. Refusing
+    to save because the safety net is missing would destroy the work it exists to
+    protect. The caller reports which way it went, so a silently absent net is
+    still visible.
+
+    COPIED, NOT HARD-LINKED. os.link would be free, but an editor that truncates
+    in place instead of renaming would then rewrite the snapshot's bytes through
+    the shared inode, and a backup that silently follows the file it is backing
+    up is worse than none.
+    """
+    dest_dir = os.path.realpath(os.path.join(SNAPSHOT_DIR, root, relpath))
+    if not (dest_dir + os.sep).startswith(os.path.realpath(SNAPSHOT_DIR) + os.sep):
+        return None
+
+    try:
+        fd, st = safe_open(abspath)
+    except (PathRefused, OSError):
+        return None  # nothing there yet: a create, not an overwrite
+    try:
+        if st.st_size > SNAPSHOT_MAX_BYTES:
+            return None
+        with os.fdopen(fd, "rb") as fh:
+            data = fh.read()
+    except OSError:
+        os.close(fd)
+        return None
+
+    # A save that changes nothing destroys nothing, so there is nothing to keep.
+    if incoming is not None and data == incoming:
+        return SNAPSHOT_UNCHANGED
+
+    digest = hashlib.sha256(data).hexdigest()[:12]
+    try:
+        os.makedirs(dest_dir, mode=0o700, exist_ok=True)
+        prior = sorted(os.listdir(dest_dir))
+        name = f"{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}.{digest}"
+        path = os.path.join(dest_dir, name)
+        # O_EXCL: two patches in the same second must not clobber each other's
+        # copy, which is exactly when a snapshot is most likely to be wanted.
+        for n in range(20):
+            try:
+                sfd = os.open(f"{path}{'' if n == 0 else f'-{n}'}",
+                              os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                break
+            except FileExistsError:
+                continue
+        else:
+            return None
+        with os.fdopen(sfd, "wb") as out:
+            out.write(data)
+
+        _prune(dest_dir, prior)
+        _sweep()
+        return path
+    except OSError:
+        return None
+
+
+def _prune(dest_dir: str, prior: list[str]) -> None:
+    """Hold one file's snapshots to SNAPSHOT_KEEP, oldest dropped first."""
+    if len(prior) < SNAPSHOT_KEEP:
+        return
+    for old in prior[:len(prior) - SNAPSHOT_KEEP + 1]:
+        try:
+            os.unlink(os.path.join(dest_dir, old))
+        except OSError:
+            pass
+
+
+def _sweep() -> None:
+    """Drop snapshots older than the policy's age, at most hourly.
+
+    Gated on a marker's mtime rather than a timer thread: the work is
+    proportional to the trash, and doing it on the save path means it cannot be
+    forgotten when the process restarts. A patch must not pay for a full walk, so
+    the common case is one stat().
+    """
+    marker = os.path.join(SNAPSHOT_DIR, ".last-sweep")
+    now = time.time()
+    try:
+        if now - os.stat(marker).st_mtime < _SWEEP_EVERY:
+            return
+    except FileNotFoundError:
+        pass
+    except OSError:
+        return
+    try:
+        with open(marker, "w"):
+            pass
+    except OSError:
+        return
+
+    cutoff = now - SNAPSHOT_MAX_AGE
+    for dirpath, _dirnames, filenames in os.walk(SNAPSHOT_DIR, topdown=False):
+        for fn in filenames:
+            if fn == ".last-sweep":
+                continue
+            p = os.path.join(dirpath, fn)
+            try:
+                if os.stat(p).st_mtime < cutoff:
+                    os.unlink(p)
+            except OSError:
+                pass
+        if dirpath != SNAPSHOT_DIR:
+            try:
+                os.rmdir(dirpath)
+            except OSError:
+                pass

--- a/apps/bothy-config/yamlpatch.py
+++ b/apps/bothy-config/yamlpatch.py
@@ -1,0 +1,407 @@
+"""Change one declared value in a YAML file without touching anything else.
+
+THIS MODULE IS THE WHOLE JOB. Everything else in this service is plumbing around
+it, and the reason is a measurement rather than a preference.
+
+── the constraint ──────────────────────────────────────────────────────────
+
+Half of this repository's compose files are comments:
+
+    edge/compose.yml                174 lines, 124 comments   71%
+    auth/compose.yml                459 lines, 299 comments   65%
+    apps/portal-files/compose.yml   112 lines,  70 comments   62%
+    all compose.yml files         1,485 lines, 754 comments   50%
+
+They are the most valuable content in the repository. Several are the only record
+of a security decision, and the README advertises them as the point of the thing.
+The naive implementation - `yaml.safe_load()`, mutate the dict, `yaml.dump()` -
+deletes all 754 of them, reformats everything else, and returns success.
+
+── what was measured, and why this file does not round-trip ────────────────
+
+The obvious defence is `ruamel.yaml` in round-trip mode, which preserves
+comments. Run over this repo's 12 compose files and 6 `edge/dynamic/*.yml` files,
+loading and dumping with nothing changed:
+
+    YAML(typ='rt'), defaults                     11 of 18 files damaged
+    ...plus indent(mapping=2, sequence=4, offset=2)
+    ...plus preserve_quotes, width=1<<30           4 of 18 files damaged
+
+The four survivors of every setting we could find are the interesting part:
+
+  1. `apps/portal/compose.yml` loses HAND-ALIGNED COLUMNS. The socket-proxy's
+     deny block is written as a column of `POST:         0   # no mutation`, and
+     ruamel re-emits it as `POST: 0           # no mutation`. The comments are
+     all still there; the table they were arranged into is not. 42 lines change
+     in a patch that was supposed to change none.
+
+  2. Three files in `edge/dynamic/` are ENTIRELY COMMENTS - retired routes and
+     worked examples kept as the record of why. A YAML document with no content
+     loads as `None`, and dumping `None` emits the word null, a newline, and a
+     document-end marker: nine bytes. Measured: `host-services.yml` goes from
+     1,702 bytes to those nine. Every word of the explanation gone, silently,
+     with the service still starting.
+
+So round-trip mode is close, and close is the failure mode this whole design
+exists to avoid: it produces a diff too large to read that looks like it worked.
+
+── what this file does instead ─────────────────────────────────────────────
+
+    ruamel PARSES. Python SPLICES. Nothing is ever re-serialised.
+
+The round-trip loader is used only as a LOCATOR: `CommentedSeq.lc.item(i)` and
+`CommentedMap.lc.value(k)` give the exact (line, column) of a scalar in the
+source. From that we compute a byte span, replace exactly that span in the
+original text, and leave every other byte alone. Byte-identity on a no-op is
+then true by construction rather than by hope, and a patch cannot damage a
+comment because it never writes to a line a comment is on.
+
+The cost is honest and worth stating: this can only change scalars that already
+exist. It cannot add a key, delete one, or reorder anything. That is a feature
+here - §3 of docs/plans/editing-model.md restricts forms to declared, allowlisted
+fields, and every one of those is a value that is already written down.
+
+── the refusal rule ────────────────────────────────────────────────────────
+
+§8 of the plan: "a form that silently drops what it did not understand" is
+refused. So every step that could be ambiguous raises RewriteRefused instead of
+guessing:
+
+  * the source text at the located span must equal the parsed scalar exactly. If
+    it does not, the scalar was quoted, folded, or otherwise not literal, and we
+    do not know where it ends;
+  * the spliced result must re-parse, and the field must then read back as
+    EXACTLY the value asked for - so a value that would change the YAML's
+    structure (`a: b` inside a plain scalar, a `#` starting a comment) is caught
+    by the parser rather than by a character blocklist we hoped was complete;
+  * every line except the one patched must be byte-identical;
+  * the whole document, compared structurally, must differ in exactly the one
+    place.
+
+Any of those failing means the file is written in a shape this module does not
+model, and the correct answer is "open it in Files", not "write something".
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from ruamel.yaml.error import YAMLError
+
+
+class RewriteRefused(Exception):
+    """The file is not in a shape this module can change safely."""
+
+
+def _reader() -> YAML:
+    """A parser, never a writer.
+
+    `width` is set absurdly high even though nothing here dumps, because the one
+    place a YAML object escapes this module is the naive-dump demonstration in
+    checks/, and the default width of 80 silently reflows long lines - which
+    would make that measurement wrong in the flattering direction.
+    """
+    y = YAML(typ="rt")
+    y.preserve_quotes = True
+    y.width = 1 << 30
+    return y
+
+
+@dataclass(frozen=True)
+class Site:
+    """One patchable value, located in the source text.
+
+    `start`/`end` are character offsets into the whole file, not into the line.
+    Splicing works on offsets so that the caller never has to reason about line
+    endings, and a file with CRLF cannot be silently rewritten to LF.
+    """
+    field: str          # the policy key, e.g. "dev.portal.project"
+    kind: str           # the locator that found it, e.g. "compose-label"
+    service: str        # the compose service the value belongs to
+    value: str          # what it says now
+    line: int           # 1-based, for a UI that wants to link into Files
+    start: int
+    end: int
+
+
+# ── locators ────────────────────────────────────────────────────────────────
+#
+# A locator answers "where in this text is field X?" for one SHAPE of file. The
+# policy names a kind per field, so adding `dev.portal.name` and
+# `dev.portal.desc` is one line each in policy.toml - they are the same shape.
+#
+# Adding a genuinely new shape (an env var, a published port) is a new function
+# here plus a name in this table, and that is the right amount of friction: a new
+# shape is a new set of ways to be wrong about where a value ends.
+
+
+def _span_of(text: str, lines: list[int], line0: int, col0: int,
+             literal: str, what: str) -> tuple[int, int]:
+    """Character offsets of `literal`, asserted to start at (line0, col0).
+
+    THE ASSERTION IS THE POINT. ruamel reports where a scalar begins; it does not
+    report where it ends, and the end is what a splice needs. For a PLAIN scalar
+    the source text and the parsed value are the same string, so the end is
+    start + len(value) - but only if the source really is plain. A single-quoted
+    scalar parses `'it''s'` to `it's`, four source characters longer than the
+    value, and splicing at start+len would eat the closing quote and leave a file
+    that does not parse.
+
+    Comparing the source slice against the parsed value settles it in one line,
+    for every quoting style at once, without a table of them.
+    """
+    if line0 < 0 or line0 >= len(lines):
+        raise RewriteRefused(f"{what}: reported line {line0 + 1} is outside the file")
+    start = lines[line0] + col0
+    end = start + len(literal)
+    if text[start:end] != literal:
+        raise RewriteRefused(
+            f"{what}: the text at line {line0 + 1} is not the literal value "
+            f"(quoted, folded, or spanning lines) - edit this file in Files instead")
+    return start, end
+
+
+def _line_starts(text: str) -> list[int]:
+    """Character offset of the first character of every line.
+
+    splitlines(keepends=True) rather than split('\\n') so that a file using CRLF,
+    or an old Mac CR, is measured with the line breaks it actually has. ruamel
+    counts lines the same way, so the two agree.
+    """
+    out, pos = [], 0
+    for ln in text.splitlines(keepends=True):
+        out.append(pos)
+        pos += len(ln)
+    out.append(pos)   # a trailing sentinel, so the last line has an end
+    return out
+
+
+def _locate_compose_label(doc, text: str, lines: list[int],
+                          field: str) -> list[Site]:
+    """Find `field` as a docker-compose label, in either shape compose accepts.
+
+    Both shapes are real and both appear on this box, so both are handled rather
+    than one being declared canonical:
+
+        labels:                                 labels:
+          - dev.portal.project=Edge · Traefik     dev.portal.project: Edge · Traefik
+
+    The LIST shape is what every compose file here uses today, and it is the
+    awkward one: the label is a single scalar `key=value`, so the value's span is
+    an offset INTO that scalar rather than a node ruamel can point at. The `=` is
+    found in the source slice we already proved literal, so the arithmetic never
+    leaves ground the assertion covered.
+    """
+    sites: list[Site] = []
+    if not isinstance(doc, CommentedMap):
+        return sites
+    services = doc.get("services")
+    if not isinstance(services, CommentedMap):
+        return sites
+
+    for name, svc in services.items():
+        if not isinstance(svc, CommentedMap):
+            continue
+        labels = svc.get("labels")
+
+        if isinstance(labels, CommentedSeq):
+            prefix = field + "="
+            for i, item in enumerate(labels):
+                if not isinstance(item, str) or not item.startswith(prefix):
+                    continue
+                lc = labels.lc.item(i)
+                if lc is None:
+                    raise RewriteRefused(
+                        f"{field}: ruamel reported no position for the label on "
+                        f"service {name!r}")
+                start, end = _span_of(text, lines, lc[0], lc[1], item,
+                                      f"{field} on {name}")
+                sites.append(Site(field=field, kind="compose-label",
+                                  service=str(name), value=item[len(prefix):],
+                                  line=lc[0] + 1,
+                                  start=start + len(prefix), end=end))
+
+        elif isinstance(labels, CommentedMap) and field in labels:
+            val = labels[field]
+            if not isinstance(val, str):
+                # A label whose value YAML read as a number or a bool. Compose
+                # would stringify it; we will not, because writing a string back
+                # over it would change the file's type as well as its value and
+                # that is a bigger change than the form asked for.
+                raise RewriteRefused(
+                    f"{field} on service {name!r} is not a plain string")
+            lc = labels.lc.value(field)
+            if lc is None:
+                raise RewriteRefused(
+                    f"{field}: ruamel reported no position for the label on "
+                    f"service {name!r}")
+            start, end = _span_of(text, lines, lc[0], lc[1], val,
+                                  f"{field} on {name}")
+            sites.append(Site(field=field, kind="compose-label",
+                              service=str(name), value=val,
+                              line=lc[0] + 1, start=start, end=end))
+
+    return sites
+
+
+LOCATORS = {
+    "compose-label": _locate_compose_label,
+}
+
+
+# ── the public surface ──────────────────────────────────────────────────────
+
+def parse(text: str):
+    """Load for LOCATION ONLY. The result is never dumped."""
+    try:
+        return _reader().load(text)
+    except YAMLError as e:
+        raise RewriteRefused(f"this file does not parse as YAML: {e}") from e
+
+
+def locate(text: str, fields: dict[str, dict]) -> list[Site]:
+    """Every patchable site in `text`, given the policy's field table.
+
+    Order is by position in the file, so a UI listing them shows them in the
+    order a person reading the file would meet them.
+    """
+    doc = parse(text)
+    lines = _line_starts(text)
+    sites: list[Site] = []
+    for field, cfg in fields.items():
+        locator = LOCATORS.get(cfg["kind"])
+        if locator is None:
+            # A policy naming a kind with no implementation is a startup-class
+            # error that only shows up on the request that needs it, so it is
+            # loud rather than an empty result.
+            raise RewriteRefused(
+                f"policy declares field {field!r} with unknown kind {cfg['kind']!r}")
+        sites.extend(locator(doc, text, lines, field))
+    return sorted(sites, key=lambda s: s.start)
+
+
+def splice(text: str, site: Site, new_value: str) -> str:
+    """Replace exactly the site's span. Verified, then returned.
+
+    The verification runs on the RESULT rather than on the input, which is the
+    whole reason it can be short. Anything a hostile or merely awkward value
+    could do to the document - close a scalar early, open a comment, turn a
+    sequence item into a mapping - shows up as the reparsed value not matching,
+    and one comparison covers all of them.
+    """
+    out = text[:site.start] + new_value + text[site.end:]
+    _verify(text, out, site, new_value)
+    return out
+
+
+def _plain(node):
+    """Strip ruamel's types so two documents can be compared for content alone.
+
+    CommentedMap and CommentedSeq compare equal to dict and list, so this is
+    strictly speaking unnecessary - but `==` on them also drags in their comment
+    attachments in some ruamel versions, and a structural comparison that
+    quietly starts comparing comments would fail every legitimate patch. Making
+    the shape explicit costs six lines and removes the dependency on that
+    behaviour.
+    """
+    if isinstance(node, dict):
+        return {k: _plain(v) for k, v in node.items()}
+    if isinstance(node, (list, tuple)):
+        return [_plain(v) for v in node]
+    return node
+
+
+def _verify(before: str, after: str, site: Site, new_value: str) -> None:
+    """Refuse unless the result is exactly the one change that was asked for.
+
+    Four assertions, each catching something the others cannot:
+
+      1. it parses, and the field reads back as the exact new value. Catches
+         every way a value can change the document's SHAPE rather than its
+         content.
+      2. the line count is unchanged. A value carrying a newline would otherwise
+         split one line into two, and every subsequent line number - including
+         those in the audit log and in any UI linking into Files - would be
+         wrong.
+      3. every line except the patched one is byte-identical. This is the
+         comment-preservation guarantee stated directly: a comment cannot be
+         lost by a write that provably did not touch its line.
+      4. structurally, the two documents differ only where they were meant to.
+         Cheap, and it is the one that would catch a locator pointing at the
+         right text in the wrong place - two services with the same label value,
+         say, where assertion 1 would happily pass on the wrong one.
+    """
+    doc = parse(after)
+    lines = _line_starts(after)
+    found = [s for s in LOCATORS[site.kind](doc, after, lines, site.field)
+             if s.service == site.service]
+    if len(found) != 1:
+        raise RewriteRefused(
+            f"after the patch, {site.field} appears {len(found)} times on service "
+            f"{site.service!r} - refusing to write")
+    if found[0].value != new_value:
+        raise RewriteRefused(
+            f"after the patch, {site.field} reads {found[0].value!r} rather than "
+            f"{new_value!r} - the value changed the document's structure")
+
+    b_lines = before.splitlines(keepends=True)
+    a_lines = after.splitlines(keepends=True)
+    if len(b_lines) != len(a_lines):
+        raise RewriteRefused(
+            f"the patch changed the line count ({len(b_lines)} -> {len(a_lines)})")
+    differing = [i for i, (x, y) in enumerate(zip(b_lines, a_lines)) if x != y]
+    # AT MOST the one line, not EXACTLY it. Writing the same value back over
+    # itself changes nothing at all, and that must be a pass rather than a
+    # failure - it is precisely the case checks/noop_bytes.py exists to assert,
+    # and requiring a change here would make the gating check impossible to
+    # write. `<=` on the set says "nowhere else", which is the actual property.
+    if not set(differing) <= {site.line - 1}:
+        raise RewriteRefused(
+            "the patch changed lines "
+            f"{[i + 1 for i in differing]} rather than only line {site.line}")
+
+    expect = _plain(parse(before))
+    got = _plain(doc)
+    if _clear_site(expect, site) != _clear_site(got, site):
+        raise RewriteRefused(
+            "the patch changed the document somewhere other than the field asked "
+            "for - refusing to write")
+
+
+def _clear_site(doc, site: Site):
+    """Blank the patched value so the rest of two documents can be compared.
+
+    Removing the label outright would be wrong: a list-shaped `labels:` would
+    then have a different LENGTH before and after, and every entry after it a
+    different index, so the comparison would report a difference that is only the
+    hole we punched. Overwriting it in place keeps the shapes aligned.
+    """
+    try:
+        svc = doc["services"][site.service]
+        labels = svc["labels"]
+    except (KeyError, TypeError):
+        return doc
+    if isinstance(labels, list):
+        prefix = site.field + "="
+        svc["labels"] = [f"{prefix}\0" if isinstance(x, str) and x.startswith(prefix)
+                         else x for x in labels]
+    elif isinstance(labels, dict) and site.field in labels:
+        labels[site.field] = "\0"
+    return doc
+
+
+def naive_dump(text: str) -> str:
+    """Load and dump with nothing changed - the thing this module refuses to do.
+
+    Lives here rather than in the check so that the comparison is against the
+    exact same parser configuration this module uses for locating. A measurement
+    of a straw man is not a measurement. See checks/naive_dump_damage.py.
+    """
+    y = _reader()
+    y.indent(mapping=2, sequence=4, offset=2)
+    buf = io.StringIO()
+    y.dump(y.load(text), buf)
+    return buf.getvalue()

--- a/apps/portal-next/checks/redirect-table.mjs
+++ b/apps/portal-next/checks/redirect-table.mjs
@@ -1,0 +1,108 @@
+// The redirect table - run with ./checks/run.sh
+//
+// WHY THIS EXISTS. Services, Access and Topology moved under /control, and every
+// URL they had before is a <Navigate replace>. Those redirects are the only
+// thing keeping a year of links in notes, chat and browser bookmarks alive, and
+// they have the worst failure mode in the app: a redirect that lands wrong still
+// answers 200 and still renders a plausible page, so nobody reports it. Nothing
+// on screen distinguishes "your bookmark worked" from "your bookmark quietly
+// took you somewhere else".
+//
+// The half that CANNOT drift is already handled in code: App.tsx builds its
+// legacy routes by mapping over LEGACY_PATHS, so the router and the table always
+// agree about which URLs are covered. What this asserts is the other half -
+// where each one lands, that the query string is carried, and that no target is
+// a path the app does not serve. That last one is the check that would have
+// caught the whole section being renamed while the redirects still pointed at
+// the old name.
+
+import { LEGACY_PATHS, LIVE_PATHS, legacyTarget } from './redirects.mjs';
+
+let bad = 0;
+const check = (label, got, want) => {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  if (!ok) bad++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label.padEnd(52)}${ok ? '' : ` want=${JSON.stringify(want)} got=${JSON.stringify(got)}`}`);
+};
+
+console.log('── every retired URL lands on its new one ──────────────');
+
+// The table from docs/plans/control-and-settings.md §3, written out longhand.
+// Deliberately NOT derived from the module under test: a check that computes its
+// expectation the same way the code does asserts nothing.
+const TABLE = [
+  ['/services', '', '/control/services'],
+  ['/services/portal-next', '', '/control/services/portal-next'],
+  ['/systems/monitoring', '', '/control/systems/monitoring'],
+  ['/topology', '', '/control/topology'],
+  ['/ports', '', '/control/ports'],
+  ['/routes', '', '/control/routes'],
+  // /access defaulted to Routes in the code (`isTab(raw) ? raw : 'routes'`),
+  // whatever the plan document says. A bookmark must land where it landed.
+  ['/access', '', '/control/routes'],
+  ['/access', '?tab=routes', '/control/routes'],
+  ['/access', '?tab=ports', '/control/ports'],
+];
+for (const [path, search, want] of TABLE) {
+  check(`${path}${search}`, legacyTarget(path, search), want);
+}
+
+console.log('\n── the query string is not dropped ─────────────────────');
+
+// The one that matters: ?tab=ports and ?tab=routes must not collapse to the same
+// place. If they ever do, half the shared /access links are silently wrong.
+check('?tab=ports and ?tab=routes differ',
+  legacyTarget('/access', '?tab=ports') !== legacyTarget('/access', '?tab=routes'), true);
+// A leading '?' is optional - location.search carries one, a hand-written test
+// or a URL object's query may not.
+check('search works with or without the leading ?',
+  legacyTarget('/access', 'tab=ports'), '/control/ports');
+// Other parameters ride along without confusing the lookup.
+check('an unrelated parameter is ignored',
+  legacyTarget('/access', '?q=redis&tab=ports'), '/control/ports');
+// An unrecognised tab falls back the way the page itself did, rather than
+// resolving to nothing and dumping the reader on the not-found page.
+check('an unknown tab falls back to Routes',
+  legacyTarget('/access', '?tab=nonsense'), '/control/routes');
+
+console.log('\n── every registered legacy route resolves ──────────────');
+
+// App.tsx maps over LEGACY_PATHS to build the routes. A path in that list with
+// no mapping renders <NotFound> at a URL we promised to keep - the exact
+// bookmark break this file exists to prevent.
+const sample = (p) => '/' + p.replace(':id', 'x').replace(':name', 'y');
+for (const p of LEGACY_PATHS) {
+  const to = legacyTarget(sample(p));
+  check(`${p} -> something`, typeof to === 'string' && to.startsWith('/control'), true);
+}
+
+console.log('\n── no redirect points at a page we do not serve ────────');
+
+// Compare against the shapes the router registers, with the params put back.
+const shape = (path) =>
+  path.replace(/^\/control\/services\/[^/]+$/, '/control/services/:id')
+      .replace(/^\/control\/systems\/[^/]+$/, '/control/systems/:name');
+const live = new Set(LIVE_PATHS);
+for (const [path, search] of TABLE) {
+  const to = legacyTarget(path, search);
+  check(`${to} is a live route`, live.has(shape(to)), true);
+}
+
+console.log('\n── a path that was never ours is left alone ────────────');
+
+// legacyTarget must return null rather than inventing /control/<anything>, or
+// every typo'd URL would redirect to a made-up page instead of reaching the
+// not-found page that tells the reader the link is broken.
+for (const p of ['/', '/files', '/settings', '/control', '/control/ports', '/nonsense', '/servicesss']) {
+  check(`${p} is not a redirect`, legacyTarget(p), null);
+}
+// The trailing slash a pasted link often carries is the same page, not a miss.
+check('/services/ resolves like /services', legacyTarget('/services/'), '/control/services');
+// Percent-encoding is passed through untouched: lib/links.ts encodes on the way
+// out, and decoding here to re-encode there is how a name with a slash in it
+// stops resolving.
+check('an encoded id survives',
+  legacyTarget('/services/edge%2Ftraefik'), '/control/services/edge%2Ftraefik');
+
+console.log(bad ? `\n${bad} FAILED` : '\nall pass');
+process.exit(bad ? 1 : 0);

--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# Compile the (dependency-free) discover module and run the status truth table
-# against it, plus a pass over the box's real container list.
+# Compile the dependency-free modules and run their truth tables against them:
+# the status classifier and the dependency graph out of discover.ts, the retired
+# URLs out of pages/control/redirects.ts, plus a pass over the box's real
+# container list.
 #
 # There is no test runner in this app on purpose - one 13-case truth table did
-# not justify pulling vitest into a static SPA's toolchain. discover.ts imports
-# nothing, which is what makes this one-liner possible; if that ever stops being
-# true, that is the moment to add a real runner.
+# not justify pulling vitest into a static SPA's toolchain. Both modules import
+# NOTHING, which is what makes these one-liners possible, and it is why anything
+# worth checking here gets written as a module that imports nothing. If that ever
+# stops being true, that is the moment to add a real runner.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -13,10 +16,16 @@ WEB="$HERE/../web"
 OUT="$(mktemp -d)"
 trap 'rm -rf "$OUT"' EXIT
 
+# One invocation per module, not one with two inputs: with two, tsc's rootDir
+# becomes their common ancestor and it reproduces the source tree's directories
+# under --outDir, so the outputs stop being where the checks import them from.
 (cd "$WEB" && npx tsc src/lib/discover.ts --ignoreConfig \
   --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
 mv "$OUT/discover.js" "$OUT/discover.mjs"
-cp "$HERE/status-classifier.mjs" "$HERE/relations.mjs" "$OUT/"
+(cd "$WEB" && npx tsc src/pages/control/redirects.ts --ignoreConfig \
+  --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
+mv "$OUT/redirects.js" "$OUT/redirects.mjs"
+cp "$HERE/status-classifier.mjs" "$HERE/relations.mjs" "$HERE/redirect-table.mjs" "$OUT/"
 
 echo "── truth table ─────────────────────────────────────────"
 node "$OUT/status-classifier.mjs"
@@ -24,6 +33,10 @@ node "$OUT/status-classifier.mjs"
 echo
 echo "── relations ───────────────────────────────────────────"
 node "$OUT/relations.mjs"
+
+echo
+echo "── redirects ───────────────────────────────────────────"
+node "$OUT/redirect-table.mjs"
 
 echo
 echo "── this box, right now ─────────────────────────────────"

--- a/apps/portal-next/web/src/App.tsx
+++ b/apps/portal-next/web/src/App.tsx
@@ -1,42 +1,83 @@
-import { Link, Navigate, Route, Routes } from 'react-router-dom';
+import { Link, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { AppShell } from './components/AppShell';
 import { Overview } from './pages/Overview';
 import { Services } from './pages/Services';
 import { ServiceDetail } from './pages/ServiceDetail';
 import { ProjectDetail } from './pages/ProjectDetail';
-import { Access } from './pages/Access';
+import { Ports, Routes as RoutesPage } from './pages/Access';
 import { Topology } from './pages/Topology';
+import { Settings } from './pages/Settings';
 import { Files } from './pages/files/Files';
+import { ControlShell } from './pages/control/ControlShell';
+import { Control } from './pages/control/Control';
+import { LEGACY_PATHS, legacyTarget } from './pages/control/redirects';
 
 // Multi-page, one shared poll (lifted into <DataProvider> in main.tsx). The
-// AppShell is the persistent layout (one topbar - the sidebar was deleted);
-// pages render into its <Outlet>.
+// AppShell is the persistent layout (one topbar - the global sidebar was
+// deleted); pages render into its <Outlet>.
+//
+// Three top-level destinations now: Overview, Control, Files. Services, Access
+// and Topology were three renderings of ONE dataset holding three of the five
+// slots, which mis-stated what the box contains; they navigate from the Control
+// sidebar instead (pages/control/ControlShell.tsx). Settings is reachable from
+// the person menu rather than the nav - it is a destination you go to on
+// purpose, not one you scan.
 export function App() {
   return (
     <Routes>
       <Route element={<AppShell />}>
         <Route index element={<Overview />} />
-        <Route path="services" element={<Services />} />
-        <Route path="services/:id" element={<ServiceDetail />} />
-        <Route path="systems/:name" element={<ProjectDetail />} />
-        <Route path="access" element={<Access />} />
-        {/* /ports and /routes were separate pages and are bookmarked - and this
-            is a dashboard people link to from notes and chat, so breaking a
-            deep link is worse than carrying two redirects forever. `replace`
-            keeps the dead URL out of the history stack. */}
-        <Route path="ports" element={<Navigate to="/access?tab=ports" replace />} />
-        <Route path="routes" element={<Navigate to="/access?tab=routes" replace />} />
-        <Route path="topology" element={<Topology />} />
+
+        {/* The section shell renders the left nav and an <Outlet>; everything
+            under it is a child route so the nav never unmounts. */}
+        <Route path="control" element={<ControlShell />}>
+          <Route index element={<Control />} />
+          <Route path="services" element={<Services />} />
+          <Route path="services/:id" element={<ServiceDetail />} />
+          <Route path="systems/:name" element={<ProjectDetail />} />
+          <Route path="ports" element={<Ports />} />
+          <Route path="routes" element={<RoutesPage />} />
+          <Route path="topology" element={<Topology />} />
+        </Route>
+
+        <Route path="settings" element={<Settings />} />
+
         {/* BothyFiles - the explorer. `?root=` and `?path=` rather than path
             segments, so a file whose own path contains slashes needs no encoding
             games and a deep link survives being pasted into chat. */}
         <Route path="files" element={<Files />} />
+
+        {/* The retired URLs. Built from the table rather than listed again here,
+            so the router and pages/control/redirects.ts cannot disagree about
+            WHICH urls are covered - checks/redirects.mjs covers the half that can
+            still drift, namely where each one lands. This is a dashboard people
+            deep-link to from notes and chat, so breaking a bookmark is worse than
+            carrying redirects forever; /ports and /routes have been carrying
+            exactly this since they were folded into Access, and they are just
+            re-pointed. `replace` keeps the dead URL out of the history stack. */}
+        {LEGACY_PATHS.map((p) => (
+          <Route key={p} path={p} element={<Legacy />} />
+        ))}
+
         {/* A typo'd deep link used to render the Overview with the bad URL still
             in the bar, so a broken link looked like it had worked. */}
         <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>
   );
+}
+
+// One component for every retired URL, because half the mapping lives in the
+// query string: /access carried its view in `?tab=`, and a <Navigate to="/…">
+// written per route drops it. A redirect that loses a query parameter is a broken
+// link that answers 200.
+function Legacy() {
+  const loc = useLocation();
+  const to = legacyTarget(loc.pathname, loc.search);
+  // Unreachable unless the table and this route list have drifted apart, which
+  // is what the check exists to prevent. The not-found page rather than null: a
+  // blank screen is the one outcome worse than a redirect landing wrong.
+  return to ? <Navigate to={to} replace /> : <NotFound />;
 }
 
 function NotFound() {

--- a/apps/portal-next/web/src/components/AppShell.tsx
+++ b/apps/portal-next/web/src/components/AppShell.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import {
-  LayoutDashboard, Boxes, Waypoints, Share2, FolderTree,
+  LayoutDashboard, Gauge, FolderTree,
   Search, RefreshCw, Moon, Sun, Monitor,
 } from 'lucide-react';
 import { usePortal } from '../lib/data';
@@ -12,16 +12,18 @@ import { useScrollProgress, useScrollRestoration, useScrollShades } from '../lib
 import { Tooltip } from './Tooltip';
 import { Brand } from './Brand';
 import { CommandPalette } from './CommandPalette';
+import { UserMenu } from './UserMenu';
 
-// Five destinations. Ports and Routes were two views of "how do I reach this?"
-// and are now tabs inside /access. Files is last because it is the only
-// destination that is not about the running stack - it reads and writes the
-// box's own trees, which is a different job from watching containers.
+// Three destinations, and they are three DATASETS rather than three views.
+// Services, Access and Topology used to hold three of the five slots between
+// them while rendering one dataset - the merged node list - which mis-stated
+// what the box contains; they are now four entries in the Control sidebar. Files
+// keeps its own slot because it genuinely is a different dataset with a
+// different mental model: it reads and writes the box's own trees, which is a
+// different job from watching containers.
 const NAV = [
   { to: '/', label: 'Overview', Icon: LayoutDashboard, end: true },
-  { to: '/services', label: 'Services', Icon: Boxes, end: false },
-  { to: '/access', label: 'Access', Icon: Waypoints, end: false },
-  { to: '/topology', label: 'Topology', Icon: Share2, end: false },
+  { to: '/control', label: 'Control', Icon: Gauge, end: false },
   { to: '/files', label: 'Files', Icon: FolderTree, end: false },
 ];
 
@@ -120,10 +122,32 @@ export function AppShell() {
         <span className="scroll-rail-fill" style={{ transform: `scaleY(${progress})` }} />
       </div>
 
-      {/* Skip link - one Tab press to content. It mattered more with the
-          sidebar (6 stops); kept because it costs nothing and the nav is still
-          the first thing in the DOM. */}
-      <a href="#content" className="skip-link">Skip to content</a>
+      {/* Skip link - one Tab press to content, past the ten stops in this bar.
+          It matters again now that Control has a nav of its own inside the page.
+
+          THE onClick IS THE WHOLE THING, and without it this link had never
+          worked. The app is a <HashRouter>, so the fragment IS the route:
+          following `#content` sets location.hash to "content", react-router
+          normalises that to the path "/content", and the skip link - the app's
+          first tab stop, the one control an assistive-technology user reaches
+          first - navigated to the not-found page. It cannot be `href="#/…"`
+          either, because that is a route and not an element. So the href stays
+          as the honest statement of intent for anything reading the markup, and
+          the default is prevented and the target focused directly. `main` needs
+          tabIndex={-1} to be focusable at all; focusing rather than only
+          scrolling is what actually moves the keyboard into the page. */}
+      <a
+        href="#content"
+        className="skip-link"
+        onClick={(e) => {
+          e.preventDefault();
+          const el = document.getElementById('content');
+          el?.focus();
+          el?.scrollIntoView();
+        }}
+      >
+        Skip to content
+      </a>
 
       <header className="topbar">
         <NavLink to="/" className="brand" end aria-label="Bothy - overview">
@@ -169,15 +193,27 @@ export function AppShell() {
           </button>
         </Tooltip>
         <ThemeToggle />
+        {/* Last in the right cluster, and the only entry point to /settings -
+            which is why it is not a nav slot. */}
+        <UserMenu />
       </header>
 
-      {/* Route/page transition - a short fade+rise keyed on the path. `mode:wait`
-          lets the outgoing page finish before the next mounts, so pages never
-          overlap. Reduced-motion collapses the offset to a plain fade. */}
+      {/* Route/page transition - a short fade+rise keyed on the SECTION, not on
+          the path. `mode:wait` lets the outgoing page finish before the next
+          mounts, so pages never overlap. Reduced-motion collapses the offset to
+          a plain fade.
+
+          Keying on the full pathname re-mounted everything under <main> on every
+          navigation, and once Control had a sidebar in there that meant the
+          "persistent" nav faded out and back in on each of its own links - a
+          sidebar-shaped page element rather than a sidebar. The section shell
+          runs the same transition around its own <Outlet>, so moving within
+          Control still animates; it just animates the part that changed. */}
       <AnimatePresence mode="wait" initial={false}>
         <motion.main
-          key={loc.pathname}
+          key={loc.pathname.split('/')[1] ?? ''}
           id="content"
+          tabIndex={-1}
           className="content"
           initial={{ opacity: 0, y: reduce ? 0 : 10 }}
           animate={{ opacity: 1, y: 0 }}

--- a/apps/portal-next/web/src/components/CommandPalette.tsx
+++ b/apps/portal-next/web/src/components/CommandPalette.tsx
@@ -31,14 +31,22 @@ export interface Cmd {
 
 const GROUPS: Cmd['group'][] = ['Go to', 'Services', 'Systems'];
 
+// These point at the LIVE paths, not through the redirects. Every old URL still
+// resolves, so leaving them would have worked - and would have been a palette
+// telling you a page lives somewhere it does not, one bounce at a time.
+//
+// `Access` is kept as a searchable ALIAS rather than a destination. It was the
+// name of a page for months; someone who types it should land somewhere useful
+// instead of getting nothing, but the label says where they are actually going.
 const DESTINATIONS: Cmd[] = [
   { id: 'go-/', group: 'Go to', label: 'Overview', to: '/' },
-  { id: 'go-/services', group: 'Go to', label: 'Services', to: '/services' },
-  // Both spellings stay reachable by name even though they are one page now -
-  // someone who thinks "ports" should not have to know it was merged.
-  { id: 'go-/access', group: 'Go to', label: 'Access', sub: 'routes + ports', to: '/access?tab=routes' },
-  { id: 'go-/ports', group: 'Go to', label: 'Ports', sub: 'in Access', to: '/access?tab=ports' },
-  { id: 'go-/topology', group: 'Go to', label: 'Topology', to: '/topology' },
+  { id: 'go-/control', group: 'Go to', label: 'Control', sub: 'what is running, and how you reach it', to: '/control' },
+  { id: 'go-/services', group: 'Go to', label: 'Services', to: '/control/services' },
+  { id: 'go-/routes', group: 'Go to', label: 'Routes', sub: 'was Access', to: '/control/routes' },
+  { id: 'go-/ports', group: 'Go to', label: 'Ports', sub: 'was Access', to: '/control/ports' },
+  { id: 'go-/topology', group: 'Go to', label: 'Topology', to: '/control/topology' },
+  { id: 'go-/files', group: 'Go to', label: 'Files', to: '/files' },
+  { id: 'go-/settings', group: 'Go to', label: 'Settings', sub: 'who you are, and what that lets you do', to: '/settings' },
 ];
 
 export function CommandPalette({ open, onClose }: { open: boolean; onClose: () => void }) {

--- a/apps/portal-next/web/src/components/CommandPalette.tsx
+++ b/apps/portal-next/web/src/components/CommandPalette.tsx
@@ -56,7 +56,7 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
         id: `svc-${n.id}`,
         group: 'Services' as const,
         label: n.name,
-        sub: n.host || n.group,
+        sub: n.host || n.groupTitle,
         to: `/services/${encodeURIComponent(n.id)}`,
         status: n.status,
       }));

--- a/apps/portal-next/web/src/components/PortsTab.tsx
+++ b/apps/portal-next/web/src/components/PortsTab.tsx
@@ -51,7 +51,7 @@ export function PortsTab({
     const terms = [query, external].map((s) => s.toLowerCase().trim()).filter(Boolean);
     const matchText = (p: PortRow) =>
       terms.every((q) =>
-        `${p.hostPort} ${p.containerPort} ${p.container} ${p.group} ${p.image} ${p.scope}`
+        `${p.hostPort} ${p.containerPort} ${p.container} ${p.group} ${p.groupTitle} ${p.image} ${p.scope}`
           .toLowerCase()
           .includes(q),
       );
@@ -69,14 +69,19 @@ export function PortsTab({
     if (filter !== 'all') r = r.filter((p) => p.scope === filter);
     for (const q of terms)
       r = r.filter((p) =>
-        `${p.hostPort} ${p.containerPort} ${p.container} ${p.group} ${p.image} ${p.scope}`
+        `${p.hostPort} ${p.containerPort} ${p.container} ${p.group} ${p.groupTitle} ${p.image} ${p.scope}`
           .toLowerCase()
           .includes(q),
       );
     const { key, dir } = sort;
     r.sort((a, b) => {
-      const av = a[key] as string | number | undefined;
-      const bv = b[key] as string | number | undefined;
+      // Sort the Group column by what it DISPLAYS. Ordering by the hidden
+      // compose slug puts `auth` before `edge` while the screen reads
+      // "Identity · Keycloak" after "Edge · Traefik" - a sort that looks broken
+      // because the user cannot see the key it used.
+      const k = key === 'group' ? 'groupTitle' : key;
+      const av = a[k] as string | number | undefined;
+      const bv = b[k] as string | number | undefined;
       const cmp =
         typeof av === 'number' && typeof bv === 'number'
           ? av - bv
@@ -181,7 +186,7 @@ export function PortsTab({
                   </td>
                   <td className="mono">{r.containerPort}</td>
                   <td>{r.container}</td>
-                  {!compact && <td className="mono">{r.group}</td>}
+                  {!compact && <td>{r.groupTitle}</td>}
                   <td className="mono">{r.proto}</td>
                   <td>
                     <span className={`tag ${r.scope}`}>{r.scope === 'public' ? 'exposed' : 'loopback'}</span>

--- a/apps/portal-next/web/src/components/ServiceRow.tsx
+++ b/apps/portal-next/web/src/components/ServiceRow.tsx
@@ -34,7 +34,12 @@ export function ServiceRow({ node, showGroup = true }: { node: PortalNode; showG
           title={node.container?.statusText || unknownReason(node) || node.status}
         />
       </td>
-      {showGroup && <td className="mono">{node.group}</td>}
+      {/* The group's DISPLAY name, not its compose slug. This cell printed
+          `node.group` and so read `auth` while the Overview called the same
+          system `Identity · Keycloak` - the rename reached one surface out of
+          three. `groupTitle` is resolved once in discovery, so every surface
+          now agrees by construction rather than by remembering. */}
+      {showGroup && <td>{node.groupTitle}</td>}
       <td><span className={`tag ${kind.bad ? 'bad' : ''}`} title={kind.hint}>{kind.label}</span></td>
       <td className="mono">{node.ports.map((p) => p.hostPort).join(', ') || '-'}</td>
       <td className="mono svc-td-img">{node.container?.image || '-'}</td>

--- a/apps/portal-next/web/src/components/UserMenu.css
+++ b/apps/portal-next/web/src/components/UserMenu.css
@@ -1,0 +1,63 @@
+/* ============================================================================
+   The person control in the topbar. Builds ON the shared utilities in index.css
+   (.icon-btn .tag) and only carries the deltas, so a change to the topbar's
+   button shape reaches this one for free.
+
+   The panel is drawn to the command palette's recipe - --surface-4, a strong
+   line and --shadow-lg - because it is the same KIND of object: something that
+   floats over the page rather than another card sitting in it.
+
+   EVERY RULE IS SCOPED UNDER .user-menu, including the ones that only touch the
+   trigger. Not tidiness: `.user-btn` and `.icon-btn` are both one class, so a
+   bare `.user-btn { width: auto }` ties with index.css and loses on import
+   order - which it does, since index.css is imported by main.tsx after this
+   file's component. The measured symptom was the button staying a 38px square
+   and clipping the username. Two classes wins regardless of order.
+   ========================================================================== */
+
+.user-menu { position: relative; display: inline-flex; flex: none; }
+
+/* .icon-btn is a fixed 38px square built for a glyph alone. This one also
+   carries a name, so it grows sideways and keeps the square as its floor: the
+   control must not shift the row when the label is hidden at narrow widths. */
+.user-menu .user-btn { width: auto; min-width: 38px; grid-auto-flow: column; gap: 8px;
+  padding: 0 12px 0 10px; font: inherit; font-size: 13px; font-weight: 600; }
+.user-menu .user-btn:hover { color: var(--fg); border-color: var(--line-strong); }
+.user-menu .user-btn.on { color: var(--fg); background: var(--surface-2); border-color: var(--line-strong); }
+.user-menu .user-btn:disabled { cursor: default; }
+.user-menu .user-btn svg { flex: none; }
+
+/* A username is arbitrary text from the realm; without a ceiling one long
+   enough would push the search box off the row. */
+.user-menu .user-name { max-width: 14ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* 900px is where the topbar already drops its labels (the freshness pill, the
+   brand text, the search hint). This joins them rather than picking its own
+   breakpoint, so the row thins out in one step instead of four. */
+@media (max-width: 900px) {
+  .user-menu .user-name { display: none; }
+  .user-menu .user-btn { width: 38px; padding: 0; }
+}
+
+/* ── the panel ───────────────────────────────────────────────────────────── */
+.user-menu .um-panel { position: absolute; z-index: 60; top: calc(100% + 8px); right: 0;
+  min-width: 234px; padding: 6px; display: flex; flex-direction: column; gap: 2px;
+  background: var(--surface-4); border: 1px solid var(--line-strong);
+  border-radius: var(--r-lg); box-shadow: var(--shadow-lg); }
+
+.user-menu .um-who { display: flex; flex-direction: column; gap: 2px; padding: 8px 10px 10px;
+  margin-bottom: 4px; border-bottom: 1px solid var(--line); }
+.user-menu .um-who-name { font-size: 13.5px; font-weight: 700; color: var(--fg); }
+.user-menu .um-who-mail { font-size: 12px; color: var(--fg-subtle); overflow-wrap: anywhere; }
+.user-menu .um-roles { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 7px; }
+.user-menu .um-noroles { font-size: 11.5px; color: var(--fg-subtle); }
+
+.user-menu .um-item { display: flex; align-items: center; gap: 10px; padding: 8px 10px;
+  border-radius: var(--r-sm); font-size: 13.5px; color: var(--fg-muted); cursor: pointer; }
+.user-menu .um-item svg { flex: none; }
+.user-menu .um-item:hover { background: var(--surface-3); color: var(--fg); }
+/* The rows are inside a menu that traps Tab, so focus is the ONLY way most of
+   this panel is reached by keyboard. It gets the same weight as hover plus the
+   ring, not less. */
+.user-menu .um-item:focus-visible { background: var(--surface-3); color: var(--fg);
+  outline: 2px solid var(--ring); outline-offset: -2px; }

--- a/apps/portal-next/web/src/components/UserMenu.tsx
+++ b/apps/portal-next/web/src/components/UserMenu.tsx
@@ -1,0 +1,31 @@
+// The person control in the topbar's right cluster.
+//
+// STUB - the contract, not the implementation. It renders enough to be wired and
+// typechecked; the real menu is filled in separately. Keep the exported shape.
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { UserRound } from 'lucide-react';
+import { fetchMe, type Me } from '../lib/me';
+
+export function useMe(): { me: Me | null; loading: boolean } {
+  const [me, setMe] = useState<Me | null>(null);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    const ac = new AbortController();
+    fetchMe(ac.signal)
+      .then((m) => { if (!ac.signal.aborted) { setMe(m); setLoading(false); } })
+      .catch(() => { if (!ac.signal.aborted) setLoading(false); });
+    return () => ac.abort();
+  }, []);
+  return { me, loading };
+}
+
+export function UserMenu() {
+  const { me } = useMe();
+  return (
+    <Link className="hbtn user-btn" to="/settings" title={me ? me.preferredUsername : 'Sign in'}
+      aria-label={me ? `Settings - signed in as ${me.preferredUsername}` : 'Sign in'}>
+      <UserRound size={16} />
+    </Link>
+  );
+}

--- a/apps/portal-next/web/src/components/UserMenu.tsx
+++ b/apps/portal-next/web/src/components/UserMenu.tsx
@@ -1,11 +1,37 @@
 // The person control in the topbar's right cluster.
 //
-// STUB - the contract, not the implementation. It renders enough to be wired and
-// typechecked; the real menu is filled in separately. Keep the exported shape.
-import { useEffect, useState } from 'react';
+// Two states and no third: signed in it is a menu button carrying the name the
+// session says you have; signed out it is a link into the sign-in flow. There is
+// deliberately no visible "checking…" state - a control that reads "Sign in" for
+// eighty milliseconds and then reads "devssh" has told the user something false,
+// so the trigger holds the glyph alone until the answer lands and only then
+// grows a name.
+//
+// WHAT THE INTERFACE HIDES IS NEVER WHAT THE API ENFORCES. The roles this menu
+// lists are for the reader. Hiding a control that the user's role forbids saves
+// a round trip and a 403 and nothing else; the decision is taken at the edge by
+// a forwardAuth middleware reading a signed cookie, which never trusts the
+// browser. If this component is ever the only thing between a user and an
+// action, that action is unprotected.
+//
+// NO SHARED Tooltip HERE, and for a different reason than the one written down
+// in pages/files/ActivityBar.tsx (that one is about a 46px strip clipping the
+// bubble). Tooltip opens on `onFocusCapture` and draws inside its own wrapper -
+// so wrapping a menu button in it means the bubble pins itself open the instant
+// the menu takes focus, on top of the menu it just opened. `title` plus the
+// button's accessible name carries the same words; only the styling is lost.
+//
+// The keyboard model is OverflowMenu's (pages/files/Menu.tsx) on purpose, down
+// to the Tab trap. Two menus on one box that answer the arrow keys differently
+// is a worse cost than the duplication. They are not merged because that one is
+// scoped to `.bothy-files`, is driven by a MenuItem[] and knows about keyboard
+// chords; this one is a fixed identity block over two rows, and generalising it
+// into the same component would leave neither call site readable.
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { UserRound } from 'lucide-react';
-import { fetchMe, type Me } from '../lib/me';
+import { LogIn, LogOut, Settings2, UserRound } from 'lucide-react';
+import { fetchMe, signInHref, signOutHref, type Me } from '../lib/me';
+import './UserMenu.css';
 
 export function useMe(): { me: Me | null; loading: boolean } {
   const [me, setMe] = useState<Me | null>(null);
@@ -21,11 +47,151 @@ export function useMe(): { me: Me | null; loading: boolean } {
 }
 
 export function UserMenu() {
-  const { me } = useMe();
+  const { me, loading } = useMe();
+  const [open, setOpen] = useState(false);
+  const [at, setAt] = useState(0);
+  const btn = useRef<HTMLButtonElement | null>(null);
+  const list = useRef<HTMLDivElement | null>(null);
+  const wrap = useRef<HTMLDivElement | null>(null);
+  const id = useId();
+
+  const close = useCallback((toButton: boolean) => {
+    setOpen(false);
+    if (toButton) btn.current?.focus();
+  }, []);
+
+  // A pointer press outside. `pointerdown` rather than `click`, so the menu is
+  // gone before whatever sits under it reacts.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      if (wrap.current?.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    document.addEventListener('pointerdown', onDown, true);
+    return () => document.removeEventListener('pointerdown', onDown, true);
+  }, [open]);
+
+  // Focus lands on the first row when it opens, or the arrow keys look ignored.
+  useEffect(() => {
+    if (!open) return;
+    setAt(0);
+    list.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+  }, [open]);
+
+  const rows = () => Array.from(
+    list.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [],
+  );
+  const move = (to: number) => {
+    const r = rows();
+    if (!r.length) return;
+    const i = ((to % r.length) + r.length) % r.length;
+    setAt(i);
+    r[i]?.focus();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'Escape': e.preventDefault(); close(true); break;
+      case 'ArrowDown': e.preventDefault(); move(at + 1); break;
+      case 'ArrowUp': e.preventDefault(); move(at - 1); break;
+      case 'Home': e.preventDefault(); move(0); break;
+      case 'End': e.preventDefault(); move(rows().length - 1); break;
+      // Tab out of an open menu and the panel is still on screen with the focus
+      // somewhere behind it. So Tab moves within, like the arrows.
+      case 'Tab': e.preventDefault(); move(at + (e.shiftKey ? -1 : 1)); break;
+      default: break;
+    }
+  };
+
+  // Signed out. An <a>, never a button with an onClick: the sign-in flow is a
+  // full navigation through oauth2-proxy to Keycloak and back, so it wants the
+  // browser's own semantics - middle-click, Back, and a status bar that says
+  // where it goes.
+  if (!loading && !me) {
+    return (
+      // Wrapped in .user-menu even with no menu to open: every rule in the
+      // stylesheet is scoped under it, so an unwrapped trigger would be styled
+      // by .icon-btn alone and come out a 38px square with the label clipped.
+      <div className="user-menu">
+        <a className="icon-btn user-btn" href={signInHref()} title="Sign in">
+          <LogIn size={18} aria-hidden="true" />
+          <span className="user-name">Sign in</span>
+        </a>
+      </div>
+    );
+  }
+
+  const label = me ? `${me.preferredUsername} - account and roles` : 'Checking your session';
+
   return (
-    <Link className="hbtn user-btn" to="/settings" title={me ? me.preferredUsername : 'Sign in'}
-      aria-label={me ? `Settings - signed in as ${me.preferredUsername}` : 'Sign in'}>
-      <UserRound size={16} />
-    </Link>
+    <div className="user-menu" ref={wrap}>
+      <button
+        type="button"
+        ref={btn}
+        className={`icon-btn user-btn ${open ? 'on' : ''}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? id : undefined}
+        aria-label={label}
+        title={label}
+        // Nothing to open until the session answers, but the control keeps its
+        // size throughout so the topbar does not shuffle when it does.
+        disabled={!me}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <UserRound size={18} aria-hidden="true" />
+        {me && <span className="user-name">{me.preferredUsername}</span>}
+      </button>
+
+      {open && me && (
+        <div
+          className="um-panel"
+          role="menu"
+          id={id}
+          // The identity block below is not a menuitem, and a screen reader in
+          // menu mode may never read it - so who you are is said here, on the
+          // menu itself, as well as drawn in it.
+          aria-label={`Signed in as ${me.preferredUsername}`}
+          ref={list}
+          onKeyDown={onKeyDown}
+        >
+          <div className="um-who">
+            <span className="um-who-name">{me.preferredUsername}</span>
+            <span className="um-who-mail">{me.email}</span>
+            {/* The roles held, and only those - the full four with what each
+                permits is the Settings page's job, one row below. */}
+            <span className="um-roles">
+              {me.roles.length > 0
+                ? me.roles.map((r) => <span className="tag" key={r}>{r}</span>)
+                : <span className="um-noroles">No roles granted</span>}
+            </span>
+          </div>
+
+          <Link
+            className="um-item"
+            role="menuitem"
+            tabIndex={at === 0 ? 0 : -1}
+            to="/settings"
+            onFocus={() => setAt(0)}
+            onClick={() => close(false)}
+          >
+            <Settings2 size={15} aria-hidden="true" />
+            <span>Settings</span>
+          </Link>
+
+          <a
+            className="um-item"
+            role="menuitem"
+            tabIndex={at === 1 ? 0 : -1}
+            href={signOutHref()}
+            onFocus={() => setAt(1)}
+          >
+            <LogOut size={15} aria-hidden="true" />
+            <span>Sign out</span>
+          </a>
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/portal-next/web/src/index.css
+++ b/apps/portal-next/web/src/index.css
@@ -1050,6 +1050,17 @@ a.card:hover { transform: translateY(-3px); border-color: var(--line-strong);
 
 *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
 
+/* ...except the skip link's target. `<main id="content" tabindex="-1">` is
+   focused programmatically by the skip link (AppShell.tsx) and can never be
+   tabbed to, so the rule above drew a 2px accent rectangle around the ENTIRE
+   page - a viewport-sized frame whose whole message is "focus is here now", and
+   it stayed until the next keypress. The ring is restyled nowhere else in this
+   app and it is never removed from a control; this is a container, and the move
+   itself is the feedback: the landmark is announced, and the next Tab lands on a
+   real control with a ring of its own. Declared after the global rule because
+   both are (0,1,0) and the later one wins. */
+.content:focus, .content:focus-visible { outline: none; }
+
 /* ── forced colours (Windows High Contrast) ────────────────────────────────
    In forced-colours mode the OS replaces every colour we declare with its own
    palette. That is fine for text, and fatal for this app's small coloured

--- a/apps/portal-next/web/src/lib/discover.ts
+++ b/apps/portal-next/web/src/lib/discover.ts
@@ -295,6 +295,9 @@ export interface PortRow extends Port {
   container: string;
   image?: string;
   group: string;
+  /** The group's display name, same contract as PortalNode.groupTitle - the
+   *  Ports table is a third surface that was printing the raw slug. */
+  groupTitle: string;
   groupKind: string;
 }
 
@@ -442,6 +445,15 @@ export interface PortalNode {
   url: string | null;
   browsable: boolean;
   group: string;
+  /** The group's DISPLAY name - what a human should ever see. Resolved here, in
+   *  discovery, rather than at each render point, because the alternative is
+   *  what shipped: the Overview routed the group through a display-name lookup
+   *  and the Services and Access tables printed the raw compose slug, so one
+   *  system was called `Identity · Keycloak` on one page and `auth` on two
+   *  others. brand-core's "one word per concept" cannot hold if the word is
+   *  chosen per surface. Falls back to a title-cased slug, so it is never empty
+   *  and never needs a label to be correct. */
+  groupTitle: string;
   groupKind: string;
   parent: string | null;
   depth: number | null;
@@ -560,6 +572,16 @@ export function classify(container?: Container | null): Classification {
   }
   return { group: proj, groupKind: 'project' };
 }
+
+// Groups that are not systems and so cannot be named like one. `unmanaged` is
+// what classify() returns for a container with no compose labels - a `docker run`
+// nobody declared. It is not a system, it is *whatever did not match*, and
+// "Unmanaged" title-cased into a peer chip beside `Edge · Traefik` claims a
+// coherence it does not have. Named for what it is; systems.ts also sorts it last.
+export const RESIDUE_TITLES: Record<string, string> = {
+  unmanaged: 'Other containers',
+  host: 'Host processes',
+};
 
 const titleCase = (s: string): string =>
   String(s).replace(/[-_]+/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase());
@@ -968,6 +990,11 @@ function makeNode({
   const path = pick('path', '');
   const browsable = isBrowsable(host, container);
 
+  // Computed BEFORE the node literal because two fields need it: the slug the
+  // app keys everything by, and the name a human reads. Deriving the title at
+  // each render point instead is exactly the bug this replaces.
+  const group = pick('group', n.parent || (container ? cls.group : n.leaf || cls.group));
+
   const node: PortalNode = {
     id: route ? route.name : `container:${container?.Id?.slice(0, 12)}`,
     kind,
@@ -987,7 +1014,8 @@ function makeNode({
     // through to classify()'s 'host' sentinel - which filed Tals' own front-end
     // under a fabricated system, separate from api/auth/algo.tals.dev.test. Its
     // leaf IS its system name, so use that.
-    group: pick('group', n.parent || (container ? cls.group : n.leaf || cls.group)),
+    group,
+    groupTitle: names.get(group) || RESIDUE_TITLES[group] || titleCase(group),
     groupKind: pick('groupKind', n.parent ? 'project' : cls.groupKind),
     parent: n.parent,
     depth: n.depth,
@@ -1070,6 +1098,9 @@ export function portsOf(container?: Container | null): Port[] {
 // Every published port on the box, flattened - the collision map.
 export function allPorts(containers: Container[] = []): PortRow[] {
   const rows: PortRow[] = [];
+  // Same map merge() uses, so a port row and a service row can never disagree
+  // about what a system is called.
+  const names = projectNames(containers);
   for (const c of containers) {
     const cls = classify(c);
     for (const p of portsOf(c)) {
@@ -1078,6 +1109,7 @@ export function allPorts(containers: Container[] = []): PortRow[] {
         container: (c.Names?.[0] || '').replace(/^\//, ''),
         image: c.Image,
         group: cls.group,
+        groupTitle: names.get(cls.group) || RESIDUE_TITLES[cls.group] || titleCase(cls.group),
         groupKind: cls.groupKind,
       });
     }

--- a/apps/portal-next/web/src/lib/links.ts
+++ b/apps/portal-next/web/src/lib/links.ts
@@ -1,10 +1,16 @@
 import type { PortalNode } from './discover';
 
 // React Router decodes params for us, so encode on the way out only.
-export const serviceLink = (n: Pick<PortalNode, 'id'>) => `/services/${encodeURIComponent(n.id)}`;
+//
+// Both moved under /control when Services and Access became one section. The old
+// paths still resolve (pages/control/redirects.ts), so pointing these at them
+// would still WORK - it would just make every service click in the app a
+// redirect, and make these two functions a stale statement about where a service
+// page lives. One line each is cheaper than either.
+export const serviceLink = (n: Pick<PortalNode, 'id'>) => `/control/services/${encodeURIComponent(n.id)}`;
 // A "system" is a compose group (project OR stack service). Its domain page is
-// /systems/:group.
-export const systemLink = (group: string) => `/systems/${encodeURIComponent(group)}`;
+// /control/systems/:group.
+export const systemLink = (group: string) => `/control/systems/${encodeURIComponent(group)}`;
 
 // The one-line subtitle shown under a service name (host, else ports, else name).
 export function nodeSub(n: PortalNode): string {

--- a/apps/portal-next/web/src/lib/me.ts
+++ b/apps/portal-next/web/src/lib/me.ts
@@ -39,7 +39,12 @@ export interface Me {
   roles: Role[];
 }
 
-const KNOWN: Role[] = ['viewer', 'editor', 'operator', 'shell'];
+/** The four, in the order they are always shown - least privilege first, so the
+ *  Settings page reads as a ladder rather than as an unordered set. Exported
+ *  because the page enumerates all four and this narrows the token to them: two
+ *  copies of "which roles exist" is exactly how a UI comes to disagree with the
+ *  realm about what a role is. */
+export const ROLES: readonly Role[] = ['viewer', 'editor', 'operator', 'shell'];
 
 /** Null when signed out. Never throws for a 401 - being signed out is ordinary. */
 export async function fetchMe(signal?: AbortSignal): Promise<Me | null> {
@@ -57,7 +62,7 @@ export async function fetchMe(signal?: AbortSignal): Promise<Me | null> {
     email: raw.email ?? '',
     preferredUsername: raw.preferredUsername ?? raw.email ?? 'unknown',
     groups,
-    roles: KNOWN.filter((k) => groups.includes(k)),
+    roles: ROLES.filter((k) => groups.includes(k)),
   };
 }
 

--- a/apps/portal-next/web/src/lib/me.ts
+++ b/apps/portal-next/web/src/lib/me.ts
@@ -1,0 +1,69 @@
+// Who is signed in, and what they may do.
+//
+// THERE IS NO `/-/api/me`, AND THERE DOES NOT NEED TO BE. oauth2-proxy already
+// serves `/oauth2/userinfo` from the session cookie, and that route is already
+// published by `oauth2-endpoints@file` (PathPrefix(`/oauth2/`), priority 100) so
+// the login flow can reach its own callback. Measured against the live box, it
+// returns exactly the fields a settings page needs:
+//
+//   {"user":"<subject uuid>","email":"…","groups":["viewer","editor","operator",
+//    "offline_access","default-roles-devbox","uma_authorization"],
+//    "preferredUsername":"devssh"}
+//
+// Signed out it is a 401 rather than a body, which is the same first-class result
+// the file API already models - not an error, an invitation.
+//
+// THE ROLES HERE ARE FOR THE INTERFACE, NEVER FOR THE BOUNDARY. Hiding a button
+// the user's role forbids is a courtesy that saves a round trip and a 403; the
+// decision is taken at the edge by a forwardAuth middleware that reads a signed
+// cookie and never trusts anything the browser says. If this file is ever the
+// only thing standing between a user and an action, that action is unprotected.
+
+/** Roles the realm defines. `shell` is deliberately granted to nobody. */
+export type Role = 'viewer' | 'editor' | 'operator' | 'shell';
+
+export const ROLE_MEANING: Record<Role, string> = {
+  viewer: 'Read the box: browse files, search their contents, download bytes.',
+  editor: 'Change a file on disk. Saves write straight to the working tree.',
+  operator: 'Act on what is running - restart, stop and start a service.',
+  shell: 'An arbitrary terminal. Granted to nobody, on purpose.',
+};
+
+export interface Me {
+  user: string;
+  email: string;
+  preferredUsername: string;
+  /** Every group the token carries, Keycloak's own bookkeeping included. */
+  groups: string[];
+  /** Just the four the realm defines - what the interface actually reasons about. */
+  roles: Role[];
+}
+
+const KNOWN: Role[] = ['viewer', 'editor', 'operator', 'shell'];
+
+/** Null when signed out. Never throws for a 401 - being signed out is ordinary. */
+export async function fetchMe(signal?: AbortSignal): Promise<Me | null> {
+  const r = await fetch('/oauth2/userinfo', {
+    signal,
+    headers: { Accept: 'application/json' },
+    redirect: 'manual',
+  });
+  if (r.status === 401 || r.status === 403 || r.type === 'opaqueredirect') return null;
+  if (!r.ok) throw new Error(`identity lookup failed: ${r.status}`);
+  const raw = (await r.json()) as Partial<Me> & { groups?: string[] };
+  const groups = raw.groups ?? [];
+  return {
+    user: raw.user ?? '',
+    email: raw.email ?? '',
+    preferredUsername: raw.preferredUsername ?? raw.email ?? 'unknown',
+    groups,
+    roles: KNOWN.filter((k) => groups.includes(k)),
+  };
+}
+
+export const hasRole = (me: Me | null, role: Role): boolean => !!me?.roles.includes(role);
+
+/** Where to send someone who needs a session, returning them to this page. */
+export const signInHref = (): string =>
+  `/oauth2/sign_in?rd=${encodeURIComponent(location.pathname + location.search + location.hash)}`;
+export const signOutHref = (): string => '/oauth2/sign_out?rd=%2F';

--- a/apps/portal-next/web/src/lib/panels.ts
+++ b/apps/portal-next/web/src/lib/panels.ts
@@ -21,13 +21,16 @@ export interface Panel {
 export function panelize(nodes: PortalNode[], allNodes: PortalNode[] = nodes): Panel[] {
   const vis = nodes.filter((n) => !n.hidden);
 
-  // A project's display name comes from its own depth-1 node if labelled, so
-  // "cvops" can present as "CVOps" in breadcrumbs without a second label.
+  // A group's display name is read off the NODE. It used to be re-derived here
+  // from the labels - a third implementation of the same rule, after discover.ts
+  // and systems.ts - and three copies is how the Overview came to call a system
+  // `Identity · Keycloak` while two other pages called it `auth`.
+  //
+  // Built from `allNodes`, not `nodes`: the title has to survive a filter that
+  // excludes the one node carrying the label, which is the reason this function
+  // takes both lists in the first place.
   const nice = new Map<string, string>();
-  for (const n of allNodes) {
-    const L = n.container?.labels || {};
-    if (L['dev.portal.project']) nice.set(n.group, L['dev.portal.project']);
-  }
+  for (const n of allNodes) if (n.groupTitle) nice.set(n.group, n.groupTitle);
   const title = (g: string) =>
     nice.get(g) || g.replace(/[-_]/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase());
   const byOrder = (a: PortalNode, b: PortalNode) =>

--- a/apps/portal-next/web/src/lib/projects.ts
+++ b/apps/portal-next/web/src/lib/projects.ts
@@ -85,6 +85,10 @@ function nodeOf(project: CollectorProject, svc: CollectorService): PortalNode {
     url,
     browsable: url != null,
     group: project.key,
+    // A declared project brings its own display name, so it needs no lookup -
+    // which is the point of the field: every node carries the name a human
+    // should see, however that node came into existence.
+    groupTitle: project.name || project.key,
     groupKind: project.kind === 'stack' || project.kind === 'infra' ? project.kind : 'project',
     parent: null,
     depth: null,

--- a/apps/portal-next/web/src/lib/systems.ts
+++ b/apps/portal-next/web/src/lib/systems.ts
@@ -51,27 +51,21 @@ export interface System {
 
 const KIND_RANK: Record<SystemKind, number> = { project: 0, stack: 1, infra: 2 };
 
-// Groups that are not systems at all, and so cannot be named like one.
+// A system's display name now arrives ON THE NODE (`groupTitle`, resolved in
+// discover.ts) rather than being looked up again here. This function used to own
+// a second copy of that rule - label-or-title-case - and a third lived in
+// panels.ts, which is precisely how the Services and Access tables ended up
+// printing raw compose slugs while this page printed the pretty name.
 //
-// `unmanaged` is what classify() returns for a container with no compose labels
-// - a `docker run` that nobody declared. It is not a system, it is *whatever did
-// not match*, and "Unmanaged" title-cased into a peer chip beside Edge · Traefik
-// claims a coherence it does not have. Named for what it is, and sorted last.
-const RESIDUE: Record<string, string> = {
-  unmanaged: 'Other containers',
-  host: 'Host processes',
-};
-export const isResidue = (key: string) => key in RESIDUE;
+// The residue names (`unmanaged` -> "Other containers") moved with it. What
+// stays here is the SORT: residue belongs last, because it is not a system
+// competing for position, it is the remainder.
+import { RESIDUE_TITLES } from './discover';
 
-// A project's display name comes from its own labelled node if present, else a
-// title-cased group slug - same rule as panelize/discover, kept in one place.
-function niceTitle(group: string, nodes: PortalNode[]): string {
-  const labelled = nodes.find((n) => n.container?.labels?.['dev.portal.project']);
-  return (
-    labelled?.container?.labels?.['dev.portal.project'] ||
-    RESIDUE[group] ||
-    group.replace(/[-_]/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase())
-  );
+export const isResidue = (key: string) => key in RESIDUE_TITLES;
+
+function niceTitle(_group: string, nodes: PortalNode[]): string {
+  return nodes[0]?.groupTitle || _group;
 }
 
 // The system's kind = the kind of the MAJORITY of its nodes. They agree in

--- a/apps/portal-next/web/src/pages/Access.tsx
+++ b/apps/portal-next/web/src/pages/Access.tsx
@@ -1,65 +1,53 @@
-import { useSearchParams } from 'react-router-dom';
 import { usePortal } from '../lib/data';
 import { PortsTab } from '../components/PortsTab';
 import { RoutesTab } from '../components/RoutesTab';
-import { Tabs, TabPanel } from '../components/Tabs';
 
-// Ports and Routes were two pages answering one question: "how do I reach this
-// thing?" They shared a filter bar, a table, a sort model and a stylesheet, and
-// differed only in which column held the address. Two top-level destinations for
-// two views of the same subject is navigation spent on an implementation detail
-// - whether a service is reached through Traefik or through a published port is
-// exactly what the user came here to find out, not something they should have to
-// know before choosing a menu item.
+// Ports and Routes were two pages, then one page with two tabs, and are now two
+// entries in the Control sidebar. The merge was right about the question - both
+// answer "how do I reach this thing?" - and wrong about the shape: a tab HIDES.
+// You could not see that Ports existed until you had already landed on Access,
+// so the third navigation level was invisible from the second, which is the
+// defect docs/plans/control-and-settings.md §2 names. A sidebar entry is visible
+// from the section landing; a tab is not.
 //
-// The tab lives in ?tab= so a specific view stays linkable, and /ports and
-// /routes still resolve (App.tsx redirects them) because they are bookmarked.
+// So the pair keeps its shared components (PortsTab, RoutesTab, Tables.css) and
+// loses the tab strip. `?tab=` is gone with it - the view is a path again, which
+// is what it was in the first place, and every old URL including the query form
+// still resolves (pages/control/redirects.ts).
+//
+// The file is still Access.tsx because that is what these two are, together, and
+// a rename here is a diff across every import for no reader's benefit.
 
-type TabKey = 'routes' | 'ports';
-const isTab = (v: string | null): v is TabKey => v === 'routes' || v === 'ports';
-
-export function Access() {
+export function Ports() {
   const { data } = usePortal();
-  const [params, setParams] = useSearchParams();
-  const raw = params.get('tab');
-  const tab: TabKey = isTab(raw) ? raw : 'routes';
-
-  const setTab = (k: string) => {
-    const next = new URLSearchParams(params);
-    next.set('tab', k);
-    // replace: switching a tab is not a navigation step worth a Back press.
-    setParams(next, { replace: true });
-  };
-
   return (
     <div className="page">
       <div className="page-head">
         <div>
-          <h1>Access</h1>
+          <h1>Ports</h1>
           <p className="page-sub">
-            {tab === 'routes'
-              ? `${data.routers.length} Traefik routers · the escape hatch, nothing hidden`
-              : `${data.ports.length} published · the collision map (from Docker)`}
+            {data.ports.length} published · the collision map (from Docker)
           </p>
         </div>
       </div>
+      <PortsTab ports={data.ports} />
+    </div>
+  );
+}
 
-      <Tabs
-        label="How services are reached"
-        value={tab}
-        onChange={setTab}
-        tabs={[
-          { key: 'routes', label: 'Routes', count: data.routers.length },
-          { key: 'ports', label: 'Ports', count: data.ports.length },
-        ]}
-      />
-
-      <TabPanel tabKey="routes" active={tab === 'routes'}>
-        <RoutesTab routers={data.routers} nodes={data.nodes} />
-      </TabPanel>
-      <TabPanel tabKey="ports" active={tab === 'ports'}>
-        <PortsTab ports={data.ports} />
-      </TabPanel>
+export function Routes() {
+  const { data } = usePortal();
+  return (
+    <div className="page">
+      <div className="page-head">
+        <div>
+          <h1>Routes</h1>
+          <p className="page-sub">
+            {data.routers.length} Traefik routers · the escape hatch, nothing hidden
+          </p>
+        </div>
+      </div>
+      <RoutesTab routers={data.routers} nodes={data.nodes} />
     </div>
   );
 }

--- a/apps/portal-next/web/src/pages/ServiceDetail.tsx
+++ b/apps/portal-next/web/src/pages/ServiceDetail.tsx
@@ -38,7 +38,7 @@ export function ServiceDetail() {
   if (!node) {
     return (
       <div className="page detail">
-        <Link to="/services" className="back-link"><ChevronRight size={15} style={{ transform: 'rotate(180deg)' }} /> Services</Link>
+        <Link to="/control/services" className="back-link"><ChevronRight size={15} style={{ transform: 'rotate(180deg)' }} /> Services</Link>
         <div className="state"><h4>Service not found</h4><p>It may have stopped, or the page was reloaded from a stale link.</p></div>
       </div>
     );
@@ -70,7 +70,7 @@ export function ServiceDetail() {
   return (
     <div className="page detail" style={accStyle}>
       <nav className="crumbs" aria-label="Breadcrumb">
-        <Link to="/services">Services</Link>
+        <Link to="/control/services">Services</Link>
         <ChevronRight size={13} className="sep" aria-hidden="true" />
         <Link to={systemLink(node.group)}>{systemTitle}</Link>
         <ChevronRight size={13} className="sep" aria-hidden="true" />

--- a/apps/portal-next/web/src/pages/Services.tsx
+++ b/apps/portal-next/web/src/pages/Services.tsx
@@ -51,7 +51,16 @@ export function Services() {
   };
 
   const projectOptions = useMemo(
-    () => [...new Set(data.nodes.filter((n) => !n.hidden).map((n) => n.group))].sort(),
+    // [slug, display name]. The VALUE stays the compose slug - it is the filter
+    // key, and `?project=` in the URL must keep working - but the LABEL reads
+    // like every other surface. A dropdown offering `auth` next to a table
+    // saying "Identity · Keycloak" is the same one-name-per-system failure in
+    // miniature.
+    () => {
+      const seen = new Map<string, string>();
+      for (const n of data.nodes) if (!n.hidden) seen.set(n.group, n.groupTitle || n.group);
+      return [...seen.entries()].sort((a, b) => a[1].localeCompare(b[1]));
+    },
     [data.nodes],
   );
 
@@ -62,7 +71,7 @@ export function Services() {
     const vis = data.nodes.filter((n) => !n.hidden);
     const needle = q.trim().toLowerCase();
     const mText = (n: PortalNode) =>
-      !needle || `${n.name} ${n.host ?? ''} ${n.group} ${n.container?.image ?? ''}`.toLowerCase().includes(needle);
+      !needle || `${n.name} ${n.host ?? ''} ${n.group} ${n.groupTitle} ${n.container?.image ?? ''}`.toLowerCase().includes(needle);
     const mProject = (n: PortalNode) => project === 'all' || n.group === project;
     const mStatus = (n: PortalNode) => statusFilter.size === 0 || statusFilter.has(n.status);
     const isHost = (n: PortalNode) => n.route?.provider === 'file';
@@ -161,7 +170,7 @@ export function Services() {
           <span>Project</span>
           <select value={project} onChange={(e) => setProject(e.target.value)}>
             <option value="all">All ({projectAll})</option>
-            {projectOptions.map((p) => <option key={p} value={p}>{p} ({projectCounts.get(p) ?? 0})</option>)}
+            {projectOptions.map(([slug, label]) => <option key={slug} value={slug}>{label} ({projectCounts.get(slug) ?? 0})</option>)}
           </select>
         </label>
         <label className="filter-select">

--- a/apps/portal-next/web/src/pages/Settings.css
+++ b/apps/portal-next/web/src/pages/Settings.css
@@ -1,0 +1,83 @@
+/* ============================================================================
+   Settings page. Builds ON the shared utilities in index.css (.panel .panel-h
+   .panel-b .kv-list .kv .mono .tag .btn) and carries only the deltas, all scoped
+   under .settings-page so nothing leaks and the overrides win regardless of
+   import order.
+
+   Narrower than the 1320px shell. Almost everything here is a sentence, and a
+   sentence 1300px wide is one nobody finishes - the measure is the point.
+   ========================================================================== */
+
+.settings-page { max-width: 820px; display: flex; flex-direction: column; gap: 20px; }
+.settings-page .page-head { margin-bottom: 0; }
+
+/* .panel-h is written for a div; these are real headings, because a settings
+   page is a document someone navigates by landmark. Only the browser's default
+   heading margin and size have to be undone. */
+.settings-page .panel-h { margin: 0; font-size: 14px; }
+
+.settings-page .set-lede { color: var(--fg-muted); font-size: 13.5px; line-height: 1.55;
+  margin: 0 0 14px; }
+
+/* A note under a value: the sentence that says what the value is FOR. Quieter
+   than the value it explains, and on its own line, so the column of values
+   stays scannable. */
+.settings-page .set-note { display: block; margin-top: 3px; font-size: 12px;
+  color: var(--fg-subtle); line-height: 1.5; }
+.settings-page .set-sub { font-size: 12px; color: var(--fg-muted); }
+
+/* ── roles ───────────────────────────────────────────────────────────────── */
+.settings-page .roles { list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; }
+.settings-page .role { display: flex; gap: 12px; padding: 13px 0;
+  border-bottom: 1px solid var(--line); }
+.settings-page .role:first-child { padding-top: 0; }
+.settings-page .role:last-child { padding-bottom: 0; border-bottom: 0; }
+.settings-page .role-mark { flex: none; margin-top: 1px; }
+.settings-page .role-text { min-width: 0; }
+.settings-page .role-line { display: flex; align-items: baseline; gap: 9px; flex-wrap: wrap;
+  margin: 0 0 3px; }
+.settings-page .role-id { font-size: 13.5px; font-weight: 700; color: var(--fg); }
+.settings-page .role-state { font-size: 11px; font-weight: 700; letter-spacing: .03em;
+  text-transform: uppercase; padding: 2px 9px; border-radius: 999px; line-height: 1.35;
+  border: 1px solid var(--line); }
+.settings-page .role-why { margin: 0; font-size: 13px; color: var(--fg-muted); line-height: 1.5; }
+
+/* Held and not-held are STATE, which is the one thing the reserved status
+   palette is for. `--st-up` for held; `--st-off` for not - the quietest token in
+   the palette, chosen because failing to hold a role is not a fault and must not
+   read as one. Colour is never the only encoder here: the glyph differs
+   (CircleCheck / Circle / Ban) and the state is written out in words. */
+/* --st-up-fg, not --st-up. The token block in index.css says it outright: the
+   fill values are sized for large solid areas and `up` measures 2.50:1 on light
+   - "re-verify if any of these is ever used for a small glyph". A 17px stroked
+   icon is that case, and the -fg values are the ones that clear 4.5:1. */
+.settings-page .role[data-held='yes'] .role-mark { color: var(--st-up-fg); }
+.settings-page .role[data-held='yes'] .role-state { color: var(--st-up-fg);
+  border-color: color-mix(in oklab, var(--st-up) 34%, transparent); }
+.settings-page .role[data-held='no'] .role-mark { color: var(--st-off-fg); }
+.settings-page .role[data-held='no'] .role-state { color: var(--fg-subtle); }
+
+/* ── what is stored where ────────────────────────────────────────────────── */
+.settings-page .stores { list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; }
+.settings-page .store { padding: 13px 0; border-bottom: 1px solid var(--line); }
+.settings-page .store:first-child { padding-top: 0; }
+.settings-page .store:last-child { padding-bottom: 0; border-bottom: 0; }
+.settings-page .store-what { margin: 0; font-size: 13.5px; font-weight: 700; color: var(--fg); }
+.settings-page .store-where { display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  margin: 5px 0 6px; font-size: 12.5px; color: var(--fg-muted); }
+/* The store's own name, beside the plain-English answer rather than instead of
+   it: "This browser" is what the reader wants, "localStorage" is what they need
+   when they go looking for it. */
+.settings-page .store-store { font-size: 11.5px; color: var(--fg-subtle);
+  background: var(--surface-2); border: 1px solid var(--line);
+  border-radius: 999px; padding: 1px 9px; }
+.settings-page .store-why { margin: 0; font-size: 13px; color: var(--fg-muted); line-height: 1.55; }
+
+@media (max-width: 560px) {
+  /* At this width the 96px label column and the value column both end up too
+     narrow to hold a line, so the pair stacks. */
+  .settings-page .kv-list { grid-template-columns: 1fr; }
+  .settings-page .kv { gap: 2px; }
+}

--- a/apps/portal-next/web/src/pages/Settings.tsx
+++ b/apps/portal-next/web/src/pages/Settings.tsx
@@ -1,0 +1,22 @@
+// Settings - who you are, and what that lets you do.
+//
+// STUB - the contract, not the implementation.
+//
+// READ-ONLY ON PURPOSE, for now. The genuinely per-user facts (identity, roles)
+// come from the session and cannot be edited here; the genuinely per-browser
+// ones (theme, pane widths) are already localStorage and already correct. What
+// is missing is a store for preferences nobody has asked to keep yet, so this
+// page shows rather than sets until one exists.
+import { useMe } from '../components/UserMenu';
+
+export function Settings() {
+  const { me, loading } = useMe();
+  return (
+    <section className="page">
+      <h1>Settings</h1>
+      {loading ? <p>Checking your session…</p>
+        : me ? <p>Signed in as {me.preferredUsername} ({me.email}).</p>
+        : <p>You are not signed in.</p>}
+    </section>
+  );
+}

--- a/apps/portal-next/web/src/pages/Settings.tsx
+++ b/apps/portal-next/web/src/pages/Settings.tsx
@@ -1,22 +1,261 @@
 // Settings - who you are, and what that lets you do.
 //
-// STUB - the contract, not the implementation.
+// READ-ONLY, and that is the design rather than a stage it is passing through.
+// The page separates three things that the word "settings" usually collapses:
 //
-// READ-ONLY ON PURPOSE, for now. The genuinely per-user facts (identity, roles)
-// come from the session and cannot be edited here; the genuinely per-browser
-// ones (theme, pane widths) are already localStorage and already correct. What
-// is missing is a store for preferences nobody has asked to keep yet, so this
-// page shows rather than sets until one exists.
+//   · theme and pane widths belong to the BROWSER, live in localStorage, and are
+//     already correct there - a pane width is a fact about the screen you are
+//     sitting at, and following you to a phone would be the bug;
+//   · identity and roles belong to the USER, arrive with the session, and are
+//     changed in the realm rather than here;
+//   · everything else - a default root, a landing page, favourites - belongs
+//     nowhere yet, because no preference store exists.
+//
+// So the page says all three plainly. What it does NOT do is render a greyed-out
+// form labelled "coming soon": a control that cannot work is a promise the page
+// has no way to keep, and a sentence saying why is both shorter and true.
+//
+// A store would be a write path, and a write path is a threat model, an audit
+// trail and a boundary - see docs/plans/control-and-settings.md §6b. It is worth
+// paying for when there is a preference somebody actually wants kept, and this
+// page exists partly to make that moment obvious when it arrives.
+
+import { Ban, Circle, CircleCheck, LogIn } from 'lucide-react';
+import { ROLES, ROLE_MEANING, signInHref, type Me, type Role } from '../lib/me';
 import { useMe } from '../components/UserMenu';
+import { Skeleton } from '../components/states';
+import './Settings.css';
 
 export function Settings() {
   const { me, loading } = useMe();
+
   return (
-    <section className="page">
-      <h1>Settings</h1>
-      {loading ? <p>Checking your session…</p>
-        : me ? <p>Signed in as {me.preferredUsername} ({me.email}).</p>
-        : <p>You are not signed in.</p>}
+    <div className="page settings-page">
+      <div className="page-head">
+        <div>
+          <h1>Settings</h1>
+          <p className="page-sub">Who you are, what that lets you do, and where each of those facts is kept.</p>
+        </div>
+      </div>
+
+      {loading ? <Skeleton variant="panels" /> : me ? <You me={me} /> : <SignedOut />}
+
+      {/* Both of these are statements about the box, not about the visitor, so
+          they render whether or not there is a session to describe. Someone
+          signed out is the reader most likely to want to know where the sign-in
+          they are about to do actually goes. */}
+      <Session />
+      <Storage />
+    </div>
+  );
+}
+
+// The same shape ServiceDetail uses for a labelled fact, deliberately copied
+// rather than shared: it is six lines wrapping three divs, and a common module
+// for it would make two unrelated pages import each other's layout.
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="kv">
+      <div className="kv-k">{label}</div>
+      <div className="kv-v">{children}</div>
+    </div>
+  );
+}
+
+function SignedOut() {
+  return (
+    <section className="panel">
+      <h2 className="panel-h">You are not signed in</h2>
+      <div className="panel-b">
+        <p className="set-lede">
+          Nothing here knows who you are yet. Signing in returns you to this page, which will
+          then say which of the four roles your account holds and what each one permits.
+        </p>
+        <a className="btn primary" href={signInHref()}>
+          <LogIn size={15} aria-hidden="true" />
+          Sign in
+        </a>
+      </div>
+    </section>
+  );
+}
+
+function You({ me }: { me: Me }) {
+  // Everything the token carries that is NOT one of the four realm roles:
+  // Keycloak's own bookkeeping (`default-roles-devbox`, `uma_authorization`,
+  // `offline_access`). Noise most days, and exactly what you want to read on the
+  // day a token looks wrong - so it is shown, quietly, and never as a role.
+  const other = me.groups.filter((g) => !(ROLES as readonly string[]).includes(g));
+
+  return (
+    <>
+      <section className="panel">
+        <h2 className="panel-h">You</h2>
+        <div className="panel-b">
+          <div className="kv-list">
+            <Field label="Username">{me.preferredUsername}</Field>
+            <Field label="Email">{me.email || <span className="dim">none on the token</span>}</Field>
+            {/* The durable one, and the reason it is on the page at all: a
+                username can be renamed and an email reassigned, but every log
+                line and every token is about this. It is what to quote when one
+                of the other two disagrees with what a service thinks. Small and
+                muted, because it is the field you need on one day in a hundred. */}
+            <Field label="Subject">
+              <span className="mono set-sub">{me.user}</span>
+              <span className="set-note">
+                The durable identifier. The username and the email can change; this cannot.
+              </span>
+            </Field>
+            {other.length > 0 && (
+              <Field label="Other groups">
+                <span className="mono set-sub">{other.join(' · ')}</span>
+                <span className="set-note">Keycloak&rsquo;s own bookkeeping. None of these grants anything here.</span>
+              </Field>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="panel">
+        <h2 className="panel-h">
+          What you may do
+          {/* Not "3 of 4". One of the four is granted to nobody, so a
+              denominator would state a total that cannot be reached. */}
+          <span className="sub">{me.roles.length} held</span>
+        </h2>
+        <div className="panel-b">
+          {/* THE ONE RULE TO CARRY OUT OF THIS FILE: what the interface hides is
+              never what the API enforces. This list is a description of a token,
+              not a permission check. Every action on this box is gated at the
+              edge by a forwardAuth middleware reading a signed cookie, and a
+              role missing from this page has never stopped a request - it only
+              explains, in advance, the 403 that would have come back. */}
+          <ul className="roles">
+            {ROLES.map((r) => <RoleRow key={r} role={r} held={me.roles.includes(r)} />)}
+          </ul>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function RoleRow({ role, held }: { role: Role; held: boolean }) {
+  // `shell` is not an absence you can fix by asking. The realm defines it and
+  // grants it to nobody, on purpose, so rendering it as a plain "not held"
+  // beside `operator` would invite exactly the wrong question. Written as a
+  // condition rather than a constant because if it is ever granted, this page
+  // must say so rather than keep insisting nobody has it.
+  const ungrantable = role === 'shell' && !held;
+  const state = held ? 'Held' : ungrantable ? 'Granted to nobody' : 'Not held';
+  const Mark = held ? CircleCheck : ungrantable ? Ban : Circle;
+
+  return (
+    // Held and not-held are STATE, so the reserved status palette is legal here
+    // (--st-up for held, --st-off for not - the quiet token, because not holding
+    // a role is not a fault). Colour is still never the only encoder: the glyph
+    // differs, and the word is written out beside it.
+    <li className="role" data-held={held ? 'yes' : 'no'}>
+      <Mark size={17} className="role-mark" aria-hidden="true" />
+      <div className="role-text">
+        <p className="role-line">
+          <span className="role-id mono">{role}</span>
+          <span className="role-state">{state}</span>
+        </p>
+        <p className="role-why">{ROLE_MEANING[role]}</p>
+      </div>
+    </li>
+  );
+}
+
+function Session() {
+  // Built from the host actually being browsed rather than a baked-in address,
+  // because this box is reached at its tailnet IP and the SPA has no other way
+  // to know it. On a Vite dev server that resolves to localhost:8090 and points
+  // at nothing - which is consistent with the rest of identity here, since the
+  // session cookie is host-only and there is no session on localhost either.
+  //
+  // The account console is linked because it was checked: /realms/devbox/account
+  // answers 200 over plain HTTP. Keycloak's /admin does not - it refuses without
+  // HTTPS on this box - so that one is deliberately not offered.
+  const kc = `http://${location.hostname}:8090`;
+
+  return (
+    <section className="panel">
+      <h2 className="panel-h">Where this session comes from</h2>
+      <div className="panel-b">
+        <div className="kv-list">
+          <Field label="Issued by">
+            Keycloak, realm <span className="mono">devbox</span>, at <span className="mono">{kc}</span>
+            <span className="set-note">
+              <a className="link" href={`${kc}/realms/devbox/account`}>Account console</a>
+              {' '}- password, sessions and devices are changed there, not here.
+            </span>
+          </Field>
+          <Field label="Carried by">
+            oauth2-proxy, asked by Traefik on every request
+            <span className="set-note">
+              A host-only cookie. No cookie domain is set, because every service on this box is a
+              different port on one host - so a session on the box&rsquo;s address is not a session on
+              localhost.
+            </span>
+          </Field>
+          <Field label="Enforced by">
+            <span className="mono">sso-viewer</span> and <span className="mono">sso-editor</span>,
+            forwardAuth middlewares at the edge
+            <span className="set-note">
+              Not by this page. The list above describes your token; the refusal, when it comes,
+              is decided before a request ever reaches an application.
+            </span>
+          </Field>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const STORES = [
+  {
+    what: 'Theme, and the widths of the panes in Files',
+    where: 'This browser',
+    store: 'localStorage',
+    why: 'Per browser is the right home for these, not a limitation. A pane width is a fact about the '
+      + 'screen you are sitting at; carrying it to a phone would be the bug. They are changed where '
+      + 'they are used - the theme button in the topbar, the panes themselves - rather than here.',
+  },
+  {
+    what: 'Your username, email, subject id and roles',
+    where: 'Your account',
+    store: 'Keycloak',
+    why: 'Per user, and read-only here. They arrive with the session and are changed in the realm. '
+      + 'This page has no way to write them, which is the point.',
+  },
+  {
+    what: 'A default root, a landing page, a list of favourites',
+    where: 'Nowhere',
+    store: 'no store exists',
+    why: 'Deliberately not built. None of these has been asked for yet, and a preference store is a '
+      + 'write path - which needs a threat model, an audit trail and a boundary before it needs a form.',
+  },
+];
+
+function Storage() {
+  return (
+    <section className="panel">
+      <h2 className="panel-h">What is stored where</h2>
+      <div className="panel-b">
+        <ul className="stores">
+          {STORES.map((s) => (
+            <li className="store" key={s.what}>
+              <p className="store-what">{s.what}</p>
+              <p className="store-where">
+                {s.where}
+                <span className="mono store-store">{s.store}</span>
+              </p>
+              <p className="store-why">{s.why}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
     </section>
   );
 }

--- a/apps/portal-next/web/src/pages/control/Control.tsx
+++ b/apps/portal-next/web/src/pages/control/Control.tsx
@@ -1,0 +1,180 @@
+// ── the Control landing ──────────────────────────────────────────────────────
+//
+// One question: what would you click next. Not a fourth copy of the Overview's
+// counts, and not a grid of destination cards - the sidebar two centimetres to
+// the left IS the destination list, and drawing it again in bigger boxes is the
+// footprint rule inverted (principles.md rule 3: an element's size is
+// proportional to how many facts it carries, and a card that carries a label a
+// nav item already carries carries none).
+//
+// docs/plans/control-and-settings.md offered a redirect to Services as the
+// acceptable outcome if this page could not say anything new. It can, and this is
+// the whole justification for it existing:
+//
+//   · PORT COLLISIONS appear NOWHERE else in the app. The Ports table is sorted
+//     by port, so two rows on 8080 are adjacent and readable - but only if you
+//     went to look;
+//   · a DISABLED ROUTER is one badge in one column of a table nobody opens until
+//     something is already broken;
+//   · services needing a look are on the Overview, but there they are a flat
+//     list of service names. Here they are grouped by SYSTEM and they link into
+//     this section, which is a different question ("which system do I open")
+//     answered with the same data.
+//
+// When there is nothing to say, this page says nothing. That is deliberate and
+// it is the shape the Overview's attention strip already has: a section that is
+// invisible on a healthy box and impossible to miss on a sick one. An empty
+// triage page is not a design failure - it is the report.
+
+import { useMemo, type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { AlertTriangle, ArrowRight, Plug, Waypoints } from 'lucide-react';
+import { usePortal, needsAttention } from '../../lib/data';
+import { systemLink } from '../../lib/links';
+import { StatusIcon } from '../../lib/icons';
+import { Skeleton } from '../../components/states';
+import './control.css';
+
+interface Finding {
+  key: string;
+  /** Where the fix lives - always inside this section. */
+  to: string;
+  /** The sidebar entry that owns it, named so the row says where it is going. */
+  where: string;
+  icon: ReactNode;
+  subject: string;
+  what: string;
+}
+
+export function Control() {
+  const { data } = usePortal();
+
+  const findings = useMemo<Finding[]>(() => {
+    const out: Finding[] = [];
+
+    // 1. Systems with something wrong. `needsAttention` rather than a rule of
+    //    this page's own: it is the one place that knows a stopped system's
+    //    wreckage is not news, and lib/data.tsx exists so the health maths is
+    //    computed one way everywhere. Grouped by system because the answer to
+    //    "what do I open" is a system page, not six service pages.
+    const bySystem = new Map<string, { title: string; n: number; worst: string }>();
+    for (const n of needsAttention(data.nodes)) {
+      const cur = bySystem.get(n.group) ?? { title: n.groupTitle || n.group, n: 0, worst: '' };
+      cur.n += 1;
+      // `down` outranks a dangling route in what it makes you do next.
+      if (n.status === 'down') cur.worst = 'down';
+      else if (!cur.worst) cur.worst = 'no container';
+      bySystem.set(n.group, cur);
+    }
+    for (const [group, s] of bySystem) {
+      out.push({
+        key: `sys:${group}`,
+        to: systemLink(group),
+        where: 'Services',
+        icon: <StatusIcon status={s.worst === 'down' ? 'down' : 'unknown'} size={15} />,
+        subject: s.title,
+        what: `${s.n} service${s.n === 1 ? '' : 's'} ${s.worst === 'down' ? 'down' : 'routed to nothing'}`,
+      });
+    }
+
+    // 2. Ports that collide. Grouped by PORT AND PROTOCOL, across bind
+    //    addresses on purpose: 0.0.0.0 covers loopback, so a container on
+    //    0.0.0.0:8080 and another on 127.0.0.1:8080 are a genuine overlap even
+    //    though the two rows do not look identical. Two rows for the same
+    //    container (docker reports tcp and udp, or the same port twice) are not
+    //    a collision, which is why the test counts distinct CONTAINERS.
+    const byPort = new Map<string, Set<string>>();
+    for (const p of data.ports) {
+      const k = `${p.hostPort}/${p.proto}`;
+      let seen = byPort.get(k);
+      if (!seen) byPort.set(k, (seen = new Set()));
+      seen.add(p.container);
+    }
+    for (const [k, containers] of byPort) {
+      if (containers.size < 2) continue;
+      out.push({
+        key: `port:${k}`,
+        to: '/control/ports',
+        where: 'Ports',
+        icon: <Plug size={15} aria-hidden="true" />,
+        subject: k,
+        what: `claimed by ${[...containers].join(' and ')}`,
+      });
+    }
+
+    // 3. Routers Traefik itself has switched off. A field read, not a rule -
+    //    the Routes table's State column derives 'no container' and 'unknown'
+    //    from the node graph, and re-deriving those here would be a second copy
+    //    of a rule that is already hard to keep honest. Whatever Traefik says is
+    //    not `enabled` is Traefik's own report of a route it will not serve, and
+    //    it is the only fault class on this page with no other surface at all.
+    for (const r of data.routers) {
+      if (!r.status || r.status === 'enabled') continue;
+      out.push({
+        key: `router:${r.name}`,
+        to: '/control/routes',
+        where: 'Routes',
+        icon: <Waypoints size={15} aria-hidden="true" />,
+        subject: String(r.name).split('@')[0],
+        what: `router is ${r.status}`,
+      });
+    }
+
+    return out;
+  }, [data.nodes, data.ports, data.routers]);
+
+  // Which sources answered. A page that reports "nothing is wrong" while the
+  // socket proxy is unreachable is claiming to know something it does not, and
+  // honesty outranks everything but accessibility (principles.md).
+  const degraded = useMemo(
+    () => [...new Set(data.errors.map((e) => e.src.split(' ')[0]))],
+    [data.errors],
+  );
+  const loading = data.at === 0 && data.fails === 0;
+
+  return (
+    <div className="page control-page">
+      <div className="page-head">
+        <div>
+          <h1>Control</h1>
+          <p className="page-sub">Everything that is running, and how you reach it.</p>
+        </div>
+      </div>
+
+      {loading ? (
+        <Skeleton />
+      ) : (
+        <>
+          {degraded.length > 0 && (
+            <p className="ctl-degraded">
+              <AlertTriangle size={14} aria-hidden="true" />
+              {degraded.join(' and ')} unreachable - this covers only what is still visible.
+            </p>
+          )}
+
+          {findings.length === 0 ? (
+            <p className="ctl-clear">
+              <StatusIcon status="up" size={15} />
+              Nothing in here needs a look. No system is reporting a fault, no two
+              containers are claiming the same port, and every router is enabled.
+            </p>
+          ) : (
+            <ul className="ctl-findings">
+              {findings.map((f) => (
+                <li key={f.key}>
+                  <Link className="ctl-finding" to={f.to}>
+                    <span className="ctl-f-ico">{f.icon}</span>
+                    <span className="ctl-f-subject">{f.subject}</span>
+                    <span className="ctl-f-what">{f.what}</span>
+                    <span className="ctl-f-where">{f.where}</span>
+                    <ArrowRight size={14} className="ctl-f-arrow" aria-hidden="true" />
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/portal-next/web/src/pages/control/ControlShell.tsx
+++ b/apps/portal-next/web/src/pages/control/ControlShell.tsx
@@ -1,0 +1,135 @@
+// ── the Control section, and its left nav ────────────────────────────────────
+//
+// Services, Ports, Routes and Topology are four renderings of ONE dataset - the
+// merged node list - and they had three top-nav slots and a hidden tab layer
+// between them. They now share one slot and navigate from here.
+//
+// A SIDEBAR IS A NAMED DEAD END IN THIS DESIGN SYSTEM (brand/foundations/
+// space-and-layout.md: "a 236px sidebar, deleted - five navigation items over
+// roughly 793 pixels of empty column, at every width, on every page"). This is
+// deliberately not that, and the differences are the whole argument:
+//
+//   · it is SCOPED. It exists inside one section rather than beside every page,
+//     and it replaces three top-nav slots plus a tab strip rather than adding to
+//     them - the item count across the app goes down, not up;
+//   · it COLLAPSES to a 46px icon strip and remembers that you collapsed it, so
+//     the empty column is a choice rather than a tax. That is the activity strip
+//     from Bothy Files, which is the pattern this propagates;
+//   · below 900px it stops being a column at all and becomes the same horizontal
+//     scroller the topbar nav already is.
+//
+// It carries NO counts or status marks. A "3" beside Routes would be the one
+// piece of chrome in the app that encodes state, which principles.md forbids in
+// as many words; the faults live one click away on the section landing, which is
+// a page whose whole job is to carry them.
+
+import { useCallback, useEffect, useState } from 'react';
+import { NavLink, Outlet, useLocation } from 'react-router-dom';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { Boxes, Gauge, PanelLeftClose, PanelLeftOpen, Plug, Share2, Waypoints } from 'lucide-react';
+import './control.css';
+
+// Ports before Routes, which reverses the old tab order. The tabs defaulted to
+// Routes; a LIST reads top-down and ports are the concrete thing (a number you
+// type) while routes are the edge's own model of the box, so ports first is the
+// order of increasing indirection. /access with no ?tab still lands on Routes -
+// see redirects.ts. Topology is last because it is the expensive one.
+const NAV = [
+  { to: '/control/services', label: 'Services', Icon: Boxes },
+  { to: '/control/ports', label: 'Ports', Icon: Plug },
+  { to: '/control/routes', label: 'Routes', Icon: Waypoints },
+  { to: '/control/topology', label: 'Topology', Icon: Share2 },
+];
+
+// Versioned like panes.ts's key, for the same reason: a shape change should be a
+// reset rather than a crash on somebody's three-week-old localStorage.
+const KEY = 'bothy-control-nav-v1';
+
+function useCollapsed(): [boolean, () => void] {
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem(KEY) === '1';
+    } catch {
+      // Private mode, a full quota, a hand-edited value - none of them are a
+      // reason for the section not to render.
+      return false;
+    }
+  });
+  useEffect(() => {
+    try { localStorage.setItem(KEY, collapsed ? '1' : '0'); } catch { /* not fatal */ }
+  }, [collapsed]);
+  return [collapsed, useCallback(() => setCollapsed((c) => !c), [])];
+}
+
+export function ControlShell() {
+  const [collapsed, toggle] = useCollapsed();
+  const loc = useLocation();
+  const reduce = useReducedMotion();
+
+  // There is no keyboard shortcut for the collapse, and that is a decision
+  // rather than an omission: every chord this app dispatches is written down in
+  // pages/files/keys.ts and shown to the user in two places, so a binding added
+  // without a row there would make the Keys sheet lie. The toggle is a real
+  // button in the first tab stop of the section, which is enough for one control.
+  return (
+    <div className="control-sec" data-collapsed={collapsed ? 'true' : 'false'}>
+      {/* `aria-label` rather than a visible heading: the section is titled by the
+          Control link inside it, and a second <h1> above the page's own would
+          give every page here two. NavLink sets aria-current="page" on the
+          active entry by itself - that is the whole reason these are NavLinks
+          and not Links. */}
+      <nav className="ct-nav scroll-shade" aria-label="Control">
+        <NavLink to="/control" end className={({ isActive }) => `ct-item ct-home ${isActive ? 'on' : ''}`} title="Control">
+          <Gauge size={16} aria-hidden="true" />
+          <span className="ct-label">Control</span>
+        </NavLink>
+
+        {NAV.map(({ to, label, Icon }) => (
+          <NavLink
+            key={to}
+            to={to}
+            // `title` is the label's fallback for touch, where neither hover nor
+            // focus-visible fires - the same third fallback the topbar nav uses,
+            // and the only label at all when this is collapsed.
+            title={label}
+            className={({ isActive }) => `ct-item ${isActive ? 'on' : ''}`}
+          >
+            <Icon size={16} aria-hidden="true" />
+            <span className="ct-label">{label}</span>
+          </NavLink>
+        ))}
+
+        <button
+          type="button"
+          className="ct-collapse"
+          onClick={toggle}
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? 'Show the Control menu labels' : 'Collapse the Control menu'}
+          title={collapsed ? 'Expand' : 'Collapse'}
+        >
+          {collapsed ? <PanelLeftOpen size={15} aria-hidden="true" /> : <PanelLeftClose size={15} aria-hidden="true" />}
+          <span className="ct-label">Collapse</span>
+        </button>
+      </nav>
+
+      {/* The page transition moved DOWN here. AppShell keys its <main> on the
+          first path segment now, so arriving in Control animates the section
+          once; moving between these four entries animates only the body, and the
+          nav beside it does not flash on every click. A "persistent sidebar" that
+          re-mounts and fades in on each navigation is not persistent, it is a
+          sidebar-shaped page element. */}
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          key={loc.pathname}
+          className="ct-body"
+          initial={{ opacity: 0, y: reduce ? 0 : 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: reduce ? 0 : -6 }}
+          transition={{ duration: 0.18, ease: [0.2, 0.7, 0.2, 1] }}
+        >
+          <Outlet />
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/apps/portal-next/web/src/pages/control/control.css
+++ b/apps/portal-next/web/src/pages/control/control.css
@@ -8,36 +8,88 @@
    pages/files/shell.css is written the way it is.
    ========================================================================== */
 
-/* `auto` on the first track, not a fixed width: the nav states its own width
-   (and changes it when collapsed) and the body takes the rest. minmax(0, 1fr)
-   rather than 1fr on the body, because `auto` as the implicit minimum lets one
-   unwrapped mono cell in the ports table set the column's minimum width and push
-   the page sideways - the single most common mysterious-overflow bug in grid.
+/* ── A FIXED-HEIGHT SECTION, not a tall page ─────────────────────────────────
 
-   `align-items: start` so the nav is its own height. A nav stretched to the
-   height of the Topology page would be 900px of empty column, which is the exact
-   thing the deleted global sidebar was deleted for. */
+   The first version scrolled as one document: the nav sat in normal flow and
+   went up with the page, and the body was capped by `.content`'s 1320px and
+   centred, so on a wide screen the nav floated ~90px in from the left edge with
+   whitespace either side of everything.
+
+   It was written NOT sticky, deliberately, and that reasoning was sound as far
+   as it went: `position: sticky` needs a `top`, the only correct value is the
+   topbar's height, and nothing in this app states that as a number - it is
+   padding plus whatever the tallest control happens to be, changing at two
+   breakpoints. shell.css already refused to measure it in JS.
+
+   The way out is not a better guess. It is to stop the page scrolling at all.
+   `pages/files/shell.css` does exactly this and says why: with `:has()` the
+   shell "stops being min-height: 100vh and becomes exactly 100vh, so its flex:1
+   child is handed precisely the space that is left". The topbar is then a flex
+   ROW rather than an overlay, so there is no offset to know - the nav simply
+   cannot go under it. Every region owns its own scrollbar.
+
+   100dvh, not 100vh: on a phone the browser chrome is part of vh, so 100vh puts
+   the last nav entry under the URL bar. Files predates dvh support; this does
+   not have to. */
+.shell:has(.control-sec) { height: 100dvh; min-height: 0; overflow: hidden; }
+
+/* `.content` is `max-width: 1320px; margin: 0 auto; padding: 26px 30px` for
+   ordinary pages, and every one of those is wrong for a shell: the max-width is
+   what held the body away from the right edge, the auto margins are what held
+   the nav away from the left, and the padding belongs to the regions now,
+   because they scroll independently and a shared pad would scroll with one of
+   them. */
+.shell:has(.control-sec) .content {
+  max-width: none;
+  padding: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
+}
+
+/* minmax(0, 1fr) rather than 1fr on the body, because `auto` as the implicit
+   minimum lets one unwrapped mono cell in the ports table set the column's
+   minimum width and push the page sideways - the single most common mysterious
+   overflow bug in grid.
+
+   `align-items: stretch` now, not `start`: both columns are full height and each
+   scrolls itself. The old comment warned a stretched nav would be "900px of
+   empty column"; that was true when the column was empty space, and is not when
+   the column is a scroll region with its own end. */
 .control-sec {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  gap: 26px;
-  align-items: start;
+  align-items: stretch;
+  height: 100%;
+  min-height: 0;
 }
 
-/* NOT sticky. The offset a sticky nav needs here is the height of the topbar,
-   and nothing in this app states that as a number: it is padding plus whatever
-   the tallest control happens to be, and it changes at two breakpoints.
-   shell.css already refused to measure it in JS ("a measurement race, and the one
-   thing space-and-layout.md says a layout must not depend on"), and a guessed
-   `top` slides the first entries under a blurred bar - a nav you cannot click is
-   worse than a nav you have to scroll back to. Four entries; scroll back up. */
+/* Its own scroll region, so more entries can be added below without the section
+   growing a second scrollbar or pushing the body down. The border replaces the
+   26px gap: at this width a rule reads as a boundary and whitespace reads as a
+   mistake. */
 .control-sec .ct-nav {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  width: 174px;
+  width: 186px;
   min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 14px 10px 18px;
+  border-right: 1px solid var(--line);
+  background: var(--surface-0, transparent);
   transition: width var(--dur) var(--ease);
+}
+
+/* THE BODY SCROLLS, NOT THE PAGE. min-height: 0 is load-bearing - without it a
+   grid item's implicit `auto` minimum is its content height, the item refuses to
+   shrink, and the overflow silently moves back to the page. */
+.control-sec .ct-body {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 24px 30px 64px;
 }
 .control-sec[data-collapsed='true'] .ct-nav { width: 46px; }
 
@@ -97,7 +149,6 @@
 .control-sec[data-collapsed='true'] .ct-collapse { justify-content: center; padding: 8px 0; }
 .control-sec[data-collapsed='true'] .ct-home { padding-bottom: 10px; }
 
-.control-sec .ct-body { min-width: 0; }
 
 /* ── narrow ──────────────────────────────────────────────────────────────────
    900px, which is where the topbar already sheds the freshness pill and the
@@ -112,8 +163,18 @@
    `[data-collapsed]` with no value on the ones that override them. The COLLAPSED
    state is ignored here on purpose: a horizontal strip of five unlabelled
    squares is not a saving, and there is no column left to reclaim. */
+/* Below 900px the nav becomes a horizontal strip above the body, so the
+   two-region layout has nothing left to hold apart - and a fixed-height shell on
+   a phone fights the browser's own chrome. Hand the page back its scroll. */
 @media (max-width: 900px) {
-  .control-sec { grid-template-columns: minmax(0, 1fr); gap: 16px; }
+  .shell:has(.control-sec) { height: auto; min-height: 100vh; overflow: visible; }
+  .shell:has(.control-sec) .content { display: block; padding: 20px 16px 60px; }
+  .control-sec { grid-template-columns: minmax(0, 1fr); gap: 16px; height: auto; }
+  .control-sec .ct-nav {
+    height: auto; overflow-y: hidden; padding: 0;
+    border-right: 0; border-bottom: 1px solid var(--line);
+  }
+  .control-sec .ct-body { overflow-y: visible; padding: 0; }
   .control-sec[data-collapsed] .ct-nav {
     width: auto; flex-direction: row; align-items: center; gap: 2px;
     overflow-x: auto; overflow-y: hidden;

--- a/apps/portal-next/web/src/pages/control/control.css
+++ b/apps/portal-next/web/src/pages/control/control.css
@@ -1,0 +1,211 @@
+/* ============================================================================
+   The Control section - a two-column shell with a persistent left nav.
+
+   SCOPING. Every rule is `.control-sec <something>` - (0,2,0) or better, which
+   beats index.css's single-class rules REGARDLESS of import order. That is not
+   paranoia: main.tsx imports ./App before ./index.css, so Vite emits index.css
+   last and a (0,1,0) rule here would lose to a (0,1,0) rule there. Same reason
+   pages/files/shell.css is written the way it is.
+   ========================================================================== */
+
+/* `auto` on the first track, not a fixed width: the nav states its own width
+   (and changes it when collapsed) and the body takes the rest. minmax(0, 1fr)
+   rather than 1fr on the body, because `auto` as the implicit minimum lets one
+   unwrapped mono cell in the ports table set the column's minimum width and push
+   the page sideways - the single most common mysterious-overflow bug in grid.
+
+   `align-items: start` so the nav is its own height. A nav stretched to the
+   height of the Topology page would be 900px of empty column, which is the exact
+   thing the deleted global sidebar was deleted for. */
+.control-sec {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 26px;
+  align-items: start;
+}
+
+/* NOT sticky. The offset a sticky nav needs here is the height of the topbar,
+   and nothing in this app states that as a number: it is padding plus whatever
+   the tallest control happens to be, and it changes at two breakpoints.
+   shell.css already refused to measure it in JS ("a measurement race, and the one
+   thing space-and-layout.md says a layout must not depend on"), and a guessed
+   `top` slides the first entries under a blurred bar - a nav you cannot click is
+   worse than a nav you have to scroll back to. Four entries; scroll back up. */
+.control-sec .ct-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 174px;
+  min-width: 0;
+  transition: width var(--dur) var(--ease);
+}
+.control-sec[data-collapsed='true'] .ct-nav { width: 46px; }
+
+.control-sec .ct-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 10px; border-radius: var(--r-sm);
+  color: var(--fg-muted); font-weight: 600; font-size: 13.5px;
+  position: relative; white-space: nowrap; min-width: 0;
+  transition: color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease);
+}
+.control-sec .ct-item svg { flex: none; opacity: .85; }
+.control-sec .ct-item:hover { background: var(--surface-1); color: var(--fg); }
+
+/* "You are here" is a STATEMENT, not a control - so it is a marker and a weight
+   change, never a filled pill that reads as a button asking to be pressed. The
+   topbar says this with an underline; a vertical list's equivalent is a bar down
+   the leading edge. `--accent` is chrome, and it is used here for exactly what
+   chrome may encode: position. Never state. */
+.control-sec .ct-item.on { color: var(--fg); background: var(--surface-1); }
+.control-sec .ct-item.on svg { opacity: 1; }
+.control-sec .ct-item.on::before {
+  content: ''; position: absolute; left: 0; top: 7px; bottom: 7px;
+  width: 2px; border-radius: 0 2px 2px 0; background: var(--accent);
+}
+
+/* The section's own name, and the link to its landing page. A rule under it
+   rather than a heading above it: the pages below already carry an <h1>, and a
+   second one here would give every page in the section two. */
+.control-sec .ct-home {
+  font-size: 14px; font-weight: 700; letter-spacing: -0.01em; color: var(--fg);
+  margin-bottom: 4px; padding-bottom: 10px;
+  border-bottom: 1px solid var(--line); border-radius: var(--r-sm) var(--r-sm) 0 0;
+}
+.control-sec .ct-home.on::before { bottom: 11px; }
+
+.control-sec .ct-collapse {
+  appearance: none; cursor: pointer; font: inherit;
+  display: flex; align-items: center; gap: 10px;
+  margin-top: 8px; padding: 8px 10px; border: 0; border-radius: var(--r-sm);
+  background: transparent; color: var(--fg-subtle);
+  font-size: 12.5px; font-weight: 600; white-space: nowrap;
+}
+.control-sec .ct-collapse svg { flex: none; }
+.control-sec .ct-collapse:hover { background: var(--surface-1); color: var(--fg); }
+
+/* `display: none` cannot be animated, so the collapsed label is a zero max-width
+   with hidden overflow - which can. Same trick as .nav-label in index.css. */
+.control-sec .ct-label {
+  display: inline-block; overflow: hidden;
+  transition: max-width var(--dur) var(--ease), opacity var(--dur-fast) var(--ease),
+              margin-left var(--dur) var(--ease);
+}
+.control-sec[data-collapsed='true'] .ct-label {
+  max-width: 0; opacity: 0; margin-left: -10px;
+}
+.control-sec[data-collapsed='true'] .ct-item,
+.control-sec[data-collapsed='true'] .ct-collapse { justify-content: center; padding: 8px 0; }
+.control-sec[data-collapsed='true'] .ct-home { padding-bottom: 10px; }
+
+.control-sec .ct-body { min-width: 0; }
+
+/* ── narrow ──────────────────────────────────────────────────────────────────
+   900px, which is where the topbar already sheds the freshness pill and the
+   wordmark - reusing a breakpoint the app has rather than inventing a fifth one.
+   Below it a 174px column beside a table is two things that both need the width,
+   so the nav stops being a column and becomes the same horizontal scroller the
+   topbar nav is: overflow driven by measurement (lib/scroll.ts sets
+   data-shade-l/r on any `.scroll-shade`), faded on whichever edge still has
+   content, never squeezed until it is unreadable.
+
+   Specificity has to match the collapsed rules above, which are (0,3,0) - hence
+   `[data-collapsed]` with no value on the ones that override them. The COLLAPSED
+   state is ignored here on purpose: a horizontal strip of five unlabelled
+   squares is not a saving, and there is no column left to reclaim. */
+@media (max-width: 900px) {
+  .control-sec { grid-template-columns: minmax(0, 1fr); gap: 16px; }
+  .control-sec[data-collapsed] .ct-nav {
+    width: auto; flex-direction: row; align-items: center; gap: 2px;
+    overflow-x: auto; overflow-y: hidden;
+    /* The strip has its own scroll affordance (the mask below); a 10px scrollbar
+       under a 34px row would eat a third of it. */
+    scrollbar-width: none;
+    /* Keeps the active item's 2px underline from being clipped by the scroll
+       box, and leaves room for the rule under the row. */
+    padding-bottom: 8px; border-bottom: 1px solid var(--line);
+  }
+  .control-sec .ct-nav::-webkit-scrollbar { display: none; }
+  .control-sec .ct-nav[data-shade-l] { mask-image: linear-gradient(90deg, transparent, #000 22px); }
+  .control-sec .ct-nav[data-shade-r] { mask-image: linear-gradient(90deg, #000 calc(100% - 22px), transparent); }
+  .control-sec .ct-nav[data-shade-l][data-shade-r] {
+    mask-image: linear-gradient(90deg, transparent, #000 22px, #000 calc(100% - 22px), transparent);
+  }
+  /* The mask above paints the inset shadows `.scroll-shade` would otherwise draw
+     out of existence anyway; turn them off so the two affordances do not stack. */
+  .control-sec .ct-nav { box-shadow: none; }
+
+  .control-sec[data-collapsed] .ct-label {
+    max-width: none; opacity: 1; margin-left: 0;
+  }
+  .control-sec[data-collapsed] .ct-item,
+  .control-sec[data-collapsed] .ct-collapse { justify-content: flex-start; padding: 7px 10px; flex: none; }
+  /* Nothing to collapse into. */
+  .control-sec .ct-collapse { display: none; }
+  /* A leading bar on a horizontal row reads as a divider between items, so the
+     current entry is underlined here - which is what the topbar nav does, and
+     the two rows now sit one above the other. */
+  .control-sec .ct-home {
+    margin-bottom: 0; padding-bottom: 7px; border-bottom: 0; border-radius: var(--r-sm);
+  }
+  .control-sec .ct-item.on::before {
+    left: 10px; right: 10px; top: auto; bottom: -8px;
+    width: auto; height: 2px; border-radius: 2px 2px 0 0;
+  }
+}
+
+/* Expanding a label is motion; a reader who asked for less of it gets the label
+   instantly rather than not at all. */
+@media (prefers-reduced-motion: reduce) {
+  .control-sec .ct-nav, .control-sec .ct-label { transition: none; }
+}
+
+/* ── the section landing ─────────────────────────────────────────────────────
+   A triage list, and nothing else. Every row carries four facts - what is
+   affected, what is wrong with it, which entry owns it, and that it is a link -
+   which is what earns a full-width row under the footprint rule. A row with a
+   name and a colour would not.
+
+   Scoped to `.control-page` rather than `.control-sec` because the landing is
+   the only page in the section that draws these; the same (0,2,0) floor applies.
+   ========================================================================== */
+.control-page .ctl-clear,
+.control-page .ctl-degraded {
+  display: flex; align-items: center; gap: 9px;
+  margin: 0 0 18px; color: var(--fg-muted); font-size: 13.5px; line-height: 1.5;
+}
+.control-page .ctl-degraded { color: var(--st-warn); }
+.control-page .ctl-clear .si,
+.control-page .ctl-degraded svg { flex: none; }
+
+.control-page .ctl-findings { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+
+.control-page .ctl-finding {
+  display: flex; align-items: center; gap: 12px;
+  padding: 11px 14px; border-radius: var(--r-md);
+  background: var(--surface-1); border: 1px solid var(--line);
+  transition: border-color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease);
+}
+.control-page .ctl-finding:hover { border-color: var(--line-strong); background: var(--surface-2); }
+.control-page .ctl-f-ico { display: inline-flex; flex: none; color: var(--fg-subtle); }
+.control-page .ctl-f-subject { font-weight: 700; font-size: 13.5px; flex: none; }
+/* The specifics wrap and can be long (two container names); they take the slack
+   and shrink first, because the subject and the destination are the two parts a
+   reader scans down a column of these. */
+.control-page .ctl-f-what {
+  color: var(--fg-muted); font-size: 13px; min-width: 0; flex: 1;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.control-page .ctl-f-where {
+  flex: none; font-size: 11.5px; font-weight: 700; letter-spacing: .04em;
+  text-transform: uppercase; color: var(--fg-subtle);
+}
+.control-page .ctl-f-arrow { flex: none; color: var(--fg-subtle); }
+.control-page .ctl-finding:hover .ctl-f-arrow { color: var(--fg); }
+
+/* At phone width the row is four things competing for 360px, so it stacks: subject
+   over specifics, destination on the right of the first line. */
+@media (max-width: 560px) {
+  .control-page .ctl-finding { flex-wrap: wrap; row-gap: 4px; }
+  .control-page .ctl-f-what { flex: 1 0 100%; white-space: normal; }
+  .control-page .ctl-f-where { margin-left: auto; }
+}

--- a/apps/portal-next/web/src/pages/control/redirects.ts
+++ b/apps/portal-next/web/src/pages/control/redirects.ts
@@ -1,0 +1,85 @@
+// ── the redirect table ───────────────────────────────────────────────────────
+//
+// Services, Access and Topology moved under /control (docs/plans/
+// control-and-settings.md §3). Every URL they had before still resolves, because
+// this is a dashboard people paste into notes and chat, and
+// brand/patterns/navigation.md is unambiguous about it: "if a URL has ever been
+// shared, breaking it is worse than carrying a redirect forever". /ports and
+// /routes have been carrying exactly this since they were merged into Access,
+// which is the precedent rather than an exception.
+//
+// It is a FUNCTION and not a `from -> to` map for one reason: /access holds its
+// view in `?tab=`, so half the mapping lives in the query string. A redirect that
+// drops the parameter is a broken link that answers 200 - it lands somewhere
+// plausible, so nobody reports it and nobody notices it was the wrong somewhere.
+//
+// This module imports NOTHING, which is what lets checks/redirects.mjs compile
+// and run it on its own - the same trick that makes lib/discover.ts testable
+// without a test runner. App.tsx builds its legacy routes FROM `LEGACY_PATHS`
+// rather than listing them again, so the router and this table cannot disagree
+// about which URLs are covered; the check covers the half that can still drift,
+// namely where each one lands.
+
+/** Every path that used to be a page here, spelled the way App.tsx registers a
+ *  child route (no leading slash, React Router params). */
+export const LEGACY_PATHS = [
+  'services',
+  'services/:id',
+  'systems/:name',
+  'access',
+  'ports',
+  'routes',
+  'topology',
+] as const;
+
+/** Every path the app serves now. A redirect target that is not in here is a
+ *  redirect into the not-found page, which is the one failure mode a redirect
+ *  table has that nobody sees until a user reports it. */
+export const LIVE_PATHS = [
+  '/',
+  '/control',
+  '/control/services',
+  '/control/services/:id',
+  '/control/systems/:name',
+  '/control/ports',
+  '/control/routes',
+  '/control/topology',
+  '/settings',
+  '/files',
+] as const;
+
+/**
+ * Where a retired URL goes now, or null when the path was never one of ours.
+ *
+ * `search` is the raw query string (`location.search`), leading `?` optional.
+ */
+export function legacyTarget(pathname: string, search = ''): string | null {
+  // A trailing slash is the same page, and a pasted link often carries one.
+  const p = pathname.replace(/\/+$/, '') || '/';
+
+  if (p === '/access') {
+    // Mirrors Access's own `isTab(raw) ? raw : 'routes'`: an absent or
+    // unrecognised tab landed on Routes, so a bare /access bookmark must still
+    // land on Routes.
+    //
+    // THE PLAN SAYS PORTS, AND THE PLAN IS WRONG about this. Both
+    // docs/plans/control-and-settings.md §3 and the brief built on it map
+    // /access to Ports "its default tab today"; the code has said
+    // `isTab(raw) ? raw : 'routes'` since the two pages were merged. What a
+    // bookmark DID is the only thing a redirect owes its user, so this follows
+    // the code. Changing where a saved link lands is the same defect as dropping
+    // its query parameter, just harder to notice.
+    const tab = new URLSearchParams(search.replace(/^\?/, '')).get('tab');
+    return tab === 'ports' ? '/control/ports' : '/control/routes';
+  }
+  if (p === '/ports') return '/control/ports';
+  if (p === '/routes') return '/control/routes';
+  if (p === '/services' || p === '/topology') return `/control${p}`;
+  // The parameterised ones. Whatever follows is passed through untouched: the
+  // id and the group are already percent-encoded by lib/links.ts, and decoding
+  // them here to re-encode them there is how a service whose name contains a
+  // slash stops resolving.
+  if (p.startsWith('/services/') || p.startsWith('/systems/')) return `/control${p}`;
+
+  return null;
+}

--- a/apps/portal-next/web/src/pages/files/ActivityBar.tsx
+++ b/apps/portal-next/web/src/pages/files/ActivityBar.tsx
@@ -3,7 +3,15 @@
 // The narrow icon strip on the far left, and the only control that decides WHAT
 // THE RAIL IS. Three entries, because this page has three rail-shaped questions:
 // which file (Explorer), what is in the files (Search), and what has changed
-// (Source Control).
+// (Changes).
+//
+// IT WAS CALLED "SOURCE CONTROL" until 2026-08-17, which is what VS Code calls
+// it, and the rename is not a preference. The top nav now has a section called
+// Control, and two unrelated things a click apart cannot share a word that
+// carries as much weight as that one - a reader who has just learned that
+// "Control" is where the running stack lives should not meet it again meaning
+// git. Bothy does not have to borrow VS Code's noun, and "Changes" is what the
+// badge on this icon actually counts.
 //
 // SEARCH WAS DELIBERATELY ABSENT until 2026-08-17, and the reasoning is kept
 // rather than deleted because it was correct while it lasted: "the explorer's
@@ -27,11 +35,14 @@ import { Files as FilesIcon, GitBranch, Search } from 'lucide-react';
 export type RailView = 'explorer' | 'search' | 'scm';
 
 // `hide` is spelled out per view rather than built from the label: "Hide the
-// source control" is what a template produces and it is not English.
+// changes" is what a template produces and it is not English.
 const VIEWS: { id: RailView; label: string; hide: string; Icon: typeof FilesIcon }[] = [
   { id: 'explorer', label: 'Explorer', hide: 'Hide the explorer', Icon: FilesIcon },
   { id: 'search', label: 'Search', hide: 'Hide search', Icon: Search },
-  { id: 'scm', label: 'Source Control', hide: 'Hide Source Control', Icon: GitBranch },
+  // The id stays `scm`. It is the localStorage key and the discriminant on
+  // RailView; renaming it would reset everyone's open rail to buy nothing a
+  // reader ever sees.
+  { id: 'scm', label: 'Changes', hide: 'Hide changes', Icon: GitBranch },
 ];
 
 export function ActivityBar({ view, onPick, changes, collapsed }: {
@@ -68,7 +79,7 @@ export function ActivityBar({ view, onPick, changes, collapsed }: {
             onClick={() => onPick(id)}
           >
             <Icon size={19} aria-hidden="true" />
-            {/* Only Source Control carries a count, and only when there is one:
+            {/* Only Changes carries a count, and only when there is one:
                 a badge reading 0 is a badge that has stopped meaning anything.
                 Capped at 99 so a repo mid-rebase cannot widen the strip. */}
             {id === 'scm' && changes > 0 && (

--- a/apps/portal-next/web/src/pages/files/Files.tsx
+++ b/apps/portal-next/web/src/pages/files/Files.tsx
@@ -1168,7 +1168,7 @@ export function Files() {
                         "edits land as git commits", which stopped being true. */}
                     {deco.total > 0
                       ? <><b className="tnum">{deco.total}</b> uncommitted change{deco.total === 1 ? '' : 's'}</>
-                      : 'save writes to disk; commit in Source Control'}
+                      : 'save writes to disk; commit in Changes'}
                   </>}
           </p>
         </div>

--- a/apps/portal-next/web/src/pages/files/Inspector.tsx
+++ b/apps/portal-next/web/src/pages/files/Inspector.tsx
@@ -216,7 +216,7 @@ export function Inspector({
                       still claimed otherwise, and a stale promise about where a
                       change goes is worse than no promise at all. */}
                   Saving writes the file to disk - <span className="kbd">Ctrl</span> <span className="kbd">S</span>.
-                  It does not commit. Stage and commit the change in <b>Source Control</b>, which has
+                  It does not commit. Stage and commit the change in <b>Changes</b>, which has
                   its own message box.
                 </p>
               </section>

--- a/apps/portal-next/web/src/pages/files/SourceControl.tsx
+++ b/apps/portal-next/web/src/pages/files/SourceControl.tsx
@@ -1,4 +1,8 @@
-// ── the left rail, as Source Control ─────────────────────────────────────────
+// ── the left rail, as Changes ────────────────────────────────────────────────
+//
+// The view is `scm` in code and "Changes" on screen. See ActivityBar.tsx for why
+// it stopped being called Source Control: the top nav now has a section called
+// Control, and two unrelated things a click apart cannot share that word.
 //
 // The same column the explorer lives in, answering a different question: not
 // "which file" but WHAT HAS CHANGED, AND WHAT DOES THAT CHANGE LOOK LIKE.
@@ -154,14 +158,14 @@ export function SourceControl({
   const total = groups.staged.length + groups.worktree.length;
 
   return (
-    <aside className="fx-rail fx-rail-l" aria-label="Source Control">
+    <aside className="fx-rail fx-rail-l" aria-label="Changes">
       {/* One button, and it re-reads. There is no `readOnly` branch anywhere in
           this panel any more: with nothing here that writes, a read-only mount
           and a writable one look and behave identically, so saying which was
           which would be explaining a restriction that no longer restricts
           anything on this page. */}
       <div className="fx-rail-h">
-        <span className="fx-rail-title">Source Control</span>
+        <span className="fx-rail-title">Changes</span>
         <span className="fx-rail-sub tnum">{total || ''}</span>
         <Tooltip label="Re-read git status" align="end">
           <button

--- a/docs/brand/patterns/navigation.md
+++ b/docs/brand/patterns/navigation.md
@@ -37,9 +37,13 @@ See [CHECKLIST.md § 13](../CHECKLIST.md#13-navigation-and-information-architect
 
 ## What Bothy decided, and why
 
-- **Four destinations in a topbar.** Five is roughly where a topbar stops
-  working; a sidebar was tried and deleted (see
-  [space-and-layout](../foundations/space-and-layout.md)).
+- **Three destinations in a topbar** (2026-08-17, was four). Five is roughly
+  where a topbar stops working, but the count was never the real rule. The rule
+  is that **a top-level slot belongs to a DATASET, not to a view of one**:
+  Services, Access and Topology were three renderings of the same merged node
+  list and held three slots, while Files - a different dataset entirely - held
+  one. They now sit behind `Control`, which owns that dataset and navigates
+  itself. Overview · Control · Files.
 - **The current item is underlined**, not filled.
 - **Responsive behaviour is a hybrid**, because the two problems are different.
   Below roughly 1080px the labels collapse to zero width and expand on hover
@@ -61,7 +65,13 @@ See [CHECKLIST.md § 13](../CHECKLIST.md#13-navigation-and-information-architect
 
 ## Dead ends
 
-- **A sidebar.** See [space-and-layout](../foundations/space-and-layout.md).
+- **A sidebar AS THE TOP-LEVEL NAVIGATION.** See
+  [space-and-layout](../foundations/space-and-layout.md). Still a dead end, and
+  worth keeping distinct from what shipped on 2026-08-17: a sidebar *within a
+  section*, subordinate to a topbar entry. The rejected version competed with the
+  topbar for the same job; this one does a job the topbar cannot do, which is
+  hold the five-odd destinations of one dataset without spending five top-level
+  slots on them. Bothy Files had already proved the pattern.
 - **A search input in the topbar that routed on every keystroke.** One history
   entry per character.
 - **Rendering the Overview for an unknown route.** A typo'd deep link looked
@@ -70,6 +80,12 @@ See [CHECKLIST.md § 13](../CHECKLIST.md#13-navigation-and-information-architect
 ## How this is verified
 
 - Assert the skip link is the first tab stop and becomes visible on focus.
+  **This item was listed and not actually verified, and it hid a real defect for
+  months.** Under `HashRouter` the fragment IS the route, so `href="#content"`
+  set `location.hash = "content"`, which react-router resolved to `/content` -
+  the not-found page. The application's first tab stop navigated away from the
+  application. Found 2026-08-17 while restructuring the nav. An item on a
+  checklist is a claim; only a check is evidence.
 - Assert the current item carries `aria-current`.
 - Crawl for detail pages with no way back.
 - At a narrow width, assert the nav overflows, that the fade appears on the side

--- a/docs/plans/control-and-settings.md
+++ b/docs/plans/control-and-settings.md
@@ -1,0 +1,294 @@
+# Plan: Control, Settings, and turning declarations into a UI
+
+_Written 2026-08-17. Status: proposed, nothing started._
+
+Four asks, in the order they were made:
+
+1. **Shrink the top nav.** Services, Access and Topology come out of it and go
+   behind one entry, which opens a section overview with its own left sidebar.
+2. **Make that the pattern**, not a one-off: the top nav carries the highest
+   level only, everything below it navigates from an inner sidebar - "an inner
+   ecosystem".
+3. **Call it Control**, and let it own services and access.
+4. **Settings**: per user, and per system - including "a compiler from compose &
+   env into an interactive UI for users to run stuff".
+
+---
+
+## 1. What is already right, and must not be rebuilt
+
+**The inner-sidebar pattern is already in the product and already works.** Bothy
+Files has an activity strip, a rail that changes what it shows, resizable panes
+that persist, and a keyboard route to all of it (`panes.ts`, `ActivityBar.tsx`).
+This proposal is not a new invention - it is propagating a pattern that shipped
+and stuck. That is the strongest argument for doing it, and it also means the
+hard parts (resize, collapse, persistence, focus order) have a reference
+implementation rather than a blank page.
+
+**Intent is already modelled.** `apps/portal-collector` exists precisely because
+"the portal only ever recorded observed facts, never intent". It reads each
+project's `project.dev.yml`, reconciles the declaration against host truth, and
+already carries a `start` command, a `ui` flag per service, and states that
+distinguish `stopped` from `stuck` from `collision` from `unverified`.
+
+That last point reframes ask 4 completely, and it is the most important
+conclusion in this document: **do not build a compose parser.** The declaration
+layer exists. See §6.
+
+**Deep links already have a migration precedent.** `/ports` and `/routes` are
+already `<Navigate>` redirects into `/access?tab=…`. Moving routes is a thing
+this app has done before and done correctly, which sets the standard: every
+existing URL keeps working.
+
+---
+
+## 2. What is actually wrong with the nav
+
+Not "it has too many things" - that is taste. Three specific defects:
+
+**Nav slots track VIEWS, not datasets.** Services, Access and Topology are three
+renderings of one dataset: the merged node list from `merge()`. Files is a
+genuinely different dataset with a different mental model. Giving one dataset
+three top-level slots and another one slot mis-states what the box contains. It
+is the footprint rule (`principles.md`: an element's footprint is proportional to
+the information dimensions it carries) applied to navigation.
+
+**Access already nests navigation inside navigation.** Today: top nav → Access →
+tabs (Routes / Ports). Three levels, and the third one *hides* - you cannot see
+Ports exists until you land on Access. A sidebar entry is visible from the
+section landing; a tab is not.
+
+**Topology is beautiful and thin.** A 3D rack view is the most expensive thing on
+the box to render and answers roughly one question ("what talks to what"). It has
+earned a place in the section; it has not earned a peer slot beside the Overview.
+
+---
+
+## 3. The target shape
+
+```
+TOP NAV        Overview          the box at a glance - unchanged, stays the front door
+               Control           everything that is running and how you reach it
+               Files             the box's contents
+               ·
+               (right cluster)   Live · Search · Refresh · Theme · You
+```
+
+Three entries, plus a person menu where the theme toggle already lives.
+
+```
+/control                    the section overview
+  ├── Services              the table, filters, search
+  ├── Ports                 (was /access?tab=ports)
+  ├── Routes                (was /access?tab=routes)
+  ├── Topology              the 3D view
+  └── Actions               start · stop · restart          [when §5 lands]
+```
+
+**Routes and redirects.** New paths under `/control/*`; every old path becomes a
+`<Navigate replace>`, exactly as `/ports` and `/routes` already are:
+
+| Old | New |
+|---|---|
+| `/services` | `/control/services` |
+| `/services/:id` | `/control/services/:id` |
+| `/access` | `/control/ports` (its default tab today) |
+| `/access?tab=routes` | `/control/routes` |
+| `/topology` | `/control/topology` |
+| `/systems/:name` | `/control/systems/:name` |
+| `/ports`, `/routes` | already redirect; re-point them |
+
+A redirect that drops a query parameter is a broken link with a 200, so
+`/access?tab=ports` must land on Ports, not on the section overview.
+
+**What the section overview is for.** Not a fourth copy of the Overview's
+counts. It answers "what would I click next": the systems with something wrong,
+the ports that collide, the routes in an error state - each a link into the
+sidebar entry that owns it. If it cannot say something the Overview does not, it
+should be a redirect to Services instead. Decide that with the page in front of
+you, not now.
+
+---
+
+## 4. The naming ruling
+
+**Use `Control`, and be aware it is a promise.**
+
+Two problems, both solvable.
+
+**It collides with "Source Control", already in Bothy Files' rail.** The brand
+review flagged this and it is real. The fix is one word: rename that rail entry
+**Changes**. VS Code calls it Source Control; Bothy does not have to, and
+"Changes" is what the badge actually counts.
+
+**"Control" is a verb, and today the section cannot do anything.** Services,
+Access and Topology are all read-only. Shipping a section called Control that
+controls nothing is the *parked configuration* mistake in naming form - the exact
+error this repo already paid for once with dead Traefik routers, and wrote down
+as "either keep a layer working or delete it".
+
+So, one of two - and this is a decision to make now, not later:
+
+- **Ship at least one action with the rename** (restart is the obvious first: it
+  is idempotent, it is what you actually reach for, and it is the least
+  destructive of the three). Then the name is true on arrival.
+- **Or call the section `Systems` until actions land**, and rename it to Control
+  in the release that makes it able to control.
+
+Recommendation: the first. The action tier is designed already (§5) and the
+rename is a bad thing to do twice.
+
+**In the UI it is "Control", not "Bothy Control".** The two-register rule from
+the brand work: bare nouns in the interface, "Bothy X" in prose and marketing.
+The nav says `Files`, not `Bothy Files`, today - this follows that.
+
+---
+
+## 5. Actions: what Control actually controls
+
+This is the plan already written in
+[`first-party-stack.md`](first-party-stack.md) §2, unchanged, and it slots
+directly into the new section as its `Actions` entry (and as row-level buttons on
+Services).
+
+Three verbs - **restart, stop, start** - behind the `operator` role, in a service
+that holds a hard-coded allowlist, on its own network with its own socket proxy.
+The critical constraint, restated because it will be tempting to skip: **do not
+set `POST=1` on the existing read-only socket proxy.** `POST=1` with
+`CONTAINERS=1` grants `/containers/create`. The mutation surface must be code you
+wrote, not an environment variable away from being everything.
+
+Explicitly out of scope, and it should be written into the compose file so it
+stays out: `exec`, `create`, `rm`, image pulls, volume operations.
+
+**A confirm step for anything Bothy depends on** - traefik, portal-next,
+portal-files, the socket proxies. Stopping the edge from a page served through
+the edge deserves a sentence, not a toast.
+
+---
+
+## 6. Settings, and the "compiler"
+
+### 6a. The blocker nobody has hit yet: Bothy does not know who you are
+
+There is no `/-/api/me`. oauth2-proxy sets `X-Auth-Request-Email`,
+`X-Auth-Request-User` and `X-Auth-Request-Groups` on requests it forwards, and
+`portal-files` uses the email to attribute a write - but the SPA never sees any
+of it. Consequences today:
+
+- the page cannot say who is signed in;
+- it cannot hide an action the user's role forbids, so the only feedback is a 403
+  after the click;
+- "per-user settings" has nothing to key on.
+
+**So step one of all settings work is a `/-/api/me` endpoint** returning
+`{ user, email, roles }` read from those headers, behind `sso-viewer`, as an
+exact `Path()` route. It is small and it unlocks everything below.
+
+One rule, and it is the same one the editor tier already follows: **what the UI
+hides is not what the API enforces.** Client-side role checks are courtesy.
+Every action stays gated at the edge regardless of what the page renders.
+
+### 6b. Per-user settings
+
+Worth separating two things that "settings" collapses:
+
+| Thing | Belongs to | Store |
+|---|---|---|
+| theme, pane widths, collapsed groups | the **browser** | `localStorage` - already correct, leave it |
+| identity, roles, what you may do | the **user** | `/-/api/me`, read-only |
+| default root, default landing page, favourites | the **user** | needs a real store |
+
+Only the third row needs new storage, and it is the least valuable of the three.
+**Recommendation: do not build a per-user preference store yet.** Ship `/-/api/me`
+and a Settings page that shows who you are, which roles you hold, what each role
+permits, and where the session comes from. That is genuinely useful, honest, and
+carries no write path. Revisit persistence when there is a preference somebody
+actually asks to keep.
+
+If it is built later, the store is Postgres (Keycloak already lives there), a
+`bothy` schema, one small table, and a write path that needs the same treatment
+as every other write path on this box.
+
+### 6c. System settings, and the compose/env compiler
+
+**The idea is good and it is the same idea the Overview is built on** - a UI
+generated from declarations rather than hand-maintained. That thesis has already
+paid off twice here, so extending it to configuration is principled rather than
+speculative.
+
+**But do not parse compose to do it.** Two reasons:
+
+- The declaration layer already exists (`project.dev.yml` + the collector), it is
+  already reconciled against host truth, and it already carries `start`, `ui` and
+  per-service state. Building a second, parallel understanding of what a project
+  is guarantees they will disagree - and the portal has already been burned by
+  two implementations of one rule (three copies of the display-name lookup, which
+  is what made a system read two different ways on two pages).
+- A compose file is not a form. It is a program: `privileged`, arbitrary bind
+  mounts, arbitrary commands. A UI that round-trips compose is a UI that can
+  write arbitrary code onto the box.
+
+**Never render env VALUES.** `~/stacks/.env` holds 19 real secrets, which is why
+`safepath` refuses `.env` by name today. The compiler shows **keys and whether
+they are set** - `POSTGRES_PASSWORD  set`, `ALERT_EMAIL_TO  not set` - and never
+the value. This is not a nice-to-have; a settings page that prints the contents
+of `.env` to any tailnet viewer undoes a control that already exists.
+
+Three layers, in increasing risk. Ship them in order, and treat each boundary as
+a separate decision:
+
+**Layer 1 - Introspect (safe, do this first).** Render what the declaration
+already says: services, their declared ports, whether they are up, which env keys
+they expect and whether each is set, what `start` command exists. All derived,
+all read-only, no new privilege. This alone answers "what is this project and is
+it healthy", which is most of the value.
+
+**Layer 2 - Run (medium).** A button that executes the declared `start` - not an
+arbitrary command, *the one the declaration names*. Same shape as §5: `operator`
+role, audit log, bounded verbs. The declaration is the allowlist, which is the
+elegant part: a project opts in by declaring, and nothing else is runnable.
+
+**Layer 3 - Change (dangerous, decide separately).** Editing values. If it
+happens: field-level allowlist declared in the project file (not "any key"), a
+diff-and-confirm before writing, an audit entry, and a written threat model
+first. Free-text editing of compose or `.env` through a browser is the editor
+tier with more privilege and fewer guards - if that is what is wanted, say so
+plainly and design it as such rather than arriving there by increment.
+
+---
+
+## 7. Sequence
+
+Each step is independently shippable and leaves the product coherent.
+
+1. **`/-/api/me`** - identity and roles reach the browser. Unblocks everything,
+   no UI change required.
+2. **The section shell** - `/control` with its sidebar, all existing pages moved
+   under it, every old URL redirecting. Pure IA; no new capability. Rename the
+   Files rail entry to **Changes** in the same change.
+3. **Actions** - restart/stop/start behind `operator`, in Control. This is what
+   makes the name honest, and it retires Portainer and Dozzle
+   ([`first-party-stack.md`](first-party-stack.md) §2).
+4. **Settings page** - who you are, what you may do, where the session came from.
+   Read-only.
+5. **Project introspection (layer 1)** - the declaration rendered.
+6. **Run (layer 2)** - the declared start command, behind `operator`.
+
+Layer 3 is deliberately not on this list.
+
+---
+
+## 8. What I would push back on
+
+- **A section called Control that cannot control.** Either an action ships with
+  it or it is called Systems. §4.
+- **A settings page that writes before it can read.** `/-/api/me` first; the
+  page has nothing to key on without it.
+- **Rendering `.env` values anywhere, ever.** Keys and set/not-set only.
+- **A generic compose editor with a nice skin.** That is not a compiler, it is
+  remote code execution with a form.
+- **Sidebars on pages that do not need one.** The ask is "this design for almost
+  all of the pages" - Overview and Files should not get one. Overview is a
+  single view; Files already has a better version of the same idea. A sidebar
+  holding one link is furniture.

--- a/docs/plans/editing-model.md
+++ b/docs/plans/editing-model.md
@@ -1,0 +1,243 @@
+# The editing model: four ways in, one thing underneath
+
+_Written 2026-08-17. Status: thinking, not yet a build plan._
+
+The ask: users should be able to change things - a project's name, a route, a
+container's config - through the UI, and there are four routes to an edit:
+
+1. the **global files editor** (Bothy Files, shipped);
+2. **per-thing UI** - forms on a project, a route, a container;
+3. a **per-file editor** attached to whatever that thing is configured by;
+4. a **terminal**, later.
+
+The instinct is right. The design question is not "which of these do we build" -
+it is **what stops them disagreeing with each other.**
+
+---
+
+## 1. The one thing underneath
+
+Every configurable thing on this box is a file in git. Compose files, `.env`,
+`project.dev.yml`, `edge/dynamic/*.yml`, `prometheus.yml`, `policy.toml`. There
+is no configuration database and there never has been.
+
+So the four routes are not four systems. **They are four ergonomics over one
+substrate**, and that gives the governing rule:
+
+> **A form is a typed lens over a file. It is never a second store.**
+
+If a form writes to a database instead of the file, the repository stops
+describing the box, `git log` stops being the history of it, and a `git pull`
+silently reverts somebody's change. Everything below follows from refusing that.
+
+The corollary is the good news: a form edit that goes through the *existing*
+write path inherits, for free, every property that path already has - resolve and
+deny rules, the conflict check, the undo snapshot, the audit line, and the role
+gate at the edge. **Do not build a second write path.** Build a thing that
+computes new file bytes and hands them to the one that exists.
+
+---
+
+## 2. The constraint that decides the implementation
+
+**Half of these files are comments.**
+
+| File | Lines | Comment lines |
+|---|---|---|
+| `edge/compose.yml` | 174 | 124 (**71%**) |
+| `auth/compose.yml` | 459 | 299 (**65%**) |
+| `apps/portal-files/compose.yml` | 112 | 70 (**62%**) |
+| all `compose.yml` files | 1,485 | 754 (**50%**) |
+
+Those comments are not decoration. The README's pitch is literally "every
+non-obvious line carries a comment explaining **why** it is there, usually
+because the alternative broke something". They are the most valuable content in
+the repository, and several of them are the only record of a security decision.
+
+The naive form implementation - `yaml.safe_load()` → mutate the dict →
+`yaml.dump()` - **deletes all 754 of them** and reformats everything else. It
+would look like it worked. The service would still start. The knowledge would be
+gone, and it would be gone in a diff so large nobody reads it.
+
+So, two hard requirements on any config writer:
+
+- **Round-trip preserving**, e.g. `ruamel.yaml` in round-trip mode, or surgical
+  text replacement that never re-serialises the document.
+- **A no-op edit must produce a byte-identical file.** That is the test to write
+  first, before any field is editable: load, change nothing, write, `diff`. If
+  that is not empty, nothing else is safe to build.
+
+There is a second-order consequence. `apps/portal-files` states, at the top of
+`app.py`, that it has **no third-party dependencies** - "this container holds
+read-write bind mounts on two git repositories, and every dependency is something
+that can ship a vulnerability into that position". A YAML round-tripper is a
+third-party dependency. **So the config tier is a separate service** from the
+file tier, exactly as the action tier will be: `portal-files` keeps its property,
+and the thing that needs a parser carries the parser and its own smaller mount.
+
+---
+
+## 3. Not everything is editable: three classes of field
+
+An allowlist, declared in policy rather than coded, on the `policy.toml`
+precedent - so widening it is a reviewable diff and not a code change.
+
+**Class A - Bothy's own metadata.** `dev.portal.project`, `dev.portal.name`,
+`icon`, `desc`, `order`. Changing these changes *what Bothy displays* and nothing
+else. A wrong value is a cosmetic bug.
+
+**Class B - declared configuration.** An image tag, a published host port, an
+env var's value, a memory limit, a project's description in `project.dev.yml`.
+A wrong value breaks one service and is visible immediately.
+
+**Class C - the ones that are code.** `volumes`, `privileged`, `cap_add`,
+`command`, `entrypoint`, `network_mode`, anything mounting a socket, and every
+rule in `edge/dynamic/`. A wrong value here is arbitrary code on the box or a
+credential leak. **These are not form fields.** They are edited in Files, by
+someone who has read the comment above them, and reviewed as a diff.
+
+**Start with class A, and specifically with the example that prompted this:
+renaming a project.** It is the highest-value, lowest-blast-radius write
+available - it proves the entire chain (form → patch → file → git → visible
+change) while the worst possible failure is a card with the wrong title. Nothing
+about the rest of the design has to be guessed at to build it.
+
+---
+
+## 4. Editing is not applying, and the UI must say so
+
+A file edit does not change a running system. This is not a detail - it is the
+single most confusing thing about the whole feature, and this box has already
+been bitten by it: the `Role · Vendor` rename changed six compose labels and
+**nothing on screen moved until every affected container was recreated**, because
+a label is fixed at container-creation time.
+
+So a rename through the UI is genuinely two acts:
+
+```
+edit    write the label into the compose file        `editor` role
+apply   recreate the container so it takes effect    `operator` role
+```
+
+The interface has to carry that state, and the vocabulary already exists: the
+collector's whole job is separating **declared** from **observed**. A service
+whose file has changed but whose container has not is *config drift* - the same
+shape as "declared but not running", and it should render in the same language,
+not as a spinner that lies.
+
+Tempting alternative, and worth stating so it is rejected on purpose: Bothy could
+keep display metadata in its own file and render it instantly, no recreate. That
+buys immediacy and costs the property this box is built on - the compose file
+would say one thing and the screen another. **One place, with an honest pending
+state, beats two places that agree most of the time.**
+
+---
+
+## 5. How the four routes relate
+
+**Route 3 is not a feature. It is a link.** "Edit this service's config" should
+open Bothy Files, scoped to that file, with the cursor near the field - not a
+second editor component. Files already has the tree, search, git history, diff,
+conflict handling and the undo net. A second editor would be a second set of
+bugs and a second thing to secure. The work is a `configFile` pointer on a
+service, which mostly exists already: the collector knows each project's root and
+compose identity.
+
+That collapses the four routes into three implementations:
+
+| Route | What it is | Good for |
+|---|---|---|
+| Forms (2) | typed lens, allowlisted fields, validated | fields Bothy understands |
+| Files (1 and 3) | the full text, one file or all of them | everything else |
+| Terminal (4) | no model at all | what no UI models |
+
+And the honest rule for which to reach for: **a form exists only where Bothy can
+validate the value.** If it cannot say what is wrong before writing, it should
+not be offering a text box - it should be offering the file.
+
+**They will collide, and the answer already exists.** Two routes editing one file
+is the ordinary case here (a form in one tab, Files in another, `vim` on the
+box). The editor tier already solved it with a `baseMtime` conflict check, and
+that comment says why it is load-bearing: writing straight to disk removed git as
+the safety net. The form path must send the same `baseMtime` and get the same
+409, not invent a second policy.
+
+**The terminal is outside all of this**, and that has to be said out loud rather
+than discovered: it bypasses the allowlist, the validation and the conflict
+check. It is `shell`-role work - the role deliberately granted to nobody today -
+and it should stay the most privileged thing on the box.
+
+---
+
+## 6. Routes are the special case
+
+`edge/dynamic/*.yml` deserves its own paragraph because it is the one place where
+a plausible edit takes the whole box down quietly. Traefik renders those files as
+Go templates **before** parsing the YAML and does not skip comments, so a doubled
+brace anywhere - including inside a comment - voids the entire file: no routers,
+no middlewares, while the file on disk looks perfect.
+
+Therefore, for routes: **generate, never free-edit.** The form asks which service
+and which path, and Bothy writes the exact-`Path()` rule from the template that
+already exists (`project.example.yml`). Write, then re-read Traefik's router
+table and confirm the rule is present and enabled; if it is not, restore the
+previous bytes from the snapshot that the write already took. `just verify` check
+5b does the parse-failure detection today - the write path should run the same
+assertion rather than hoping someone runs it later.
+
+---
+
+## 7. Who may do what
+
+The roles exist and are already enforced on the file tier: `viewer`, `editor`,
+`operator`, `shell`.
+
+| Action | Role |
+|---|---|
+| see a settings page, see current values | `viewer` |
+| change a class A or class B field | `editor` |
+| apply - recreate, restart, run a declared start command | `operator` |
+| terminal | `shell` (nobody) |
+
+Attribution is already wired: `X-Auth-Request-Email` reaches the service and
+lands in the audit log. Every form write should carry the same line, so "who
+renamed this and when" is answerable without `git blame` - and `git blame`
+answers it too, because the change is a commit.
+
+The UI may hide what a role forbids. That is courtesy, not enforcement - the edge
+decides, exactly as it does now.
+
+---
+
+## 8. What I would refuse
+
+- **Parse-and-dump YAML.** It deletes 754 comment lines and looks like success.
+- **A settings database.** Two sources of truth; the repo stops being the box.
+- **A second write path.** Reuse resolve, conflict, snapshot, audit, role gate,
+  or explain in writing why each is not needed.
+- **Free-text editing of `edge/dynamic/` through a form.** Generate from a
+  template, verify, roll back.
+- **Rendering `.env` values.** Keys and set/not-set. The deny-list exists.
+- **Class C fields as form fields.** `privileged`, `volumes`, `command`,
+  socket mounts. Those are diffs, reviewed by a human who read the comment.
+- **A form that silently drops what it did not understand.** If the writer meets
+  a construct it cannot round-trip, it must refuse the write, not rewrite the
+  file into something it can express.
+
+---
+
+## 9. The first thing to build
+
+Rename a project from the UI, end to end:
+
+1. `/-/api/me` so the page knows the user holds `editor`.
+2. A config service (separate from `portal-files`, carrying the round-trip
+   parser) with a byte-identity no-op test as its first check.
+3. `policy` declaring exactly one patchable field: `dev.portal.project`.
+4. A form on the system page. Writes through the existing write chain: resolve,
+   `baseMtime` conflict check, snapshot, audit.
+5. The **pending** state - "changed on disk, not yet applied" - and an Apply that
+   recreates the container behind `operator`.
+
+That is the whole architecture exercised on the safest possible field. Everything
+after it is adding rows to an allowlist.

--- a/edge/compose.yml
+++ b/edge/compose.yml
@@ -163,7 +163,11 @@ services:
     # filesnet added 2026-08-12 with the editor tier: it holds exactly two
     # containers, traefik and portal-files, so that a service with no auth of
     # its own is reachable only from the edge that authorises it.
-    networks: [devnet, socketnet, filesnet]
+    # confignet joins the same family as socketnet and filesnet: one network per
+    # thing that authenticates nobody, holding traefik and that thing only. The
+    # config tier can rewrite compose files and edge routes, so it is the highest
+    # stake of the three.
+    networks: [devnet, socketnet, filesnet, confignet]
 
 networks:
   devnet:
@@ -171,4 +175,6 @@ networks:
   socketnet:
     external: true
   filesnet:
+    external: true
+  confignet:
     external: true

--- a/edge/dynamic/.gitignore
+++ b/edge/dynamic/.gitignore
@@ -21,6 +21,12 @@
 # so it is tracked. It was ignored by the `*` above for its first two commits,
 # which is exactly the failure mode this comment exists to prevent repeating.
 !portal-files.yml
+# The config-tier routes, tracked for exactly the reason portal-files.yml is:
+# they carry the `editor` gate on a service that can rewrite this repo's compose
+# files, so losing the file would silently unprotect a write path. It holds no
+# credential. Added in the same commit as the file, on the strength of the note
+# above - portal-files.yml went two commits untracked before anyone noticed.
+!bothy-config.yml
 # The redacted twin of the GENERATED portal-prom.yml (which stays ignored by the
 # `*` above - it carries a basic-auth credential). Comments only: a live example
 # in this directory overwrites the real router, see the file's own header.

--- a/edge/dynamic/bothy-config.yml
+++ b/edge/dynamic/bothy-config.yml
@@ -1,0 +1,124 @@
+# Routes for the config tier - the second place on this box where a request can
+# CHANGE something, so the shape here is the security control.
+#
+# WARNING - this directory is rendered as a Go template. A doubled brace
+# anywhere, INCLUDING INSIDE A COMMENT, voids the whole file. Traefik then keeps
+# serving its last-good config, so nothing looks wrong until the next restart,
+# when every @file router disappears at once. `just verify` check 5b catches it.
+#
+# THE RULES ARE EXACT Path(), NEVER PathPrefix. The variable part of every
+# request travels in the QUERY STRING for reads and in the JSON BODY for writes,
+# exactly as the file tier's routes do. That is not style: a prefix rule covering
+# /-/api/config/ would also cover any endpoint added to that service later,
+# including one nobody meant to expose. With exact paths a new endpoint is
+# unreachable until someone writes a rule here - which is the correct default for
+# a service holding write access to the repository that describes this box.
+#
+# READ requires `viewer`; WRITE requires `editor`. Same tiers as the file tier,
+# on purpose: this service can change strictly LESS than portal-files can (one
+# declared field in one file type, versus the whole text of any writable file),
+# so a role above `editor` would be claiming a boundary that is not there. If it
+# ever grows a class B field - an image tag, a published port - that is the
+# moment to revisit this line, not before.
+#
+# ── the middlewares are borrowed, and that is a real coupling ───────────────
+#
+# `sso-viewer`, `sso-editor` and `sso-errors` are NOT defined in this file. They
+# are defined in edge/dynamic/portal-files.yml and edge/dynamic/auth.yml, and
+# Traefik's file provider merges every .yml in this directory into one namespace,
+# so referencing them by bare name resolves.
+#
+# Defining a second copy here would be the worse option and it is worth saying
+# why, because copying them looks tidier: two definitions of a middleware named
+# `sso-editor` in one provider is a collision, and the one that wins is not
+# something this file can decide. The two would then drift, and the drift would
+# be invisible - both routers would still answer, one of them against the wrong
+# role.
+#
+# The cost is that deleting portal-files.yml silently unauthenticates this file's
+# routers. That is a genuine hazard and the mitigation is this paragraph plus
+# checks/authz_probe-style verification at the edge, not a duplicate definition.
+
+http:
+  routers:
+    # ── read: what is patchable here, and what it says now ─────────────────
+    #
+    # `viewer`, not `editor`. This endpoint returns the current value of a
+    # compose label and the file's mtime - both of which any viewer can already
+    # read through the file tier, and through the compose file itself. Gating it
+    # at `editor` would mean a viewer's settings page could not render the
+    # values it is not allowed to change, which makes the UI worse and hides
+    # nothing.
+    #
+    # It returns NO env values, ever. §8 of docs/plans/editing-model.md: keys and
+    # set/not-set, never values. The service has no endpoint that reads one, and
+    # the policy's [patch].suffixes cannot reach a `.env` file at all.
+    bothy-config-read:
+      rule: "Path(`/-/api/config/fields`)"
+      entryPoints: [web]
+      priority: 100
+      service: bothy-config
+      middlewares: [bothy-config-strip, config-deidentify, sso-viewer, sso-errors]
+
+    # ── write: requires the editor role ────────────────────────────────────
+    bothy-config-write:
+      rule: "Path(`/-/api/config/patch`)"
+      entryPoints: [web]
+      priority: 110          # above the read router; disjoint anyway, but explicit
+      service: bothy-config
+      middlewares: [bothy-config-strip, config-deidentify, sso-editor, sso-errors]
+
+    # NO router for /healthz, deliberately. It is reached by the container's own
+    # HEALTHCHECK on 127.0.0.1 and needs no route; publishing it would put the
+    # root list and the field allowlist on the tailnet for nothing.
+
+  middlewares:
+    # Map the public path onto the service's own. The service serves
+    # /config/patch, the world asks for /-/api/config/patch - so the service
+    # cannot accidentally be correct about a path nobody routed.
+    #
+    # stripPrefix of `/-/api` rather than `/-/api/config`, because the service's
+    # own routes are already under /config/. Stripping the longer prefix would
+    # leave `/patch`, which no handler answers.
+    bothy-config-strip:
+      stripPrefix:
+        prefixes: ["/-/api"]
+
+    # Delete any X-Auth-Request-* header the CLIENT sent, before forwardAuth runs.
+    #
+    # The service names the audit line's author from X-Auth-Request-Email.
+    # Traefik sets that header from the auth response, but a client is free to
+    # send one too, and relying on "the auth response wins" is relying on an
+    # ordering rather than on a guarantee. An empty value in customRequestHeaders
+    # removes the header outright, so the only one that can reach the service is
+    # the one oauth2-proxy produced.
+    #
+    # The blast radius if this were missing is a forged NAME in the patch log,
+    # not unauthorised access - authorisation is decided by sso-editor, which
+    # reads a signed session cookie and never a header. It matters more here than
+    # in the file tier even so: a form write leaves no diff a human reads, so the
+    # log is closer to being the only record of who did it.
+    #
+    # A SEPARATE middleware from portal-files' `files-deidentify`, with the same
+    # body. This one is not shared because it is not a role gate - it is a local
+    # scrub with no coupling worth taking, and the duplication is six lines that
+    # cannot drift into a wrong ANSWER, only into a wrong-but-harmless list.
+    config-deidentify:
+      headers:
+        customRequestHeaders:
+          X-Auth-Request-User: ""
+          X-Auth-Request-Email: ""
+          X-Auth-Request-Groups: ""
+          X-Auth-Request-Preferred-Username: ""
+          X-Forwarded-User: ""
+          X-Forwarded-Email: ""
+
+  services:
+    bothy-config:
+      loadBalancer:
+        servers:
+          # confignet holds exactly two containers: traefik and this. The service
+          # publishes no host port and has no auth of its own, so reachability IS
+          # authorisation - the same rule the socket-proxy and the file tier are
+          # both built on.
+          - url: "http://bothy-config:8098"

--- a/justfile
+++ b/justfile
@@ -26,6 +26,11 @@ default:
 # Create the shared docker networks (idempotent)
 network:
     -docker network create devnet 2>/dev/null || true
+    # confignet: traefik + bothy-config, and nothing else. That service can
+    # REWRITE compose files and edge routes, so the same rule the socket proxy
+    # taught applies with a higher stake - it authenticates nobody, and the
+    # network is what stands in for that.
+    -docker network create confignet 2>/dev/null || true
     # socketnet holds exactly two containers: traefik + portal-socket-proxy.
     # docker-socket-proxy has NO auth, so network reachability IS authorisation -
     # on devnet, any of ~20 containers (incl. third-party wiki.js, kafka-ui) could
@@ -112,12 +117,24 @@ up-mgmt: network
 # file from a bind mount. No second copy, no sync lag, nothing to keep out of git.
 up-apps: network
     docker compose {{BOTHY}} up -d
+    # The config tier. Separate from the editor tier on purpose: portal-files
+    # states it carries no third-party dependencies because it holds read-write
+    # handles on two repositories, and a YAML parser is a dependency. This one
+    # carries it, and mounts far less.
+    #
+    # The snapshot directory must exist before it starts - policy.toml declares
+    # it and the service refuses to boot without it, on the same reasoning as the
+    # editor tier's undo net: a safety net nobody notices is missing is worse
+    # than none at all.
+    mkdir -p ~/.local/state/bothy/config-trash
+    docker compose -f apps/bothy-config/compose.yml up -d
 
 # Stop everything (keeps volumes/data)
 down:
     -docker compose -f auth/compose.yml down
     -docker compose -f edge/compose.yml down
     -docker compose {{BOTHY}} down
+    -docker compose -f apps/bothy-config/compose.yml down
     # apps/wiki is superseded but never deleted: its content lives in a `wiki`
     # database this cannot recreate. Kept so an older deployment still gets
     # cleaned up.
@@ -140,6 +157,7 @@ nuke:
     -docker compose -f auth/compose.yml down -v
     -docker compose -f edge/compose.yml down -v
     -docker compose {{BOTHY}} down -v
+    -docker compose -f apps/bothy-config/compose.yml down -v
     -docker compose -f apps/wiki/compose.yml down -v
     -docker compose -f mgmt/compose.yml down -v
     # retired 2026-08-12 and their volumes already deleted, so `-v` here is a


### PR DESCRIPTION
Built by three agents working in parallel worktrees, then integrated. Two of them
contradicted my spec with a measurement, and both were right.

## 1. The nav is three entries

Services, Access and Topology were three renderings of **one** dataset holding
three top-level slots, while Files — a genuinely different dataset — held one.
Nav slots now track datasets: **Overview · Control · Files**, with Control
carrying a persistent sidebar (Services · Ports · Routes · Topology).

`/control` is a triage list, not a fourth counts panel: systems reporting a
fault, **ports claimed by two containers**, and **routers Traefik reports as not
enabled**. The middle two appear nowhere else in the app, which is what justifies
the page. Its empty state names the three checks it ran rather than saying "all
good".

Every old URL redirects, **asserted by a check** — a redirect table is exactly
the thing that rots silently.

## 2. Three things the spec got wrong

- **`/access` defaulted to `routes`, not ports** (`isTab(raw) ? raw : 'routes'`).
  My redirect would have landed every bare `/access` bookmark on a different view
  than it left — the same defect as dropping a query parameter, harder to notice.
- **The skip link had never worked.** Under `HashRouter` the fragment *is* the
  route, so `href="#content"` resolved to `/content` → not-found. The app's first
  tab stop navigated off the page. The brand checklist listed "assert the skip
  link is the first tab stop" under *How this is verified*; it was a claim, not a
  check.
- **A page transition keyed on the full pathname** remounted everything under
  `<main>` on every navigation — the "persistent" sidebar would have faded out
  and back in on each of its own links.

## 3. Identity needed no backend

`/oauth2/userinfo` already returns `{user, email, preferredUsername, groups}`
from the session cookie, on an already-published route. `/-/api/me` was never
built. Settings shows who you are, which of the four roles you hold, where the
session comes from, and — honestly — that there is **no preference store**,
rather than rendering a disabled form for one.

## 4. `ruamel` round-trip is not safe on this repo

The spec said use it. The measurement says no. A **no-op** round-trip — load,
change nothing, dump — damages **seven** files:

```
edge/dynamic/host-services.yml        1702 ->    9 bytes
edge/dynamic/project.example.yml      3371 ->    9
edge/dynamic/portal-prom.example.yml  2504 ->    9
edge/dynamic/tals.yml                 2874 ->    9
apps/portal/compose.yml               5809 -> 5707
monitoring/.../rules.yml              3230 -> 3200
mgmt/dozzle-users.yml                  210 ->  188
```

`host-services.yml` is 31 comment lines and comes back as `null\n...\n`, because
a document with no content loads as `None`. Valid YAML, service still starts,
every word gone. That is why it would have shipped.

So **ruamel parses, Python splices**: `lc.item()`/`lc.value()` give a scalar's
exact line and column, the span is asserted literal against the source bytes
before anything is written, and only that span is replaced. Nothing is ever
re-serialised, so byte-identity is true by construction rather than by
configuration. `checks/naive_dump_damage.py` keeps the measurement alive and
**fails if the damage ever reaches zero**, so the reasoning cannot go stale.

## Verified end to end on the live box

Renaming a project through the API:

- exactly **one line** changed, **128 comment lines before and after**;
- rename → rename-back leaves the file **byte-identical**;
- stale `baseMtime` → **409**, class-C field (`privileged`) → **403**,
  unauthenticated → **401**, no host port;
- the outgoing bytes kept in the snapshot directory;
- the response says the file changed and the container did not — *"a compose
  label is read at container-creation time … that is operator work, not this
  service's."*

`just verify` 25/25 · portal checks 86 pass / 0 fail · `bothy-config` checks all
pass with the stack down · `just doctor` clean.

## Also

`confignet` joins socketnet/filesnet — one network per thing that authenticates
nobody. The `Source Control` → `Changes` rename is finished (I had scoped it to
one file; the rail header still disagreed with the strip). The command palette
pointed at three paths that now only resolve via redirect. Brand docs corrected:
"four destinations" → three, and the sidebar dead end narrowed to what was
actually rejected — a sidebar *as the top-level navigation*.

## Not in this PR

Actions (restart/stop/start) — which is what makes the name "Control" honest, and
is the next step. Until then the section is read-only and the name is a promise.