### PR TITLE
Files opens as a reader; the IDE keeps its route

### DIFF
--- a/apps/portal-next/checks/redirect-table.mjs
+++ b/apps/portal-next/checks/redirect-table.mjs
@@ -17,6 +17,7 @@
 // the old name.
 
 import { LEGACY_PATHS, LIVE_PATHS, legacyTarget } from './redirects.mjs';
+import { EDIT_PATH, READ_PATH, filesHref, filesMode, filesTarget } from './files-routes.mjs';
 
 let bad = 0;
 const check = (label, got, want) => {
@@ -103,6 +104,83 @@ check('/services/ resolves like /services', legacyTarget('/services/'), '/contro
 // stops resolving.
 check('an encoded id survives',
   legacyTarget('/services/edge%2Ftraefik'), '/control/services/edge%2Ftraefik');
+
+console.log('\n── Files: one nav entry, two destinations ──────────────');
+
+// WHY THIS IS IN THE SAME FILE as the redirects. It is the same defect with a
+// different cause: a URL that resolves, answers 200, renders a plausible page,
+// and is not the page the link meant. `/files` used to be the IDE and is now the
+// reader, `/files/edit` is the IDE, and BOTH carry `?root=&path=` so that every
+// deep link written before the split opens the same document in either. There is
+// nothing on screen that distinguishes "your link opened your document" from
+// "your link opened the reader's empty state", which is exactly the property
+// that makes this worth a truth table rather than a glance.
+//
+// The expectations are written longhand and NOT derived from the module: a check
+// that computes its answer the same way the code does asserts nothing.
+
+check('/files is the reader', filesMode('/files'), 'read');
+check('/files/edit is the editor', filesMode('/files/edit'), 'edit');
+// `/files` is a PREFIX of `/files/edit`, so an order-sensitive implementation
+// gets this wrong in a way that sends every Edit click to the reader.
+check('/files/edit is not matched as /files', filesMode('/files/edit') !== 'read', true);
+// A pasted link often carries a trailing slash. Same page.
+check('/files/ resolves', filesMode('/files/'), 'read');
+check('/files/edit/ resolves', filesMode('/files/edit/'), 'edit');
+// A near miss must be nothing at all rather than the reader, or a typo renders
+// a document index instead of the not-found page that says the link is broken.
+for (const p of ['/', '/filesx', '/files/editx', '/files/edit/x', '/control', '/settings']) {
+  check(`${p} is not a Files route`, filesMode(p), null);
+}
+
+console.log('\n── ?root= and ?path= survive both modes ────────────────');
+
+// The pair that has to hold in both directions: a URL built for one mode, parsed
+// back, is the same document. A builder that drops `path` passes every test that
+// only looks at the pathname.
+const DOCS = [
+  ['stacks', 'docs/plans/reading-first.md'],
+  ['notes', 'network/dns.md'],
+  // A space and a hash in a filename - both are legal on disk, and both break a
+  // hand-rolled query string. The hash matters twice over here: main.tsx mounts
+  // a HashRouter, so a raw `#` in a value would truncate the whole route.
+  ['projects', 'a folder/a file #2.md'],
+  ['home', 'x.md'],
+];
+for (const mode of ['read', 'edit']) {
+  for (const [root, path] of DOCS) {
+    const href = filesHref(mode, root, path);
+    const [p, s] = href.split('?');
+    check(`${mode}: ${root}/${path} round-trips`,
+      filesTarget(p, s), { mode, root, path });
+    check(`${mode}: ${path} carries no bare #`, href.includes('#'), false);
+  }
+}
+// The reader with nothing open still names its root, so a reload lands on the
+// same index rather than on the first root in the list.
+check('a root with no path keeps the root',
+  filesTarget(...filesHref('read', 'notes').split('?')), { mode: 'read', root: 'notes', path: '' });
+// A bare /files is legal - it is what the nav entry links to.
+check('a bare /files parses', filesTarget('/files'), { mode: 'read', root: '', path: '' });
+// The two modes must produce DIFFERENT urls for the same document, or the Edit
+// button is a link to the page it is already on.
+check('the two modes differ',
+  filesHref('read', 'stacks', 'a.md') !== filesHref('edit', 'stacks', 'a.md'), true);
+
+console.log('\n── the router and the redirect table agree ─────────────');
+
+// Both routes have to be in LIVE_PATHS: that list is what every redirect target
+// is tested against, so a page missing from it turns a correct redirect into a
+// reported failure - and, worse, hides a redirect that really does point at a
+// page that no longer exists.
+check('/files is a live route', new Set(LIVE_PATHS).has(READ_PATH), true);
+check('/files/edit is a live route', new Set(LIVE_PATHS).has(EDIT_PATH), true);
+// Neither is a redirect. `/files` in particular: it changed MEANING rather than
+// address, and the temptation when that happens is to redirect the old meaning
+// somewhere. Every link ever shared to /files was a link to a file, and it still
+// opens that file - in the reader.
+check('/files is not a redirect', legacyTarget(READ_PATH), null);
+check('/files/edit is not a redirect', legacyTarget(EDIT_PATH), null);
 
 console.log(bad ? `\n${bad} FAILED` : '\nall pass');
 process.exit(bad ? 1 : 0);

--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Compile the dependency-free modules and run their truth tables against them:
 # the status classifier and the dependency graph out of discover.ts, the retired
-# URLs out of pages/control/redirects.ts, plus a pass over the box's real
-# container list.
+# URLs out of pages/control/redirects.ts, the two Files URLs out of
+# pages/files/routes.ts and the document titles out of pages/files/titles.ts,
+# plus a pass over the box's real container list.
 #
 # There is no test runner in this app on purpose - one 13-case truth table did
 # not justify pulling vitest into a static SPA's toolchain. Both modules import
@@ -25,7 +26,14 @@ mv "$OUT/discover.js" "$OUT/discover.mjs"
 (cd "$WEB" && npx tsc src/pages/control/redirects.ts --ignoreConfig \
   --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
 mv "$OUT/redirects.js" "$OUT/redirects.mjs"
-cp "$HERE/status-classifier.mjs" "$HERE/relations.mjs" "$HERE/redirect-table.mjs" "$OUT/"
+(cd "$WEB" && npx tsc src/pages/files/routes.ts --ignoreConfig \
+  --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
+mv "$OUT/routes.js" "$OUT/files-routes.mjs"
+(cd "$WEB" && npx tsc src/pages/files/titles.ts --ignoreConfig \
+  --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
+mv "$OUT/titles.js" "$OUT/titles.mjs"
+cp "$HERE/status-classifier.mjs" "$HERE/relations.mjs" "$HERE/redirect-table.mjs" \
+   "$HERE/titles-table.mjs" "$OUT/"
 
 echo "── truth table ─────────────────────────────────────────"
 node "$OUT/status-classifier.mjs"
@@ -35,8 +43,12 @@ echo "── relations ───────────────────
 node "$OUT/relations.mjs"
 
 echo
-echo "── redirects ───────────────────────────────────────────"
+echo "── redirects and the two Files URLs ────────────────────"
 node "$OUT/redirect-table.mjs"
+
+echo
+echo "── document titles ─────────────────────────────────────"
+node "$OUT/titles-table.mjs"
 
 echo
 echo "── this box, right now ─────────────────────────────────"

--- a/apps/portal-next/checks/titles-table.mjs
+++ b/apps/portal-next/checks/titles-table.mjs
@@ -1,0 +1,132 @@
+// What the reader calls a document - run with ./checks/run.sh
+//
+// WHY THIS EXISTS. The reader's side panel lists titles derived from filenames
+// (docs/plans/reading-first.md §3, pages/files/titles.ts). A wrong title is a
+// quiet defect: nothing errors, the list still renders, and the reader simply
+// does not find the note they were looking for because it is filed under a word
+// they would not have guessed. The failure is in the reader's head, not in a log.
+//
+// The cases below are REAL paths from the two documentation roots, so the table
+// doubles as the evidence for the decision the plan defers - whether prettified
+// filenames are good enough, or whether /tree needs a `titles=1` variant that
+// reads each file's first heading. The `heading` column is what the file's own
+// `# ` line says today; where it differs from the title, that difference is the
+// argument for the endpoint, and it is written down rather than remembered.
+
+import { isProse, titleOf } from './titles.mjs';
+
+let bad = 0;
+const check = (label, got, want) => {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  if (!ok) bad++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label.padEnd(52)}${ok ? '' : ` want=${JSON.stringify(want)} got=${JSON.stringify(got)}`}`);
+};
+
+console.log('── a filename is already a title ───────────────────────');
+
+// The ordinary case, and the reason the cheap version is worth shipping: whoever
+// named these files was writing the title.
+for (const [path, want] of [
+  ['docs/brand/foundations/shape-and-elevation.md', 'Shape and elevation'],
+  ['docs/brand/patterns/data-display.md', 'Data display'],
+  ['docs/kb/editor-drafts.md', 'Editor drafts'],
+  ['network/tailnet-troubleshooting.md', 'Tailnet troubleshooting'],
+  ['docs/plans/first-party-stack.md', 'First party stack'],
+  ['docs/kb/always-on.md', 'Always on'],
+]) check(path, titleOf(path), want);
+
+console.log('\n── acronyms are not sentence-cased ─────────────────────');
+
+// The one class of output that is visibly, embarrassingly wrong without a table:
+// "Dns" and "Metadata and seo" read as typos rather than as titles.
+for (const [path, want] of [
+  ['network/dns.md', 'DNS'],
+  ['machine/ssh.md', 'SSH'],
+  ['machine/wsl.md', 'WSL'],
+  ['docs/brand/quality/metadata-and-seo.md', 'Metadata and SEO'],
+  ['docs/brand/quality/pwa-and-manifest.md', 'PWA and manifest'],
+  ['docs/brand/quality/qa-and-verification.md', 'QA and verification'],
+  ['stack/kubernetes.md', 'Kubernetes'],
+]) check(path, titleOf(path), want);
+
+console.log('\n── SHOUTING FILENAMES stop shouting ────────────────────');
+
+// A top-level doc is named in caps by convention. Twenty of them in a list is
+// the list shouting at the reader, so the convention is dropped - except for the
+// handful of names that ARE the convention.
+for (const [path, want] of [
+  ['docs/ARCHITECTURE.md', 'Architecture'],
+  ['CODE_OF_CONDUCT.md', 'Code of conduct'],
+  ['.github/PULL_REQUEST_TEMPLATE.md', 'Pull request template'],
+  ['docs/brand/CHECKLIST.md', 'Checklist'],
+  ['README.md', 'README'],
+  ['docs/kb/README.md', 'README'],
+  ['LICENSE', 'LICENSE'],
+]) check(path, titleOf(path), want);
+
+console.log('\n── a dated note keeps its date ─────────────────────────');
+
+// The incident notes are found BY their date. Folding it into the sentence
+// ("2026 08 08 WSL node…") loses the one thing they are sorted and remembered by.
+for (const [path, want] of [
+  ['docs/kb/incidents/2026-08-01-ethernet-ndis.md', '2026-08-01 · Ethernet ndis'],
+  ['docs/kb/incidents/2026-08-08-wsl-node-large-packet-blackhole.md',
+   '2026-08-08 · WSL node large packet blackhole'],
+]) check(path, titleOf(path), want);
+
+console.log('\n── only the basename is read ───────────────────────────');
+
+// The folder is shown separately by the index. Folding it in here would title
+// every README after its directory and make four of them look like four
+// different documents when they are the same kind of document in four places.
+check('the folder is not part of the title',
+  titleOf('docs/brand/foundations/colour.md'), titleOf('colour.md'));
+check('a dotted stem keeps its first part', titleOf('a.b.md'), 'A b');
+
+console.log('\n── what counts as prose ────────────────────────────────');
+
+// The claim `isProse` makes is "a person reads this end to end", not "this is
+// text". A .yml is text and nobody reads one for pleasure - and if this ever
+// widened to include them, the "prose first" ordering would stop meaning
+// anything and the index would silently become the Explorer again.
+for (const [path, want] of [
+  ['docs/kb/access.md', true],
+  ['a.markdown', true],
+  ['requirements.txt', true],
+  ['x.rst', true],
+  ['compose.yml', false],
+  ['app.py', false],
+  ['policy.toml', false],
+  ['Dockerfile', false],
+  ['justfile', false],
+  ['logo.svg', false],
+]) check(`${path} is ${want ? '' : 'not '}prose`, isProse(path), want);
+
+console.log('\n── where a filename is NOT enough ──────────────────────');
+
+// NOT failures - these are the measured limit of the cheap version, recorded so
+// the decision in reading-first.md §3 ("add /tree?titles=1 only if the titles are
+// actually wrong often enough to notice") is made from evidence rather than from
+// memory. In every case the title is CORRECT and INCOMPLETE: the document's own
+// heading is the filename plus a subtitle. That is a subtitle problem, and a
+// subtitle is not what the index has room for.
+const SUBTITLED = [
+  ['docs/kb/runbook-cant-reach.md', 'RUNBOOK - "I can\'t reach the dev stack"'],
+  ['docs/kb/access.md', 'Access - every way into the dev box, and why the obvious ones fail'],
+  ['docs/kb/topology.md', 'Topology - machines, users, addresses'],
+  ['docs/kb/lessons.md', 'Lessons - principles paid for in real debugging time'],
+];
+const firstWord = (s) => (s.toLowerCase().match(/[a-z0-9]+/) ?? [''])[0];
+for (const [path, heading] of SUBTITLED) {
+  const t = titleOf(path);
+  // The assertion is narrow and it is the one that matters: the title and the
+  // heading OPEN ON THE SAME WORD, so the filename is naming the same subject
+  // and what it is missing is only the tail. The day one of these stops agreeing
+  // is the day the filename names something else, and THAT is the signal to
+  // build /tree?titles=1 - not a general feeling that headings are nicer.
+  check(`${path} names the same subject`, firstWord(t), firstWord(heading));
+  console.log(`      ${t}  ·  heading: ${heading}`);
+}
+
+console.log(bad ? `\n${bad} FAILED` : '\nall pass');
+process.exit(bad ? 1 : 0);

--- a/apps/portal-next/web/src/App.tsx
+++ b/apps/portal-next/web/src/App.tsx
@@ -8,6 +8,7 @@ import { Ports, Routes as RoutesPage } from './pages/Access';
 import { Topology } from './pages/Topology';
 import { Settings } from './pages/Settings';
 import { Files } from './pages/files/Files';
+import { Reader } from './pages/files/Reader';
 import { ControlShell } from './pages/control/ControlShell';
 import { Control } from './pages/control/Control';
 import { LEGACY_PATHS, legacyTarget } from './pages/control/redirects';
@@ -42,10 +43,18 @@ export function App() {
 
         <Route path="settings" element={<Settings />} />
 
-        {/* BothyFiles - the explorer. `?root=` and `?path=` rather than path
-            segments, so a file whose own path contains slashes needs no encoding
-            games and a deep link survives being pasted into chat. */}
-        <Route path="files" element={<Files />} />
+        {/* Bothy Files - one nav entry, two destinations (docs/plans/
+            reading-first.md §2). `/files` opens as a READER; the IDE is
+            unchanged at `/files/edit`.
+
+            Both take the same `?root=` and `?path=` - path segments would make a
+            file whose own path contains slashes an encoding game, and the query
+            string is what lets an existing deep link resolve in EITHER mode. The
+            route paths and the two link builders live in pages/files/routes.ts
+            with a truth table over them, because a builder that drops `path` is
+            a link that answers 200 and quietly goes somewhere else. */}
+        <Route path="files" element={<Reader />} />
+        <Route path="files/edit" element={<Files />} />
 
         {/* The retired URLs. Built from the table rather than listed again here,
             so the router and pages/control/redirects.ts cannot disagree about

--- a/apps/portal-next/web/src/pages/control/redirects.ts
+++ b/apps/portal-next/web/src/pages/control/redirects.ts
@@ -45,7 +45,13 @@ export const LIVE_PATHS = [
   '/control/routes',
   '/control/topology',
   '/settings',
+  // Files is one nav entry and two routes since reading-first.md §2: `/files`
+  // reads, `/files/edit` is the IDE. Both are listed because this array is what
+  // the check tests redirect targets against - and because the moment a page
+  // exists and is not in here, a redirect pointed at it would be reported as
+  // broken by a check that was right about everything except this list.
   '/files',
+  '/files/edit',
 ] as const;
 
 /**

--- a/apps/portal-next/web/src/pages/files/DocIndex.tsx
+++ b/apps/portal-next/web/src/pages/files/DocIndex.tsx
@@ -1,0 +1,305 @@
+// ── the document index ───────────────────────────────────────────────────────
+//
+// The reader's side panel, and the part of docs/plans/reading-first.md §3 that
+// says most plainly what it must NOT be: "the Explorer with different CSS".
+//
+// Three differences, and each one is a decision rather than a style:
+//
+//   · IT SHOWS TITLES. `tailnet-troubleshooting.md` is "Tailnet
+//     troubleshooting" (titles.ts), with the filename underneath in mono for
+//     anyone who came looking for a path. The Explorer shows the filename
+//     because the Explorer is a view of a filesystem; this is a view of a
+//     library.
+//   · IT IS PROSE FIRST. Markdown, rst and txt, grouped by folder. Everything
+//     else - 117 code files and 42 configs in the stacks root alone - is behind
+//     one "All files" toggle. The reader is NOT lied to about what is there;
+//     the order is by what the page is for, and the count of what is hidden is
+//     printed next to the switch that reveals it.
+//   · IT IS FLAT INSIDE A ROOT. Folder, then its documents, then the next
+//     folder - no chevrons, no expand state, no lazy children. That works here
+//     and does not work in the Explorer for one measurable reason: prose is
+//     ~84 files across the two documentation roots, and a tree exists to make
+//     3,500 files navigable. Turning on "All files" is the case where that
+//     stops being true, so that is exactly where the row cap lives.
+//
+// A ROOT IS LOADED WHEN IT IS OPENED, not on mount. /tree is capped at 4,000
+// entries per root (portal-files/app.py MAX_LISTING) and there are four roots,
+// so listing all of them up front is up to 16,000 entries of JSON to render a
+// panel whose first screen is eighteen notes. The root the URL names is open on
+// arrival; the others are one click.
+
+import { useEffect, useMemo, useRef } from 'react';
+import { ChevronRight, FileText, Layers, Lock } from 'lucide-react';
+import { fmtBytes, type FileRoot, type TreeFile } from '../../lib/files';
+import { FileIcon } from './icons';
+import { folderLabel, isProse, stemOf, titleOf } from './titles';
+import { tailPath } from './tree';
+
+/** What one root's listing is doing. Held by the Reader, one per root. */
+export interface RootTree {
+  entries: TreeFile[];
+  truncated: boolean;
+  loading: boolean;
+  err: string | null;
+}
+
+/** Rows drawn for one root before the list gives up and says so.
+ *
+ *  Only reachable with "All files" on: prose tops out at 69 files in the largest
+ *  root. It is the same refusal the Explorer's search results make at 250 and
+ *  the tree listing makes at 4,000 - a list that silently stops is how someone
+ *  concludes a file is not there. */
+const MAX_ROWS = 400;
+
+interface Folder { dir: string; files: TreeFile[] }
+
+/** Lowercase, and every separator run collapsed to one space - so `a-b_c.md`
+ *  and "A b c" compare equal. Used only to decide whether a row's title and its
+ *  filename are the same string wearing different punctuation. */
+const fold = (s: string) => s.toLowerCase().replace(/[-_.\s]+/g, ' ').trim();
+
+/** Group a root's files by their directory, keeping the service's path order.
+ *  `entries` arrives sorted by path, so directories come out in path order and
+ *  the files inside one are already alphabetical - no second sort, and the
+ *  ordering matches the tree the Explorer draws from the same bytes. */
+function foldersOf(entries: TreeFile[], prose: boolean): { folders: Folder[]; total: number } {
+  const at = new Map<string, Folder>();
+  const folders: Folder[] = [];
+  let total = 0;
+  for (const e of entries) {
+    if (e.dir === true) continue;
+    if (prose && !isProse(e.path)) continue;
+    total++;
+    if (total > MAX_ROWS) continue;
+    const cut = e.path.lastIndexOf('/');
+    const dir = cut === -1 ? '' : e.path.slice(0, cut);
+    let f = at.get(dir);
+    if (!f) { f = { dir, files: [] }; at.set(dir, f); folders.push(f); }
+    f.files.push(e);
+  }
+  return { folders, total };
+}
+
+function DocRow({ entry, root, current, onOpen }: {
+  entry: TreeFile; root: string; current: string; onOpen: (root: string, path: string) => void;
+}) {
+  const on = entry.path === current;
+  const denied = entry.readable === false;
+  const name = entry.path.slice(entry.path.lastIndexOf('/') + 1);
+  const prose = isProse(entry.path);
+  // A title is a CLAIM about what the file is for, and it is only honest for
+  // prose. `compose.yml` prettified to "Compose" would be inventing a document.
+  const label = prose ? titleOf(entry.path) : name;
+  // The filename under the title, and only when the title is not already the
+  // filename. Compared with the separators FOLDED, which is the whole point:
+  // "Tailnet performance" and `tailnet-performance.md` are the same string with
+  // different punctuation, and printing both put a second line under most rows
+  // that carried no information at all. What survives the fold is a title the
+  // filename genuinely does not spell - a dated incident note, mostly - and
+  // those are exactly the rows where the filename is worth showing.
+  const sub = prose && fold(stemOf(name)) !== fold(label) ? name : '';
+
+  return (
+    <li className="rd-li">
+      <button
+        type="button"
+        className={`rd-doc${on ? ' on' : ''}${denied ? ' denied' : ''}`}
+        // Both halves, because `home` mirrors the other roots: the same
+        // relative path exists in two open sections, and a lookup on the path
+        // alone would scroll to whichever rendered first.
+        data-root={root}
+        data-path={entry.path}
+        aria-current={on ? 'true' : undefined}
+        aria-disabled={denied || undefined}
+        disabled={denied}
+        onClick={() => onOpen(root, entry.path)}
+        title={denied ? `${entry.path} - this session may not read it` : `${root}/${entry.path} · ${fmtBytes(entry.size)}`}
+      >
+        {denied
+          ? <Lock size={13} className="rd-doc-ico" aria-hidden="true" />
+          : prose
+            ? <FileText size={13} className="rd-doc-ico" aria-hidden="true" />
+            : <FileIcon name={name} size={13} />}
+        <span className="rd-doc-text">
+          <span className="rd-doc-title">{label}</span>
+          {sub && <span className="rd-doc-name">{sub}</span>}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+function RootSection({
+  root, tree, open, onToggle, allFiles, current, currentRoot, onOpen, onRetry,
+}: {
+  root: FileRoot;
+  tree: RootTree | undefined;
+  open: boolean;
+  onToggle: () => void;
+  allFiles: boolean;
+  current: string;
+  currentRoot: string;
+  onOpen: (root: string, path: string) => void;
+  onRetry: (root: string) => void;
+}) {
+  const entries = tree?.entries ?? [];
+  const { folders, total } = useMemo(
+    () => foldersOf(entries, !allFiles),
+    [entries, allFiles],
+  );
+  // What the toggle would ADD, stated on the toggle's own row rather than left
+  // for the reader to infer from a number that changed.
+  const hidden = useMemo(
+    () => (allFiles ? 0 : entries.filter((e) => e.dir !== true && !isProse(e.path)).length),
+    [entries, allFiles],
+  );
+
+  return (
+    <section className="rd-root" aria-label={root.label || root.key}>
+      <h3 className="rd-root-h">
+        <button type="button" className="rd-root-btn" aria-expanded={open} onClick={onToggle}>
+          <ChevronRight size={12} className={`rd-chev${open ? ' open' : ''}`} aria-hidden="true" />
+          <span className="rd-root-name mono">{root.key}</span>
+          {root.readOnly && <Lock size={10} className="rd-root-ro" aria-label="read-only" />}
+          {open && !tree?.loading && (
+            <span className="rd-root-n tnum">{total > MAX_ROWS ? `${MAX_ROWS}+` : total}</span>
+          )}
+        </button>
+      </h3>
+
+      {open && (
+        tree?.loading ? (
+          <div className="rd-skel" aria-hidden="true">
+            {Array.from({ length: 6 }, (_, i) => <span className="skel" key={i} />)}
+          </div>
+        ) : tree?.err ? (
+          <div className="rd-msg">
+            <p>{tree.err}</p>
+            <button type="button" className="btn ghost sm" onClick={() => onRetry(root.key)}>Retry</button>
+          </div>
+        ) : !total ? (
+          <div className="rd-msg">
+            <p>{allFiles ? 'This root is empty.' : 'No documents in this root - try All files.'}</p>
+          </div>
+        ) : (
+          <>
+            {folders.map((f) => (
+              <div className="rd-folder" key={f.dir || '.'}>
+                {/* Truncated from the LEFT, via the same helper the Explorer's
+                    search hits use, and for the same measured reason: the tail
+                    of a folder path is what distinguishes it, and CSS's
+                    text-overflow can only cut the end. `docs/brand/foundations`
+                    and `docs/brand/patterns` are identical for the first
+                    eleven characters. */}
+                <p className="rd-folder-h mono" title={`${root.key}/${f.dir}`}>
+                  {tailPath(folderLabel(f.dir, root.key), 32)}
+                </p>
+                <ul className="rd-list">
+                  {f.files.map((e) => (
+                    <DocRow
+                      key={e.path}
+                      entry={e}
+                      root={root.key}
+                      current={root.key === currentRoot ? current : ''}
+                      onOpen={onOpen}
+                    />
+                  ))}
+                </ul>
+              </div>
+            ))}
+            {total > MAX_ROWS && (
+              <p className="rd-more">
+                {(total - MAX_ROWS).toLocaleString()} more in this root - use the search above.
+              </p>
+            )}
+            {/* The listing cap, carried through from /tree. The Explorer says
+                this in the Problems panel, which the reader does not have. */}
+            {tree?.truncated && (
+              <p className="rd-more warn">
+                The file service stopped listing this root at its own cap, so files
+                below it are missing here. A search still reaches them.
+              </p>
+            )}
+            {!allFiles && hidden > 0 && (
+              <p className="rd-more">
+                {hidden.toLocaleString()} more file{hidden === 1 ? '' : 's'} that are not documents.
+              </p>
+            )}
+          </>
+        )
+      )}
+    </section>
+  );
+}
+
+export function DocIndex({
+  roots, trees, openRoots, onToggleRoot, allFiles, onAllFiles,
+  currentRoot, currentPath, onOpen, onRetry,
+}: {
+  roots: FileRoot[];
+  trees: Record<string, RootTree | undefined>;
+  openRoots: ReadonlySet<string>;
+  onToggleRoot: (root: string) => void;
+  allFiles: boolean;
+  onAllFiles: (on: boolean) => void;
+  currentRoot: string;
+  currentPath: string;
+  onOpen: (root: string, path: string) => void;
+  onRetry: (root: string) => void;
+}) {
+  const box = useRef<HTMLDivElement | null>(null);
+
+  // Keep the open document visible in the index. It matters most for the case
+  // this reader exists to serve: following a relative link three documents deep
+  // moves the selection to a row that may be hundreds below the fold, and an
+  // index that does not follow stops being a place you know where you are.
+  //
+  // `nearest` is doing real work - it is a no-op when the row is already on
+  // screen, so browsing the list by hand is never yanked out from under the
+  // pointer. The frame's wait is for the row itself: a root that has just been
+  // opened has not rendered its listing yet.
+  useEffect(() => {
+    if (!currentPath) return;
+    const raf = requestAnimationFrame(() => {
+      box.current
+        ?.querySelector(`[data-root="${CSS.escape(currentRoot)}"][data-path="${CSS.escape(currentPath)}"]`)
+        ?.scrollIntoView({ block: 'nearest' });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [currentRoot, currentPath, trees, allFiles]);
+
+  return (
+    <div className="rd-index" ref={box}>
+      <div className="rd-index-h">
+        <span className="rd-index-title">Documents</span>
+        {/* Not an icon and not in a menu. It changes what the list CLAIMS to be
+            - a library or a filesystem - and a control that changes the meaning
+            of everything below it has to be visible while you read them. */}
+        <label className="rd-all">
+          <input
+            type="checkbox"
+            checked={allFiles}
+            onChange={(e) => onAllFiles(e.target.checked)}
+          />
+          <Layers size={12} aria-hidden="true" />
+          <span>All files</span>
+        </label>
+      </div>
+
+      {roots.map((r) => (
+        <RootSection
+          key={r.key}
+          root={r}
+          tree={trees[r.key]}
+          open={openRoots.has(r.key)}
+          onToggle={() => onToggleRoot(r.key)}
+          allFiles={allFiles}
+          current={currentPath}
+          currentRoot={currentRoot}
+          onOpen={onOpen}
+          onRetry={onRetry}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/portal-next/web/src/pages/files/FileView.tsx
+++ b/apps/portal-next/web/src/pages/files/FileView.tsx
@@ -36,7 +36,7 @@ type State =
   | { at: 'too-large'; why: string }
   | { at: 'error'; why: string };
 
-export function FileView({ root, path, view = 'preview', frag = '', onOpen }: {
+export function FileView({ root, path, view = 'preview', frag = '', onOpen, onLoad }: {
   root: string;
   path: string;
   /** Controlled by the caller. A reader that wants a Preview/Source switch owns
@@ -47,6 +47,14 @@ export function FileView({ root, path, view = 'preview', frag = '', onOpen }: {
   /** Follow a cross-document link. Absent means those links keep rendering as
    *  inert text, which is the honest state for a view with nowhere to send you. */
   onOpen?: (path: string, frag: string) => void;
+  /** The file this view is currently showing, or null while it is not showing
+   *  one. Read-only, and it is worth saying WHY that is not a crack in the rule
+   *  at the top: a caller cannot write anything with it. It exists because the
+   *  facts a reader puts around a document - when it last changed and who
+   *  changed it - come back on the SAME read this component already made, and
+   *  the alternative is the page fetching the file a second time to learn what
+   *  this component already knows. */
+  onLoad?: (file: FileRead | null) => void;
 }) {
   const [state, setState] = useState<State>({ at: 'loading' });
   const [tick, setTick] = useState(0);
@@ -90,6 +98,16 @@ export function FileView({ root, path, view = 'preview', frag = '', onOpen }: {
     const at = box.current?.querySelector(`[data-md-anchor="${CSS.escape(slug)}"]`);
     at?.scrollIntoView({ block: 'start', behavior: 'auto' });
   }, [state, frag]);
+
+  // Announced from an EFFECT rather than from the `.then()` above, so a caller
+  // that sets state on it is not doing so during this component's render - and
+  // so every path that stops showing a file (missing, denied, too large) reports
+  // the same `null` without each catch branch having to remember to.
+  const notify = useRef(onLoad);
+  useEffect(() => { notify.current = onLoad; });
+  useEffect(() => {
+    notify.current?.(state.at === 'ready' ? state.file : null);
+  }, [state]);
 
   const retry = () => setTick((n) => n + 1);
 

--- a/apps/portal-next/web/src/pages/files/Files.tsx
+++ b/apps/portal-next/web/src/pages/files/Files.tsx
@@ -49,8 +49,8 @@
 //     history survive a tab switch, which the old `key={docKey}` destroyed.
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { PanelBottom, PanelLeft, PanelRight } from 'lucide-react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { BookOpen, PanelBottom, PanelLeft, PanelRight } from 'lucide-react';
 import {
   ARCHIVE_MAX_ENTRIES, ARCHIVE_MAX_MEMBER, ARCHIVE_MAX_TOTAL,
   archiveUrl, fileHistory, fmtBytes, gitDiff, gitStatus, isAuthError, langFor,
@@ -75,6 +75,7 @@ import { SignInCard } from './SignInCard';
 import { SourceControl } from './SourceControl';
 import { decorate, NO_DECORATIONS, type Change } from './gitdeco';
 import { usePanes } from './panes';
+import { filesHref } from './routes';
 import { ancestorsOf, baseName, buildTree, defaultMessage, type Node } from './tree';
 
 import './shell.css';
@@ -1172,6 +1173,27 @@ export function Files() {
                   </>}
           </p>
         </div>
+        {/* ── the way back ─────────────────────────────────────────────────
+            Work -> Read, which reading-first.md §2 asks for so that closing the
+            tools is one click and does not lose the file: it carries the ACTIVE
+            document, not just the root.
+
+            Here rather than in the status strip, which is where the file's path
+            now lives. That strip is a readout - position, size, language,
+            writability - and it says so out loud ("NO BUTTONS BELOW THIS LINE",
+            Editor.tsx); it is also per-GROUP, and a split would give the page two
+            of these. This header is the one thing on screen that belongs to the
+            page rather than to a document.
+
+            Spelled out in words rather than an icon, unlike its three neighbours,
+            because it is a DESTINATION and they are layout toggles. */}
+        <Link
+          className="btn ghost sm fx-head-read"
+          to={filesHref('read', active ? active.root : root, active ? active.path : '')}
+          title={active ? `Read ${baseName(active.path)} without the editor` : 'Open the reading view'}
+        >
+          <BookOpen size={14} aria-hidden="true" /> Reading view
+        </Link>
         <div className="fx-head-actions" role="group" aria-label="Layout">
           <Tooltip label={`${panes.cl ? 'Show' : 'Hide'} the explorer`}>
             <button

--- a/apps/portal-next/web/src/pages/files/Reader.tsx
+++ b/apps/portal-next/web/src/pages/files/Reader.tsx
@@ -1,0 +1,367 @@
+// ── Files, as a reader ───────────────────────────────────────────────────────
+//
+// The default at `/files`. docs/plans/reading-first.md: markdown under docs/ and
+// ~/claude-notes is 76 files and 9,141 lines, this page replaced a MkDocs site,
+// and what the IDE showed on arrival was an empty centre, six keyboard shortcuts
+// and a tree of 3,500 files. The tax of the editor's four regions was paid on
+// every read, by everyone, to make the rarer case one click cheaper.
+//
+// So: a document, an index of documents, and its own headings. The IDE is
+// unchanged at `/files/edit`, and both take the same `?root=&path=`.
+//
+// ── THE LINE THIS PAGE IS BUILT AROUND (§7) ──────────────────────────────────
+//
+// **Reading mode never writes.** Not "does not write yet". There is no draft
+// here, no dirty flag, no conflict check, no save, no localStorage key. The
+// failure mode that rule exists to prevent is this page growing a save button,
+// then a dirty indicator, then a conflict dialog, until there are two editors
+// and the second one is missing the mtime check that makes the first one safe.
+// Its answer to every one of those is the Edit button, which is a LINK.
+//
+// The proof is mechanical rather than a promise: nothing in this module's import
+// graph reaches writeFile, CodeSurface or Editor.tsx. FileContent takes its text
+// surface as a prop for exactly this reason, so the reader hands it a
+// highlighted `<pre>` and the editor hands it CodeMirror - and the reader never
+// downloads CodeMirror's 332 kB chunk.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { ChevronLeft, GitCommitHorizontal, Pencil } from 'lucide-react';
+import {
+  isAuthError, listRoots, listTree, relDate,
+  type FileRead, type FileRoot,
+} from '../../lib/files';
+import { ErrState } from '../../components/states';
+import { useMe } from '../../components/UserMenu';
+import { hasRole } from '../../lib/me';
+import { DocIndex, type RootTree } from './DocIndex';
+import { FileView } from './FileView';
+import { SearchView } from './Search';
+import { SignInCard } from './SignInCard';
+import { Toc, useHeadings } from './Toc';
+import { filesHref } from './routes';
+import { baseName, dirName } from './tree';
+
+// shell.css carries the section scope (the full-height escape from `.content`,
+// the inset focus ring and the syntax palette) and editor.css carries `.fx-read`
+// and every `.md-*` rule - both of which belong to the RENDERED DOCUMENT rather
+// than to the editor, which is why the reader gets them by importing rather than
+// by copying. explorer.css is here for `.fx-filter`, the search box's frame.
+import './shell.css';
+import './editor.css';
+import './explorer.css';
+import './search.css';
+import './read.css';
+
+const LOADING: RootTree = { entries: [], truncated: false, loading: true, err: null };
+
+export function Reader() {
+  const [params, setParams] = useSearchParams();
+  const urlRoot = params.get('root') || '';
+  const path = params.get('path') || '';
+  const { me } = useMe();
+
+  const [roots, setRoots] = useState<FileRoot[]>([]);
+  const [needsAuth, setNeedsAuth] = useState(false);
+  const [rootsErr, setRootsErr] = useState<string | null>(null);
+  const [trees, setTrees] = useState<Record<string, RootTree | undefined>>({});
+  const [openRoots, setOpenRoots] = useState<Set<string>>(new Set());
+  const [allFiles, setAllFiles] = useState(false);
+  const [tick, setTick] = useState(0);
+
+  // The `#heading` of a followed cross-document link. State and NOT the URL:
+  // main.tsx mounts a HashRouter, so the whole route already lives after a `#`
+  // and a second one would be ambiguous to the browser and to anyone pasting it.
+  const [frag, setFrag] = useState('');
+  const [file, setFile] = useState<FileRead | null>(null);
+
+  // Which of the two columns a NARROW screen is showing. On anything wide enough
+  // for both this is inert - read.css only acts on it under the breakpoint. It
+  // is the list/detail pattern, because the alternative on a 390px screen is an
+  // index that occupies the phone and a document nobody can reach.
+  const [pane, setPane] = useState<'index' | 'doc'>(path ? 'doc' : 'index');
+
+  const docBox = useRef<HTMLDivElement | null>(null);
+  const root = urlRoot;
+
+  // ── the roots ──────────────────────────────────────────────────────────────
+  //
+  // Same fallback as the editor's: a `?root=` naming a root that no longer
+  // exists lands on the first one rather than rendering a 400 as if the service
+  // were broken. `replace`, so Back does not bounce off the dead URL.
+  useEffect(() => {
+    const ac = new AbortController();
+    listRoots(ac.signal)
+      .then((r) => {
+        setRoots(r.roots);
+        setNeedsAuth(false);
+        setRootsErr(null);
+        if (!r.roots.length) return;
+        const known = r.roots.some((x) => x.key === urlRoot);
+        const pick = known ? urlRoot : r.roots[0].key;
+        if (!known) {
+          const next = new URLSearchParams();
+          next.set('root', pick);
+          setParams(next, { replace: true });
+        }
+        // The root you arrived in is the one open on arrival. The others are one
+        // click, and each pays for its own listing - see the note in DocIndex.
+        setOpenRoots((prev) => (prev.size ? prev : new Set([pick])));
+      })
+      .catch((e: unknown) => {
+        if (ac.signal.aborted) return;
+        if (isAuthError(e)) { setNeedsAuth(true); return; }
+        setRootsErr(e instanceof Error ? e.message : String(e));
+      });
+    return () => ac.abort();
+    // `urlRoot` is read but is deliberately not a dependency: the default-root
+    // write is a one-shot that would otherwise re-fire on its own result.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tick]);
+
+  // ── one listing per opened root ────────────────────────────────────────────
+  //
+  // Fetched when the section opens and kept for the life of the page. Nothing
+  // here mutates a file, so a listing cannot go stale under this page's own
+  // hands - the refresh is the Retry on a failed one.
+  //
+  // THE CONTROLLERS LIVE IN A REF, AND THIS EFFECT HAS NO CLEANUP THAT ABORTS
+  // THEM. That is not an oversight, it is the fix for one: this effect writes
+  // `trees` (the LOADING marker) and also depends on it, so a cleanup that
+  // aborted would cancel the request it had just made, one commit later, on its
+  // own state change - and the section would sit on its skeleton forever with a
+  // net::ERR_ABORTED in the log and no error on screen. Measured, on `home`.
+  // The only abort that is correct here is the one on unmount.
+  const inflight = useRef(new Map<string, AbortController>());
+  useEffect(() => () => { for (const ac of inflight.current.values()) ac.abort(); }, []);
+
+  useEffect(() => {
+    const want = [...openRoots].filter((k) => !trees[k] && !inflight.current.has(k));
+    if (!want.length) return;
+    setTrees((prev) => {
+      const next = { ...prev };
+      for (const k of want) next[k] = LOADING;
+      return next;
+    });
+    for (const k of want) {
+      const ac = new AbortController();
+      inflight.current.set(k, ac);
+      listTree(k, ac.signal)
+        .then((r) => {
+          if (ac.signal.aborted) return;
+          inflight.current.delete(k);
+          setTrees((prev) => ({
+            ...prev,
+            [k]: { entries: r.files, truncated: !!r.truncated, loading: false, err: null },
+          }));
+        })
+        .catch((e: unknown) => {
+          if (ac.signal.aborted) return;
+          inflight.current.delete(k);
+          if (isAuthError(e)) { setNeedsAuth(true); return; }
+          setTrees((prev) => ({
+            ...prev,
+            [k]: { entries: [], truncated: false, loading: false, err: e instanceof Error ? e.message : String(e) },
+          }));
+        });
+    }
+  }, [openRoots, trees]);
+
+  const openDoc = useCallback((r: string, p: string, at = '') => {
+    const next = new URLSearchParams();
+    next.set('root', r);
+    if (p) next.set('path', p);
+    setParams(next);
+    setFrag(at);
+    setPane('doc');
+    // A root you opened a document in is a root you are reading, so its section
+    // opens too - otherwise following a search result into `notes` leaves the
+    // index showing a root the document is not in.
+    setOpenRoots((prev) => (prev.has(r) ? prev : new Set(prev).add(r)));
+  }, [setParams]);
+
+  const toggleRoot = useCallback((k: string) => {
+    setOpenRoots((prev) => {
+      const next = new Set(prev);
+      next.has(k) ? next.delete(k) : next.add(k);
+      return next;
+    });
+  }, []);
+
+  const retryRoot = useCallback((k: string) => {
+    inflight.current.delete(k);
+    setTrees((prev) => {
+      const next = { ...prev };
+      delete next[k];
+      return next;
+    });
+  }, []);
+
+  const headings = useHeadings(docBox, `${root}\0${path}`);
+  const last = file?.history?.[0] ?? null;
+
+  // ── the Edit button (§2, step 5) ───────────────────────────────────────────
+  //
+  // ABSENT rather than disabled for someone who cannot write. A reader should not
+  // carry a control that exists to be refused - a greyed Edit is a promise the
+  // page has no way to keep, and it invites a click that produces a 403.
+  //
+  // `hasRole` is an INTERFACE decision and never a boundary. The file service
+  // decides who may write, from a signed cookie, and would refuse this session
+  // just as flatly if this line were deleted.
+  //
+  // The FILE's own answer is the second half, and it is not redundant: the
+  // policy makes `home` and `projects` read-only roots and limits writes to a
+  // handful of suffixes, so an `editor` looking at a .ts in `stacks`, or at
+  // anything at all under `home`, would land in an editor with its own Edit
+  // pencil already missing. Same rule as the role, applied to the other half of
+  // the question - `writable` is what the read itself reported, so there is no
+  // extra request to ask it.
+  const mayEdit = hasRole(me, 'editor') && file?.writable === true;
+
+  const index = (
+    <DocIndex
+      roots={roots}
+      trees={trees}
+      openRoots={openRoots}
+      onToggleRoot={toggleRoot}
+      allFiles={allFiles}
+      onAllFiles={setAllFiles}
+      currentRoot={root}
+      currentPath={path}
+      onOpen={openDoc}
+      onRetry={retryRoot}
+    />
+  );
+
+  return (
+    <div className="bothy-files bothy-read" data-pane={pane}>
+      {needsAuth ? (
+        <div className="fx-gate"><SignInCard what="read the box" onRetry={() => setTick((t) => t + 1)} /></div>
+      ) : rootsErr ? (
+        <div className="fx-gate">
+          <ErrState
+            title="Cannot reach the file service"
+            body={`/-/api/files did not answer (${rootsErr}). Nothing on this page can load until it does.`}
+            onRetry={() => setTick((t) => t + 1)}
+          />
+        </div>
+      ) : (
+        <div className="rd-grid">
+          {/* ── the side panel ──────────────────────────────────────────────
+              Search at the TOP, not behind an icon (§3), and it is the editor's
+              own SearchView rather than a second one. The index rides in its
+              `idle` slot, so the two share one scroll container and results
+              replace the index instead of pushing it off the screen. */}
+          <aside className="rd-side" aria-label="Documents">
+            <SearchView
+              roots={roots}
+              // '*' - every root that does not alias another, which is the
+              // service's own token. A reader looking for a sentence does not
+              // know which root it is in; that is the question search answers.
+              root="*"
+              onOpen={(r, p) => openDoc(r, p)}
+              onNeedsAuth={() => setTick((t) => t + 1)}
+              idle={index}
+            />
+          </aside>
+
+          <main className="rd-main" aria-label="Document">
+            {path ? (
+              <>
+                {/* ── the header, and the title it deliberately does NOT carry ──
+                    A derived title here would be printed directly above the
+                    document's own `# heading`, which is the same words twice,
+                    ninety pixels apart - and worse than twice when they
+                    disagree: `~/claude-notes/README.md` would read "README"
+                    above "Claude notes - map", labelling the document with the
+                    one name that says nothing about it.
+
+                    md.tsx has always shifted heading levels down one "because
+                    the shell already owns the document title". In the editor
+                    that was not true of anything on screen. Here it is: the
+                    document's own first heading IS the title, rendered by the
+                    renderer, and this strip is its address and its provenance.
+                    The prettified title still earns its place in the index,
+                    where there is no document to speak for itself. */}
+                <header className="rd-head">
+                  <button
+                    type="button"
+                    className="rd-back"
+                    onClick={() => setPane('index')}
+                    aria-label="Back to the documents"
+                  >
+                    <ChevronLeft size={14} aria-hidden="true" /> Documents
+                  </button>
+                  <div className="rd-head-row">
+                    <p className="rd-crumb mono" title={`${root}/${path}`}>
+                      {root}/{dirName(path)}<b>{baseName(path)}</b>
+                    </p>
+                    {mayEdit && (
+                      <Link className="btn sm rd-edit" to={filesHref('edit', root, path)}>
+                        <Pencil size={13} aria-hidden="true" /> Edit
+                      </Link>
+                    )}
+                  </div>
+                  {/* One provenance line, not the inspector's eleven facts. The
+                      editor's answer to "what is this file" is a panel; a
+                      reader's is a sentence. */}
+                  {last ? (
+                    <p className="rd-prov">
+                      <GitCommitHorizontal size={13} aria-hidden="true" />
+                      <span className="rd-prov-t">
+                        Last changed <b title={last.date}>{relDate(last.date)}</b> by {last.author}
+                        {' - '}{last.subject}
+                      </span>
+                      <span className="rd-sha mono">{last.sha.slice(0, 7)}</span>
+                    </p>
+                  ) : file ? (
+                    // No history is a FACT about the file (untracked, or outside
+                    // a work tree), not a gap in the page.
+                    <p className="rd-prov">
+                      <GitCommitHorizontal size={13} aria-hidden="true" />
+                      <span className="rd-prov-t">Not in a git history{file.versioned === false ? ' - this root is not a work tree' : ' yet'}.</span>
+                    </p>
+                  ) : null}
+                </header>
+
+                <div className="rd-body" ref={docBox}>
+                  <FileView
+                    root={root}
+                    path={path}
+                    frag={frag}
+                    // A cross-document link stays in the READER. That is the
+                    // whole point of step 3 landing before this page:
+                    // ~/claude-notes is built out of relative links, and a
+                    // documentation site whose links do not click is not one.
+                    onOpen={(p, at) => openDoc(root, p, at)}
+                    onLoad={setFile}
+                  />
+                </div>
+              </>
+            ) : (
+              <div className="rd-empty">
+                <h2>Pick a document</h2>
+                <p>
+                  Everything readable on the box, ordered by what it is for: prose first,
+                  then the rest behind <b>All files</b>. Search reads the bytes of every
+                  root, so a phrase you half-remember is enough.
+                </p>
+                <p className="rd-empty-note">
+                  This view never writes. The editor is at{' '}
+                  <Link to={filesHref('edit', root)}>/files/edit</Link>.
+                </p>
+              </div>
+            )}
+          </main>
+
+          {/* The outline renders nothing for a document with fewer than two
+              headings, and nothing at all for a kind that has none - so this
+              column is empty for an image or a JSON file without either side
+              having to know which kinds have headings. */}
+          <Toc headings={headings} box={docBox} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/portal-next/web/src/pages/files/Search.tsx
+++ b/apps/portal-next/web/src/pages/files/Search.tsx
@@ -85,7 +85,7 @@ function Marked({ text, col, len }: { text: string; col: number; len: number }) 
 }
 
 export function SearchView({
-  roots, root, onOpen, onNeedsAuth,
+  roots, root, onOpen, onNeedsAuth, idle,
 }: {
   roots: FileRoot[];
   /** The root the EXPLORER is browsing. The search starts scoped to it, because
@@ -96,6 +96,15 @@ export function SearchView({
    *  editor highlights every other occurrence in that file. */
   onOpen: (root: string, path: string, at?: { line: number; col: number; len: number }) => void;
   onNeedsAuth: () => void;
+  /** What fills the result area when nothing has been searched yet.
+   *
+   *  In the IDE this is absent and the area is blank, which is right for a rail
+   *  you opened on purpose. The READER puts its document index here, because
+   *  reading-first.md §3 wants search at the top of the panel rather than behind
+   *  an icon - and stacking two scrolling lists to achieve that would give the
+   *  panel two scrollbars. This is the one line that lets one component be both,
+   *  and it is why the reader does not fork this file. */
+  idle?: React.ReactNode;
 }) {
   const [q, setQ] = useState('');
   const [scope, setScope] = useState<string>(root);
@@ -240,6 +249,11 @@ export function SearchView({
       )}
 
       <div className="fx-sr-list">
+        {/* `res` and not `q`: the index stays put while a query is being typed
+            and only gives way once an ANSWER exists. Swapping on the first
+            keystroke would blank the panel for the whole debounce, which reads
+            as the list having been lost. */}
+        {idle && !res ? idle : null}
         {groups.map((g) => (
           <div className="fx-sr-group" key={`${g.root} ${g.path}`}>
             <button

--- a/apps/portal-next/web/src/pages/files/Toc.tsx
+++ b/apps/portal-next/web/src/pages/files/Toc.tsx
@@ -1,0 +1,194 @@
+// ── the table of contents ────────────────────────────────────────────────────
+//
+// The thing a docs viewer has and a file explorer does not (docs/plans/
+// reading-first.md §3), and it costs NO new data and NO second parse - which is
+// the reason it is built the way it is.
+//
+// IT READS THE RENDERED DOM, not the markdown source. md.tsx already parses
+// every heading in order to render it, and since the cross-document link work it
+// stamps each one with `data-md-anchor="<slug>"`. So the headings are already on
+// the page, already slugged, already in document order. Re-parsing the source
+// here would be a second markdown parser to keep in step with the first, and it
+// would list headings that the renderer did not actually produce.
+//
+// The consequence worth stating: this is SELF-REGULATING. A JSON file, an image,
+// a PDF or the Source view emit no `data-md-anchor` at all, so the outline finds
+// nothing and renders nothing, and no caller has to know which kinds have
+// headings.
+//
+// A MutationObserver rather than a prop or an effect on the content: the
+// document arrives asynchronously (FileView owns the fetch), the reader does not
+// hold its bytes, and re-collecting on every DOM change inside the article is
+// both correct and cheap - the article changes once per document.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface Heading {
+  slug: string;
+  text: string;
+  /** 1-6, as the FILE wrote it. md.tsx renders `#` as `<h2 class="md-h md-h1">`
+   *  because the shell owns the page title, so the tag name is one deeper than
+   *  the author's level. The class is the author's level, and the author's level
+   *  is what an outline should indent by. */
+  level: number;
+}
+
+/** The scrolling ancestor of the rendered article. `.fx-read` is the element
+ *  with `overflow: auto` (editor.css), but finding it by CLASS would tie this to
+ *  one of FileContent's branches - so it is found by its computed overflow, the
+ *  property that actually decides which element emits the scroll events. */
+function scrollerOf(el: Element | null): HTMLElement | null {
+  let at: HTMLElement | null = el as HTMLElement | null;
+  while (at && at !== document.body) {
+    const o = getComputedStyle(at).overflowY;
+    if ((o === 'auto' || o === 'scroll') && at.scrollHeight > at.clientHeight) return at;
+    at = at.parentElement;
+  }
+  return null;
+}
+
+function levelOf(el: Element): number {
+  const m = /(?:^|\s)md-h([1-6])(?:\s|$)/.exec(el.className);
+  if (m) return Number(m[1]);
+  // A heading with no md-h class is not something this renderer makes today.
+  // Falling back to the tag keeps the outline honest if one ever appears.
+  const tag = /^H([1-6])$/.exec(el.tagName);
+  return tag ? Math.max(1, Number(tag[1]) - 1) : 1;
+}
+
+/**
+ * @param box the element the document is rendered into. Everything is scoped to
+ *            it - `data-md-anchor` is a data attribute rather than an `id`
+ *            precisely because the editor mounts several documents at once, and
+ *            a document-wide lookup would answer with the wrong one.
+ */
+export function useHeadings(box: React.RefObject<HTMLElement | null>, key: string): Heading[] {
+  const [heads, setHeads] = useState<Heading[]>([]);
+
+  useEffect(() => {
+    const el = box.current;
+    if (!el) return;
+    const read = () => {
+      const found = Array.from(el.querySelectorAll('[data-md-anchor]'));
+      const next: Heading[] = found.map((h) => ({
+        slug: h.getAttribute('data-md-anchor') || '',
+        text: h.textContent?.trim() || '',
+        level: levelOf(h),
+      })).filter((h) => h.slug && h.text);
+      // Compared by value, not replaced blindly: the observer fires for every
+      // mutation inside the article, and a fresh array each time would re-render
+      // the outline (and restart its scroll listener) on changes that did not
+      // touch a heading.
+      setHeads((prev) => (
+        prev.length === next.length && prev.every((p, i) => p.slug === next[i].slug && p.text === next[i].text)
+          ? prev
+          : next
+      ));
+    };
+    read();
+    const mo = new MutationObserver(read);
+    mo.observe(el, { childList: true, subtree: true, characterData: true });
+    return () => mo.disconnect();
+  }, [box, key]);
+
+  return heads;
+}
+
+export function Toc({ headings, box }: {
+  headings: Heading[];
+  box: React.RefObject<HTMLElement | null>;
+}) {
+  const [active, setActive] = useState('');
+  const nav = useRef<HTMLElement | null>(null);
+
+  // ── which heading you are reading ──────────────────────────────────────────
+  //
+  // NOT an IntersectionObserver, which is the usual answer and the wrong one
+  // here. IO reports headings entering and leaving a band, so on a document
+  // whose sections are taller than the viewport there are stretches with NO
+  // heading intersecting anything and the highlight either sticks to the last
+  // one that left or clears. Reading the positions on scroll answers the actual
+  // question - "which heading is the last one above the top of the viewport" -
+  // and it has an answer at every scroll position, including the gaps.
+  //
+  // rAF-coalesced, so a fast scroll does one measurement per frame rather than
+  // one per event.
+  useEffect(() => {
+    const el = box.current;
+    if (!el || !headings.length) { setActive(''); return; }
+    const scroller = scrollerOf(el.querySelector('[data-md-anchor]')) ?? el;
+    let raf = 0;
+    const measure = () => {
+      raf = 0;
+      const top = scroller.getBoundingClientRect().top;
+      let at = headings[0].slug;
+      for (const h of headings) {
+        const node = el.querySelector(`[data-md-anchor="${CSS.escape(h.slug)}"]`);
+        if (!node) continue;
+        // 8px of grace: a heading scrolled exactly to the top has a rounding
+        // error's chance of measuring at 0.4px and being counted as "below".
+        if (node.getBoundingClientRect().top - top <= 8) at = h.slug;
+        else break;
+      }
+      // The bottom of the document can never be reached by the rule above when
+      // the last section is short - the page stops scrolling before its heading
+      // clears the top. At the end, the last heading is the answer.
+      if (scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - 4) {
+        at = headings[headings.length - 1].slug;
+      }
+      setActive(at);
+    };
+    const onScroll = () => { if (!raf) raf = requestAnimationFrame(measure); };
+    measure();
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      scroller.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+    };
+  }, [headings, box]);
+
+  // Keep the marked entry visible in a long outline. `nearest` so a short list
+  // never scrolls at all, and no smooth behaviour - this happens while the user
+  // is already scrolling something else.
+  useEffect(() => {
+    if (!active) return;
+    nav.current?.querySelector('[aria-current="true"]')
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [active]);
+
+  const go = useCallback((slug: string) => {
+    const el = box.current;
+    const node = el?.querySelector(`[data-md-anchor="${CSS.escape(slug)}"]`);
+    node?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+  }, [box]);
+
+  // Fewer than two headings is not an outline, it is a repeat of the title.
+  if (headings.length < 2) return null;
+
+  // The shallowest level in THIS document is the baseline, so a file whose
+  // headings all start at `##` is not indented one step for its whole length.
+  const base = Math.min(...headings.map((h) => h.level));
+
+  return (
+    <nav className="rd-toc" aria-label="On this page" ref={nav}>
+      <p className="rd-toc-h">On this page</p>
+      <ul className="rd-toc-list">
+        {headings.map((h, i) => (
+          <li key={`${h.slug}-${i}`} style={{ paddingLeft: `${Math.min(h.level - base, 3) * 11}px` }}>
+            <button
+              type="button"
+              className={`rd-toc-a${h.slug === active ? ' on' : ''}`}
+              aria-current={h.slug === active ? 'true' : undefined}
+              onClick={() => go(h.slug)}
+              title={h.text}
+            >
+              {h.text}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/portal-next/web/src/pages/files/read.css
+++ b/apps/portal-next/web/src/pages/files/read.css
@@ -1,0 +1,279 @@
+/* ============================================================================
+   Bothy Files - the reader. Scoped under .bothy-files, (0,2,0), for the reason
+   shell.css states at its top: main.tsx imports ./App before ./index.css, so a
+   (0,1,0) rule here would lose to a (0,1,0) rule there whatever the file order.
+
+   The page carries BOTH classes - `.bothy-files .bothy-read` - because
+   `.bothy-files` is the SECTION's scope and not the IDE's. It is what buys the
+   full-height escape from `.content`, the inset focus ring, the syntax palette
+   and every `.md-*` rule, all of which belong to a rendered document rather than
+   to an editor. `.bothy-read` is only the layout below.
+   ========================================================================== */
+
+/* ── three columns, and only one of them is unsized ──────────────────────────
+   The document takes the remainder, which is the same arrangement panes.ts
+   argues for in the IDE and for the same reason - a fixed centre plus a
+   remainder rail is a reconciliation bug waiting for a resize.
+
+   The document is NOT stretched to the column: `.fx-read > *` is already capped
+   at 72ch (editor.css), which is the measure this whole page exists to give
+   back. The extra width becomes margin, which is what a wide screen is for. */
+.bothy-files.bothy-read .rd-grid {
+  flex: 1; min-height: 0;
+  display: grid;
+  grid-template-columns: 296px minmax(0, 1fr) 232px;
+}
+
+/* ── the side panel ──────────────────────────────────────────────────────── */
+.bothy-files .rd-side {
+  min-width: 0; min-height: 0; display: flex; flex-direction: column;
+  border-right: 1px solid var(--line); background: var(--bg-2);
+}
+.bothy-files .rd-side > .fx-sr { padding-top: 4px; }
+
+/* ── the one thing the reader changes about the search rail ──────────────────
+   SearchView is reused whole - same component, same debounce, same options, no
+   fork (see the `idle` prop in Search.tsx). One piece of it is IDE-shaped and
+   does not survive the move: the line NUMBER on each hit.
+
+   In the editor that number is a destination - clicking a hit jumps the caret
+   to it. A reader has no caret and, in a rendered document, no lines: the
+   preview is prose, and there is nothing at "line 141" to land on. Printing a
+   precise number beside a click that lands at the top of the document is a
+   promise the page cannot keep, and it is the kind of broken promise nobody
+   reports - the reader concludes the search is wrong.
+
+   The matched line ITSELF stays, because it is the most valuable thing in the
+   list: it is the sentence you were looking for, with the match marked. */
+.bothy-files.bothy-read .fx-sr-no { display: none; }
+.bothy-files.bothy-read .fx-sr-line { padding-left: 26px; }
+
+.bothy-files .rd-index { padding: 0 0 14px; }
+/* Sticky, because the index lives inside the search view's scrolling result
+   area (that is what puts search at the TOP of the panel rather than behind an
+   icon) - and without this the All files switch scrolls away after ten rows,
+   leaving no way back to it except scrolling the list you were reading. */
+.bothy-files .rd-index-h {
+  position: sticky; top: 0; z-index: 2;
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 10px 7px; border-bottom: 1px solid var(--line);
+  background: var(--bg-2);
+}
+.bothy-files .rd-index-title {
+  font-size: 11px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
+  color: var(--fg-subtle);
+}
+/* The toggle that changes what the list CLAIMS to be. Left visible rather than
+   put in a menu: it decides whether this is a library or a filesystem, and the
+   reader has to be able to see which one they are looking at. */
+.bothy-files .rd-all {
+  margin-left: auto; display: inline-flex; align-items: center; gap: 5px;
+  font-size: 11px; color: var(--fg-muted); cursor: pointer; user-select: none;
+}
+.bothy-files .rd-all input { margin: 0; accent-color: var(--accent); }
+.bothy-files .rd-all svg { color: var(--fg-subtle); }
+.bothy-files .rd-all:hover { color: var(--fg); }
+
+.bothy-files .rd-root { border-bottom: 1px solid var(--line); }
+/* The root name sticks under the index header, so a long listing never leaves
+   you looking at folders without knowing which root they are in. `top` is the
+   header's own height, measured rather than guessed - 30px is 6+16+7 plus the
+   border. */
+.bothy-files .rd-root-h {
+  position: sticky; top: 30px; z-index: 1;
+  margin: 0; font-size: inherit; font-weight: inherit; background: var(--bg-2);
+}
+.bothy-files .rd-root-btn {
+  appearance: none; cursor: pointer; width: 100%; text-align: left;
+  display: flex; align-items: center; gap: 6px;
+  border: 0; background: transparent; font: inherit; color: var(--fg);
+  padding: 0 10px; height: 28px;
+}
+.bothy-files .rd-root-btn:hover { background: var(--surface-2); }
+.bothy-files .rd-root-name { font-size: 11.5px; font-weight: 700; }
+.bothy-files .rd-root-ro { color: var(--st-off-fg); }
+.bothy-files .rd-root-n {
+  margin-left: auto; font-size: 10px; font-family: var(--mono); color: var(--fg-subtle);
+}
+.bothy-files .rd-chev { flex: none; color: var(--fg-subtle); transition: transform .12s ease; }
+.bothy-files .rd-chev.open { transform: rotate(90deg); }
+@media (prefers-reduced-motion: reduce) {
+  .bothy-files .rd-chev { transition: none; }
+}
+
+.bothy-files .rd-folder { padding-bottom: 4px; }
+/* The folder, in mono, small and quiet. It is an ADDRESS - the one piece of
+   filesystem left in a panel of titles - so it is typeset as one rather than as
+   a heading competing with the documents under it. */
+.bothy-files .rd-folder-h {
+  margin: 8px 0 2px; padding: 0 10px;
+  font-size: 10.5px; color: var(--fg-subtle);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.bothy-files .rd-list { list-style: none; margin: 0; padding: 0; }
+.bothy-files .rd-li { margin: 0; }
+
+/* 26px rather than the tree's 22px: this row can carry two lines of text, and
+   these are read rather than scanned. */
+.bothy-files .rd-doc {
+  appearance: none; cursor: pointer; width: 100%; text-align: left;
+  display: flex; align-items: center; gap: 8px;
+  border: 0; border-left: 2px solid transparent; background: transparent;
+  font: inherit; color: var(--fg-muted);
+  padding: 3px 10px 3px 8px; min-height: 26px; min-width: 0;
+}
+.bothy-files .rd-doc:hover { background: var(--surface-2); color: var(--fg); }
+.bothy-files .rd-doc-ico { flex: none; color: var(--fg-subtle); }
+.bothy-files .rd-doc-text { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.bothy-files .rd-doc-title {
+  font-size: 12.5px; line-height: 1.25;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* The filename under the title, for anyone who arrived knowing the path. Only
+   rendered when it differs from the title, so most rows are one line. */
+.bothy-files .rd-doc-name {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-subtle);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* The open document. A left BAR and a background, never colour alone -
+   docs/brand/foundations/principles.md, and it is what makes the mark survive a
+   monochrome screen. */
+.bothy-files .rd-doc.on {
+  border-left-color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  color: var(--fg);
+}
+.bothy-files .rd-doc.on .rd-doc-ico { color: var(--accent-fg); }
+.bothy-files .rd-doc.on .rd-doc-title { font-weight: 600; }
+.bothy-files .rd-doc.denied { cursor: not-allowed; opacity: .5; }
+
+.bothy-files .rd-msg { padding: 12px 12px 14px; color: var(--fg-subtle); font-size: 12px; text-align: center; }
+.bothy-files .rd-msg p { margin: 0 0 8px; }
+.bothy-files .rd-more {
+  margin: 6px 10px 8px; font-size: 10.5px; line-height: 1.45; color: var(--fg-subtle);
+}
+.bothy-files .rd-more.warn { color: var(--st-warn-fg); }
+.bothy-files .rd-skel { display: grid; gap: 6px; padding: 8px 10px 12px; }
+.bothy-files .rd-skel .skel { height: 16px; }
+
+/* ── the document ────────────────────────────────────────────────────────── */
+.bothy-files .rd-main { min-width: 0; min-height: 0; display: flex; flex-direction: column; }
+
+/* The strip above the document: what it is and where it came from. It carries
+   no title - the document's own first heading is the title, and printing a
+   second one derived from the filename says the same words twice. See the note
+   in Reader.tsx. */
+.bothy-files .rd-head {
+  flex: none; padding: 14px 28px 12px; border-bottom: 1px solid var(--line);
+}
+.bothy-files .rd-head-row { display: flex; align-items: center; gap: 16px; }
+.bothy-files .rd-crumb {
+  margin: 0; flex: 1 1 auto; min-width: 0; font-size: 12.5px; color: var(--fg-subtle);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.bothy-files .rd-crumb b { color: var(--fg); font-weight: 700; }
+.bothy-files .rd-edit { flex: none; text-decoration: none; gap: 6px; }
+
+.bothy-files .rd-prov {
+  display: flex; align-items: baseline; gap: 7px; margin: 7px 0 0;
+  font-size: 12px; color: var(--fg-subtle); line-height: 1.45;
+}
+.bothy-files .rd-prov svg { flex: none; align-self: center; }
+/* `flex: 1 1 0` and not `1 1 auto`. The sentence has to wrap INSIDE itself
+   rather than as a whole - with `auto` its flex base size is its content width,
+   which on a phone is wider than the row, so the whole span moved to a second
+   line and left the commit glyph sitting alone on the first. A zero basis makes
+   its hypothetical size 0, so it always shares the line and wraps its own text.
+   Measured at 390px. */
+.bothy-files .rd-prov-t { flex: 1 1 0; min-width: 0; }
+.bothy-files .rd-prov b { color: var(--fg-muted); font-weight: 600; }
+.bothy-files .rd-sha {
+  flex: none; margin-left: auto; font-size: 10.5px;
+  background: var(--surface-2); border: 1px solid var(--line);
+  border-radius: var(--r-xs); padding: 0 5px;
+}
+
+/* The wrapper FileView renders into. It is `.rd-body` and not `.rd-doc` on
+   purpose: `.rd-doc` is the index row, and two elements a screen apart sharing a
+   class is how a padding change to one silently moves the other. */
+.bothy-files .rd-body { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+/* FileView's own root is `.fx-doc`, which editor.css already makes a
+   full-height flex column - so the document, its skeleton and its error states
+   all fill this box without a second set of rules. */
+
+.bothy-files .rd-empty {
+  flex: 1; min-height: 0; overflow: auto;
+  padding: 64px 28px; max-width: 60ch; color: var(--fg-muted);
+}
+.bothy-files .rd-empty h2 { margin: 0 0 10px; font-size: 20px; color: var(--fg); }
+.bothy-files .rd-empty p { margin: 0 0 12px; line-height: 1.6; }
+.bothy-files .rd-empty-note { font-size: 12.5px; color: var(--fg-subtle); }
+.bothy-files .rd-empty a { color: var(--accent-fg); }
+
+/* ── the outline ─────────────────────────────────────────────────────────── */
+.bothy-files .rd-toc {
+  min-width: 0; min-height: 0; overflow: auto;
+  padding: 22px 12px 40px 4px; border-left: 1px solid var(--line);
+}
+.bothy-files .rd-toc-h {
+  margin: 0 0 8px 10px;
+  font-size: 10.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase;
+  color: var(--fg-subtle);
+}
+.bothy-files .rd-toc-list { list-style: none; margin: 0; padding: 0; }
+.bothy-files .rd-toc-list li { margin: 0; }
+.bothy-files .rd-toc-a {
+  appearance: none; cursor: pointer; width: 100%; text-align: left;
+  border: 0; border-left: 2px solid var(--line); background: transparent;
+  font: inherit; font-size: 11.5px; line-height: 1.35; color: var(--fg-subtle);
+  padding: 4px 6px 4px 10px;
+  display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.bothy-files .rd-toc-a:hover { color: var(--fg); border-left-color: var(--line-strong); }
+/* The heading you are reading. Weight and a bar, not colour on its own. */
+.bothy-files .rd-toc-a.on {
+  color: var(--fg); font-weight: 600; border-left-color: var(--accent);
+}
+
+/* ── the way back on a narrow screen ─────────────────────────────────────────
+   Hidden by default because on a wide screen the index is already beside the
+   document and a "back" that goes nowhere is furniture. */
+.bothy-files .rd-back {
+  display: none;
+  appearance: none; cursor: pointer; align-items: center; gap: 4px;
+  border: 1px solid var(--line); border-radius: var(--r-sm);
+  background: var(--surface-2); color: var(--fg-muted);
+  font: inherit; font-size: 11.5px; padding: 3px 9px 3px 6px; margin: 0 0 8px;
+}
+.bothy-files .rd-back:hover { color: var(--fg); border-color: var(--line-strong); }
+
+/* ── narrower than three columns ────────────────────────────────────────────
+   The outline goes first. It is the most valuable column per pixel on a wide
+   screen and the least useful on a narrow one, where the document it points into
+   is itself only a few characters wide. */
+@media (max-width: 1180px) {
+  .bothy-files.bothy-read .rd-grid { grid-template-columns: 268px minmax(0, 1fr); }
+  .bothy-files .rd-toc { display: none; }
+}
+
+/* ── one column ──────────────────────────────────────────────────────────────
+   List and detail, which is what a reader on a phone actually does: choose a
+   document, then read it. Both columns rendered and one of them hidden, so
+   nothing refetches when you go back to the index and the scroll position of
+   both survives the trip.
+
+   Driven by `data-pane` on the root, written by React. CSS alone cannot express
+   "show the index unless a document is open AND the reader has not asked for the
+   index back", because the second half is a decision rather than a state. */
+@media (max-width: 820px) {
+  .bothy-files.bothy-read .rd-grid { grid-template-columns: minmax(0, 1fr); }
+  .bothy-files .rd-side { border-right: 0; }
+  .bothy-files.bothy-read[data-pane='doc'] .rd-side { display: none; }
+  .bothy-files.bothy-read[data-pane='index'] .rd-main { display: none; }
+  .bothy-files .rd-back { display: inline-flex; }
+  .bothy-files .rd-head { padding: 12px 16px 10px; }
+  /* editor.css pads .fx-read at 24px 28px; at this width that is a tenth of the
+     line. The 72ch cap is doing nothing here - the viewport is the measure. */
+  .bothy-files.bothy-read .fx-read { padding: 16px 16px 40px; }
+  .bothy-files .rd-empty { padding: 32px 16px; }
+}

--- a/apps/portal-next/web/src/pages/files/routes.ts
+++ b/apps/portal-next/web/src/pages/files/routes.ts
@@ -1,0 +1,71 @@
+// ── the two Files URLs, in one place ─────────────────────────────────────────
+//
+// Files is one nav entry and two destinations (docs/plans/reading-first.md §2):
+//
+//   /files        READ  the default. A document, and how to find one.
+//   /files/edit   WORK  the IDE, unchanged, at a route.
+//
+// Both carry the SAME `?root=&path=`, which is the whole reason every deep link
+// written before the split still resolves - and the reason this file exists.
+// Three places now build one of those URLs (the reader's Edit button, the
+// editor's way back, and the router itself), and a builder that drops `path` is
+// the same defect the redirect table was written to prevent: a link that answers
+// 200, renders a plausible page, and quietly goes somewhere else. Nobody reports
+// that. So the builder and the parser are ONE module with a truth table over it
+// (checks/redirect-table.mjs).
+//
+// This module imports NOTHING, on purpose - the same property that lets
+// lib/discover.ts and pages/control/redirects.ts be compiled and run by the
+// checks with no bundler and no test runner. `URLSearchParams` is a platform
+// global in both the browser and node, not an import, so it does not break that.
+
+export const READ_PATH = '/files';
+export const EDIT_PATH = '/files/edit';
+
+/** Which of the two the reader is in. */
+export type FilesMode = 'read' | 'edit';
+
+/** `null` for a path that is not one of ours at all. Note that `/files/edit` has
+ *  to be tested BEFORE `/files`, which is why this is a function rather than a
+ *  map: `/files` is a prefix of `/files/edit`. */
+export function filesMode(pathname: string): FilesMode | null {
+  // A trailing slash is the same page; a pasted link often carries one. Same
+  // normalisation as pages/control/redirects.ts, for the same reason.
+  const p = pathname.replace(/\/+$/, '') || '/';
+  if (p === EDIT_PATH) return 'edit';
+  if (p === READ_PATH) return 'read';
+  return null;
+}
+
+/**
+ * The URL for one file in one mode. `path` may be empty - that is the reader
+ * with nothing open yet, and the root still belongs in the URL so a reload lands
+ * on the same index.
+ *
+ * Percent-encoding is left to URLSearchParams, which encodes `/` in a value as
+ * `%2F`. That matches what Files.tsx has always written (it builds its URL the
+ * same way), so a link from here and a link the editor wrote are the same
+ * string, and the browser's Back button cannot tell them apart.
+ */
+export function filesHref(mode: FilesMode, root: string, path = ''): string {
+  const q = new URLSearchParams();
+  if (root) q.set('root', root);
+  if (path) q.set('path', path);
+  const s = q.toString();
+  const base = mode === 'edit' ? EDIT_PATH : READ_PATH;
+  return s ? `${base}?${s}` : base;
+}
+
+/** What a Files URL asks for, or null if it is not a Files URL.
+ *
+ *  `search` is the raw query string (`location.search`), leading `?` optional -
+ *  the same shape `legacyTarget` takes, so callers do not have to remember which
+ *  of the two wants which. */
+export function filesTarget(
+  pathname: string, search = '',
+): { mode: FilesMode; root: string; path: string } | null {
+  const mode = filesMode(pathname);
+  if (!mode) return null;
+  const q = new URLSearchParams(search.replace(/^\?/, ''));
+  return { mode, root: q.get('root') ?? '', path: q.get('path') ?? '' };
+}

--- a/apps/portal-next/web/src/pages/files/shell.css
+++ b/apps/portal-next/web/src/pages/files/shell.css
@@ -142,7 +142,12 @@
   padding: 0 14px 0 18px; height: 42px;
   border-bottom: 1px solid var(--line); background: var(--surface-2);
 }
-.bothy-files .fx-head-id { display: flex; align-items: baseline; gap: 10px; min-width: 0; }
+/* `flex: 1 1 auto` so the identity block claims the free width and everything
+   after it is pushed to the right edge. It used to be content-sized, which was
+   invisible while `.fx-head-actions` (margin-left: auto) was the only thing to
+   its right; the Reading view link is now between the two, and without this it
+   floats a few pixels off the end of the subtitle. */
+.bothy-files .fx-head-id { flex: 1 1 auto; display: flex; align-items: baseline; gap: 10px; min-width: 0; }
 .bothy-files .fx-head-title {
   margin: 0; font-size: 14px; font-weight: 700; letter-spacing: -0.01em; flex: none;
 }
@@ -151,7 +156,14 @@
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .bothy-files .fx-head-sub b { color: var(--fg-muted); font-weight: 700; }
-.bothy-files .fx-head-actions { margin-left: auto; display: flex; align-items: center; gap: 2px; flex: none; }
+.bothy-files .fx-head-actions { display: flex; align-items: center; gap: 2px; flex: none; }
+/* Work -> Read. A DESTINATION, so it carries its words; its neighbours are
+   layout toggles and carry glyphs. The rule that separates the two is in
+   docs/brand/patterns/navigation.md and it is the reason this is not a fourth
+   icon in the group beside it. */
+.bothy-files .fx-head-read {
+  flex: none; gap: 6px; text-decoration: none; margin-right: 8px;
+}
 
 /* The small square button used by every region header. One definition, because
    five near-identical icon buttons is how a toolbar starts drifting. */

--- a/apps/portal-next/web/src/pages/files/titles.ts
+++ b/apps/portal-next/web/src/pages/files/titles.ts
@@ -1,0 +1,112 @@
+// ── what a document is called, without an index ──────────────────────────────
+//
+// The reader's side panel lists TITLES, not filenames (docs/plans/
+// reading-first.md §3). The cheapest title that is right most of the time is the
+// filename, prettified: `tailnet-troubleshooting.md` is already "Tailnet
+// troubleshooting", because whoever named the file was writing the title.
+//
+// THE ALTERNATIVE IS DELIBERATELY NOT BUILT YET. The plan's own answer for a
+// better title is the document's first heading, read server-side behind a
+// `titles=1` parameter on /tree - and it says explicitly: do the filename
+// version first, add the parameter only if the titles are wrong often enough to
+// notice. This is that first version. Measured against the real roots, it agrees
+// with the `# heading` on essentially all of docs/brand (39 files) and all of
+// ~/claude-notes, and it is worse on exactly one shape - docs/kb, where the
+// heading is the filename PLUS a subtitle ("RUNBOOK - I can't reach the dev
+// stack" for runbook-cant-reach.md). That is a subtitle problem, not a wrong
+// title, which is why it does not yet justify a second endpoint.
+//
+// Imports NOTHING, so checks/ can compile and run it on its own.
+
+/** Tokens whose sentence-cased form is visibly wrong, and their display form.
+ *
+ *  This is the ONLY table here, and it is short because it only has to cover
+ *  what is actually in the roots - a general "is this an acronym?" rule does not
+ *  exist, and guessing produces `THE` and `AND`. Keys are lowercase; a token is
+ *  matched case-insensitively. */
+const ACRONYMS: Record<string, string> = {
+  api: 'API', cd: 'CD', ci: 'CI', cli: 'CLI', corp: 'CORP', cors: 'CORS',
+  cpu: 'CPU', csp: 'CSP', css: 'CSS', db: 'DB', dhcp: 'DHCP', dns: 'DNS',
+  dom: 'DOM', faq: 'FAQ', gpu: 'GPU', html: 'HTML', http: 'HTTP',
+  https: 'HTTPS', id: 'ID', ide: 'IDE', io: 'IO', ip: 'IP', json: 'JSON',
+  jwt: 'JWT', k8s: 'k8s', kb: 'KB', mcp: 'MCP', nic: 'NIC', npm: 'npm',
+  os: 'OS', pdf: 'PDF', png: 'PNG', pwa: 'PWA', qa: 'QA', ram: 'RAM',
+  scm: 'SCM', sdk: 'SDK', seo: 'SEO', sh: 'SH', sql: 'SQL', ssh: 'SSH',
+  sso: 'SSO', ssl: 'SSL', svg: 'SVG', tls: 'TLS', ui: 'UI', url: 'URL',
+  ux: 'UX', vpn: 'VPN', wsl: 'WSL', yaml: 'YAML',
+};
+
+/** Names that are conventions rather than words. Left exactly as written,
+ *  because "Readme" reads as a typo of a filename everybody already knows. */
+const KEPT = new Set(['README', 'LICENSE', 'CHANGELOG', 'NOTICE', 'TODO', 'CONTRIBUTING']);
+
+/** A leading ISO date, which is how the incident notes are named. Kept as the
+ *  date rather than folded into the sentence - it is the thing those files are
+ *  sorted and remembered by, and "2026 08 08 WSL node…" is a worse title than
+ *  either half on its own. */
+const RE_DATED = /^(\d{4}-\d{2}-\d{2})[-_](.+)$/;
+
+function word(tok: string): string {
+  const hit = ACRONYMS[tok.toLowerCase()];
+  if (hit) return hit;
+  // AN ALL-CAPS TOKEN IS A FILENAME CONVENTION, NOT EMPHASIS. `CODE_OF_CONDUCT`
+  // and `ARCHITECTURE` are shouting because that is how a top-level doc is
+  // named, and reproducing it in a list of twenty titles shouts at the reader
+  // instead. Anything else is left exactly as typed, so a name that already
+  // carries its own capitals (`CVOps`, `Thinkpad`) keeps them.
+  if (tok.length > 1 && tok === tok.toUpperCase() && /[A-Z]/.test(tok)) return tok.toLowerCase();
+  return tok;
+}
+
+/** The file's own name, without its extension. Exported because the index shows
+ *  it under the title, and a second copy of "strip the extension" is how the two
+ *  come to disagree about a file called `a.b.md`. */
+export function stemOf(name: string): string {
+  const dot = name.lastIndexOf('.');
+  return dot > 0 ? name.slice(0, dot) : name;
+}
+
+/**
+ * A display title for one file, from its path alone. No fetch, no index.
+ *
+ * @param path root-relative, `docs/kb/access.md`. Only the basename is read;
+ *             the folder is shown separately by the index, and folding it in
+ *             here would title every README after its directory.
+ */
+export function titleOf(path: string): string {
+  const name = path.slice(path.lastIndexOf('/') + 1);
+  const stem = stemOf(name);
+  if (KEPT.has(stem.toUpperCase())) return stem.toUpperCase();
+
+  const dated = RE_DATED.exec(stem);
+  const body = dated ? dated[2] : stem;
+
+  const words = body.split(/[-_.\s]+/).filter(Boolean).map(word);
+  if (!words.length) return stem;
+  // Sentence case: the FIRST word gets a capital and the rest keep whatever
+  // `word()` decided. Title Case Every Word looks like a headline and disagrees
+  // with how the documents themselves are titled ("Shape and elevation",
+  // "Data display and tables") - so the list would be shouting a different
+  // sentence than the page it opens.
+  let out = words.join(' ');
+  out = out.charAt(0).toUpperCase() + out.slice(1);
+  // A middle dot rather than a dash: the title itself often contains dashes and
+  // a second one would read as part of the sentence.
+  return dated ? `${dated[1]} · ${out}` : out;
+}
+
+/** Extensions the reader treats as PROSE, and orders first. Deliberately small:
+ *  the claim being made is "a person reads this end to end", not "this is
+ *  text". A .yml is text and nobody reads it for pleasure. */
+const PROSE_EXT = new Set(['md', 'markdown', 'mdx', 'rst', 'txt', 'adoc']);
+
+export function isProse(path: string): boolean {
+  const dot = path.lastIndexOf('.');
+  return dot > 0 && PROSE_EXT.has(path.slice(dot + 1).toLowerCase());
+}
+
+/** How a folder is labelled in the index. `''` is the root of the root, which
+ *  has no name of its own and is not "the empty folder". */
+export function folderLabel(dir: string, root: string): string {
+  return dir ? dir.replace(/\/+$/, '') : root;
+}


### PR DESCRIPTION
Steps 4-5 of `docs/plans/reading-first.md`. `/files` is now a reader; the IDE is unchanged at `/files/edit`. Both take the same `?root=&path=`, and the nav stays at three entries.

## The regression test that matters

**The reader does not pull the CodeMirror chunk.** Measured on the deployed build: loading a document requests exactly one script, `index-*.js`. `CodeSurface-*.js` (332 kB) exists in its own chunk and is reachable — clicking Source in `/files/edit` adds it — but the reader has no path to it.

That is the load-bearing consequence of `FileContent` taking `source` as a prop rather than deciding it internally, and it is the cheapest proof the boundary is real rather than nominal.

## Prettified filenames were good enough — no title endpoint built

The plan said to add `/tree?titles=1` only if filenames proved wrong in use. They did not, and there is now a truth table in `checks/titles-table.mjs` asserting it:

- `docs/brand` (39 files) and `~/claude-notes` (18): the filename **is** the heading, once an acronym table exists — without one you get "Dns", "Pwa and manifest".
- `docs/kb` degrades as a **subtitle** problem, not a wrong title: `access.md` → "Access" vs "Access - every way into the dev box…". Same subject, shorter name.
- Three genuine misses in 57 files. Apostrophes are unrecoverable (`cant`).

The check asserts title and heading open on the same word, so the day that stops being true is the signal to build the endpoint.

## The header carries no title, deliberately

A derived title printed above the document's own `# heading` is the same words twice, and worse when they disagree. `md.tsx` has always shifted heading levels "because the shell already owns the document title" — in the editor that was false of anything on screen; here the document itself is the title. The header is address, provenance and Edit.

## Edit

Role-gated on `editor` **and** on the file's own `writable` — policy makes `home`/`projects` read-only and limits writes by suffix, so without the second gate an editor opening a `.ts` would land in an IDE whose own pencil is missing. Absent, not disabled.

## Also

- The TOC reads the rendered DOM's `data-md-anchor` — no second parse, and it cannot disagree with the renderer. Scroll tracking is "last heading above the top", **not** an IntersectionObserver: IO reports crossings, so on sections taller than the viewport there are stretches with nothing intersecting and the mark sticks.
- `SearchView` is reused, not forked — one optional `idle` slot puts the index in its result area, which is what gets search to the *top* of the panel without two scrolling lists.
- A bug found while building: the per-root listing effect wrote a loading marker **and** depended on it, so its cleanup aborted the request it had just made. The section sat on a skeleton forever with `net::ERR_ABORTED` and no error on screen.

## Verification

`tsc -b --force --noEmit` clean · `checks/run.sh` **158 PASS / 0 FAIL** (was 92) · rendered at 1280 and 390 in both themes · `just verify` 23/23 · deployed and confirmed on the live box.
