### PR TITLE
fix(theme): the colours that had quietly stopped following the palette

### DIFF
--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -63,6 +63,12 @@ for (const [k, v] of Object.entries(n)) console.log(\`  \${k.padEnd(9)} \${v.len
 "
 
 echo
+echo "── every colour comes from a token ─────────────────────"
+# Reads the source tree directly - no compile step, because it is looking at the
+# text rather than at behaviour. Runs regardless of whether there is a build.
+node "$HERE/stray-colour.mjs"
+
+echo
 echo "── the CSP and the inline script must agree ────────────"
 # Needs web/dist, so it runs after a build. Skipped rather than failed when there
 # is none: an unbuilt tree is not a broken policy.

--- a/apps/portal-next/checks/stray-colour.mjs
+++ b/apps/portal-next/checks/stray-colour.mjs
@@ -1,0 +1,176 @@
+// Every colour in this app must come from a token.
+//
+// WHY THIS EXISTS. Four separate colour bugs were found in one afternoon while
+// preparing the app for named themes, and all four shared a shape: a colour that
+// had stopped following the palette, in a way that throws nothing and logs
+// nothing. `STATUS_VAR` pointed at `--ok/--warn/--down/--off/--unk` after the
+// tokens were renamed to `--st-*`, so every status glyph silently inherited body
+// text. `cssVar('--primary')` named a token that never existed, so three point
+// lights and the rack emissive stayed on the accent colour from before the
+// palette was replaced. The whole SVG topology inlined the 3D scene's hex mirror
+// and could not re-theme at all. Two `color: #fff` rules painted white text on a
+// light-mode accent gradient.
+//
+// None of those are visible in a diff, and none are visible on the theme you
+// happen to be using. They are only visible on the OTHER one - which is exactly
+// the thing nobody looks at. So the rule gets a test rather than a paragraph.
+//
+// THE RULE. A colour literal - hex, rgb(), hsl(), or a named CSS colour - may
+// appear only:
+//   1. in a file that DEFINES tokens (index.css, the theme files, the syntax
+//      palette) or that genuinely cannot read them (the 3D material constants);
+//   2. inside a mask, where black and white are alpha and not colour;
+//   3. on a line carrying a `stray-colour-ok:` marker with a reason.
+//
+// The marker is deliberately ugly and deliberately requires prose. It is not an
+// escape hatch, it is a place to write down why this one is not a token - and if
+// that reason is hard to write, the honest answer was a token.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const SRC = join(HERE, '..', 'web', 'src');
+
+// ── files exempt in full, each with the reason it is exempt ──────────────────
+//
+// Kept as a list with reasons rather than a glob: an exemption nobody can
+// explain is an exemption that should not exist, and a glob hides how many
+// there are. Four is a number you can hold in your head; if it reaches ten,
+// something has gone wrong with the idea rather than with the list.
+const EXEMPT = new Map([
+  ['index.css',
+    'defines the tokens. This is the palette; it is where the literals live.'],
+  ['pages/files/shell.css',
+    'defines the five --hl-* syntax tokens for both themes. Same job as '
+    + 'index.css, kept beside the editor it serves.'],
+  ['components/three/webgl.ts',
+    'the ScenePalette and the STATUS_HEX mirror. The 3D scene paints with real '
+    + 'materials and cannot resolve a CSS variable into a mesh colour, so its '
+    + 'palette is data. statusHexes() reads the live tokens where it can.'],
+  ['components/three/StackScene.tsx',
+    'TYPE_TINT, the glow-sprite gradient and the nameplate canvas. Canvas 2D '
+    + 'and material constants, none of which has a CSS equivalent.'],
+]);
+
+// A theme is a full token set by definition, so the whole directory is a
+// definition site. Matched by prefix rather than listed, because the point of
+// the theme format is that adding one is adding a file.
+const EXEMPT_DIR = 'themes/';
+
+// ── what counts as a colour ─────────────────────────────────────────────────
+const HEX = /#[0-9a-fA-F]{3,8}\b/;
+const FUNC = /\b(?:rgba?|hsla?)\s*\(/;
+// Named colours only in value position (after `:` or `,`) and not followed by a
+// hyphen, so `white-space: nowrap` and `grayscale(1)` are not colours.
+const NAMED = /(?<=[:,]\s*)(?:white|black|red|green|blue|yellow|orange|purple|gray|grey|silver|maroon|navy|teal|olive|lime|aqua|fuchsia|cyan|magenta|pink|brown|gold|beige|ivory|coral|salmon|khaki|violet|indigo|crimson|tomato|orchid|plum|tan|azure|linen|wheat|snow)\b(?!-)/;
+
+// Black and white inside a mask are ALPHA, not colour: a mask reads the
+// luminance channel and throws the hue away, so `#000` there means "hide" and
+// `#fff` means "show". Re-theming them would be a category error, not a fix.
+const MASK = /mask(?:-image)?\s*:/;
+const MASK_SAFE = /^#(?:0{3,4}|0{6}|0{8}|f{3,4}|f{6}|f{8})$/i;
+
+const MARKER = 'stray-colour-ok:';
+
+// ── comment stripping ───────────────────────────────────────────────────────
+//
+// Blanked rather than removed, so line numbers survive into the report. A
+// literal in a comment is prose - several of the comments in this app quote the
+// very hexes that caused a bug - and prose is not a colour.
+function stripComments(text, js) {
+  const out = text.split('');
+  let i = 0, block = false, line = false, quote = null;
+  while (i < text.length) {
+    const c = text[i], d = text[i + 1];
+    if (block) {
+      if (c === '*' && d === '/') { out[i] = out[i + 1] = ' '; i += 2; block = false; continue; }
+      if (c !== '\n') out[i] = ' ';
+      i++; continue;
+    }
+    if (line) {
+      if (c === '\n') { line = false; i++; continue; }
+      out[i] = ' '; i++; continue;
+    }
+    if (quote) {
+      if (c === '\\') { i += 2; continue; }
+      if (c === quote) quote = null;
+      i++; continue;
+    }
+    if (c === '"' || c === "'" || (js && c === '`')) { quote = c; i++; continue; }
+    if (c === '/' && d === '*') { out[i] = out[i + 1] = ' '; i += 2; block = true; continue; }
+    if (js && c === '/' && d === '/') { out[i] = out[i + 1] = ' '; i += 2; line = true; continue; }
+    i++;
+  }
+  return out.join('');
+}
+
+function walk(dir, acc = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, acc);
+    else if (/\.(css|ts|tsx)$/.test(name)) acc.push(p);
+  }
+  return acc;
+}
+
+// ── the pass ────────────────────────────────────────────────────────────────
+const findings = [];
+let scanned = 0, exempted = 0, marked = 0, masked = 0;
+
+for (const file of walk(SRC).sort()) {
+  const rel = relative(SRC, file).split('\\').join('/');
+  if (EXEMPT.has(rel) || rel.startsWith(EXEMPT_DIR)) { exempted++; continue; }
+  scanned++;
+
+  const js = /\.tsx?$/.test(file);
+  const raw = readFileSync(file, 'utf8').split('\n');
+  const lines = stripComments(raw.join('\n'), js).split('\n');
+
+  // The marker lives in a comment, and comments are blanked above - so it has to
+  // be looked for in the RAW line, not the stripped one. A marker excuses the
+  // line it sits on, or the first code line after the comment block it opens:
+  // walk back over lines that are blank once stripped but not blank raw, which
+  // is precisely the definition of "was a comment". That keeps the marker
+  // attached to a specific declaration rather than to a line range someone has
+  // to count.
+  const excused = (n) => {
+    if (raw[n]?.includes(MARKER)) return true;
+    for (let i = n - 1; i >= 0; i--) {
+      if (lines[i].trim() !== '' || raw[i].trim() === '') return false;
+      if (raw[i].includes(MARKER)) return true;
+    }
+    return false;
+  };
+
+  lines.forEach((line, n) => {
+    const hex = line.match(new RegExp(HEX, 'g')) ?? [];
+    const other = FUNC.test(line) || NAMED.test(line);
+    if (!hex.length && !other) return;
+
+    if (excused(n)) { marked++; return; }
+    if (MASK.test(line) && !other && hex.every((h) => MASK_SAFE.test(h))) { masked++; return; }
+
+    findings.push({ rel, line: n + 1, text: line.trim().slice(0, 96) });
+  });
+}
+
+// ── report ──────────────────────────────────────────────────────────────────
+console.log(`  scanned ${scanned} files · ${exempted} exempt by name · `
+  + `${marked} marked · ${masked} mask-alpha`);
+
+for (const [rel, why] of EXEMPT) console.log(`  exempt  ${rel.padEnd(38)} ${why.slice(0, 60)}…`);
+
+if (!findings.length) {
+  console.log('  PASS: every colour outside the palette comes from a token');
+  process.exit(0);
+}
+
+console.log(`\n  FAIL: ${findings.length} colour literal(s) outside the palette\n`);
+for (const f of findings) console.log(`    ${f.rel}:${f.line}\n      ${f.text}`);
+console.log(
+  '\n  Each one is a colour that will not follow a theme. Use a token, or add\n'
+  + `  a \`${MARKER} <reason>\` comment on the line saying why it cannot be one.`,
+);
+process.exit(1);

--- a/apps/portal-next/web/src/components/ServiceActions.css
+++ b/apps/portal-next/web/src/components/ServiceActions.css
@@ -39,7 +39,7 @@
      26px box and loses the disappearing act: muted at rest, full contrast on
      hover. A control you cannot find has a footprint of zero and a value to
      match. */
-  opacity: var(--rest-opacity, .55);
+  opacity: var(--rest-opacity);
   transition: opacity var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease),
               border-color var(--dur-fast) var(--ease);
 }

--- a/apps/portal-next/web/src/components/three/StackScene.tsx
+++ b/apps/portal-next/web/src/components/three/StackScene.tsx
@@ -23,18 +23,25 @@ import './three.css';
 const PaletteCtx = createContext<ScenePalette>(scenePalette());
 const usePal = () => useContext(PaletteCtx);
 
-// Re-reads on a theme pin (data-theme) or an OS theme change.
-function useScenePalette(): ScenePalette {
-  const [pal, setPal] = useState<ScenePalette>(scenePalette);
+// "The theme changed" as one subscription, counted rather than valued.
+//
+// This used to live inside useScenePalette and serve only the ScenePalette, so
+// the two OTHER things this scene reads from the theme - the status LED hexes
+// and the accent that lights it - were `useMemo(..., [])` and were read exactly
+// once, at mount. Flipping the theme repainted the chassis and left the lights
+// and the LEDs on the old palette. A tick shared by all three is what makes
+// "reads a token" and "follows the theme" the same statement.
+function useThemeTick(): number {
+  const [tick, setTick] = useState(0);
   useEffect(() => {
-    const update = () => setPal(scenePalette());
-    const mo = new MutationObserver(update);
+    const bump = () => setTick((n) => n + 1);
+    const mo = new MutationObserver(bump);
     mo.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
     const mq = window.matchMedia('(prefers-color-scheme: light)');
-    mq.addEventListener('change', update);
-    return () => { mo.disconnect(); mq.removeEventListener('change', update); };
+    mq.addEventListener('change', bump);
+    return () => { mo.disconnect(); mq.removeEventListener('change', bump); };
   }, []);
-  return pal;
+  return tick;
 }
 
 // ── layout constants (world units; 1U slab ≈ 0.5 tall) ───────────────────────
@@ -199,7 +206,7 @@ function Slab({
       <group ref={grp}>
         {/* chassis */}
         <RoundedBox args={[SLAB_W, SLAB_H, SLAB_D]} radius={0.03} smoothness={2}>
-          <meshStandardMaterial color={hovered ? '#26324a' : '#182031'} metalness={0.85} roughness={0.34} />
+          <meshStandardMaterial color={hovered ? pal.slabBodyHover : pal.slabBody} metalness={0.85} roughness={0.34} />
         </RoundedBox>
         {/* brushed front bezel, slightly proud */}
         <mesh position={[0, 0, SLAB_D / 2 + 0.001]}>
@@ -232,7 +239,7 @@ function Slab({
         {[0, 1, 2].map((i) => (
           <mesh key={i} position={[SLAB_W / 2 - 0.16 - i * 0.14, -SLAB_H / 2 + 0.12, front + 0.008]}>
             <boxGeometry args={[0.06, 0.06, 0.02]} />
-            <meshStandardMaterial color="#22d3ee" emissive="#22d3ee" emissiveIntensity={0.55} toneMapped={false} />
+            <meshStandardMaterial color={pal.activity} emissive={pal.activity} emissiveIntensity={0.55} toneMapped={false} />
           </mesh>
         ))}
         {/* status LED + additive glow, top-right */}
@@ -750,9 +757,15 @@ function Scene({
     return () => { document.body.style.cursor = ''; };
   }, [hover]);
 
-  const hexes = useMemo<Hexes>(() => statusHexes(), []);
-  const pal = useScenePalette();
-  const primary = useMemo(() => cssVar('--primary') || '#4d9bff', []);
+  // All three read from the theme, so all three share its tick.
+  const tick = useThemeTick();
+  const hexes = useMemo<Hexes>(() => statusHexes(), [tick]);
+  const pal = useMemo<ScenePalette>(() => scenePalette(), [tick]);
+  // `--accent`, not `--primary` - the latter was never a token, so this had been
+  // pinned to the literal below since the accent palette was replaced, and three
+  // point lights plus the rack emissive were still lighting the scene in the old
+  // blue. Reading `--accent` is what makes the scene follow a theme at all.
+  const primary = useMemo(() => cssVar('--accent') || '#4d9bff', [tick]);
 
   const edgePanel = panels.find((p) => p.key === 'infra');
   const rackPanels = panels.filter((p) => p.key !== 'infra');
@@ -799,7 +812,7 @@ function Scene({
       <directionalLight position={[6, 15, 10]} intensity={1.95} color={pal.key} />
       <directionalLight position={[-9, 8, -6]} intensity={0.7} color={pal.fill} />
       <pointLight position={[-7, 8, -5]} intensity={55} distance={50} color={primary} />
-      <pointLight position={[0, 3, 13]} intensity={22} distance={44} color="#22d3ee" />
+      <pointLight position={[0, 3, 13]} intensity={22} distance={44} color={pal.activity} />
       <pointLight position={[0, edgeY, 5]} intensity={16} distance={30} color={primary} />
 
       <Rig focus={focus} presets={presets} animate={animate} />

--- a/apps/portal-next/web/src/components/three/three.css
+++ b/apps/portal-next/web/src/components/three/three.css
@@ -59,7 +59,8 @@
 }
 .sv-focus-btn:hover { color: var(--fg); }
 .sv-focus-btn.is-on {
-  color: #fff;
+  /* See .topo-view-btn.is-on - same control, same fix. */
+  color: var(--on-accent);
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
 }
 
@@ -96,6 +97,11 @@
   border-radius: inherit;
   background: radial-gradient(120% 120% at 50% 40%,
     transparent 52%,
+    /* stray-colour-ok: #000 here is a DARKENER, not a colour. The value that
+       carries the theme is var(--bg); black is the direction it is pushed in,
+       and "further from the viewer is darker" is true of every theme, including
+       the light one - where this correctly darkens white rather than lightening
+       it. A token for it would be a token whose only legal value is black. */
     color-mix(in oklab, var(--bg) 58%, #000 42%) 100%);
 }
 

--- a/apps/portal-next/web/src/components/three/webgl.ts
+++ b/apps/portal-next/web/src/components/three/webgl.ts
@@ -21,18 +21,25 @@ export function prefersReducedMotion(): boolean {
 
 import type { Status } from '../../lib/discover';
 
-// The reserved status palette, mirrored EXACTLY from index.css
-// (--ok/--warn/--down/--unk) so the 3D LEDs glow in the same colours as every
-// dot on the page. Kept as a hard fallback; `statusHexes()` prefers the live
-// computed values so a theme/token change stays in sync automatically.
+// The reserved status palette, mirrored from index.css's DARK block
+// (--st-up/--st-warn/--st-down/--st-off/--st-unknown) so the 3D LEDs glow in the
+// same colours as every dot on the page. This is a hard fallback for the case
+// where there is no computed style to read (SSR, a detached canvas);
+// `statusHexes()` prefers the live token values, so a theme change stays in sync
+// automatically.
+//
+// `stopped` and `unknown` were #4a5263 and #6b7688 here, against tokens of
+// #4a5568 and #64748b. Two hand-copied values drifting is exactly what happens
+// when the live path silently stops running - the fallback becomes the only code
+// path and nothing compares it to its source again. Corrected with the bridge.
 export const STATUS_HEX: Record<Status, string> = {
   up: '#34d399',
   starting: '#fbbf24',
   down: '#fb7185',
   // Dimmer than 'unknown': a stopped unit should read as an unlit slab in the
   // rack, not as another thing demanding attention.
-  stopped: '#4a5263',
-  unknown: '#6b7688',
+  stopped: '#4a5568',
+  unknown: '#64748b',
 };
 
 export const STATUS_LABEL: Record<Status, string> = {
@@ -43,10 +50,23 @@ export const STATUS_LABEL: Record<Status, string> = {
   unknown: 'Unknown',
 };
 
-// index.css maps state → status var (up=ok, starting=warn, down=down,
-// stopped=off, unknown=unk).
+// index.css maps state → status token.
+//
+// The BARE fill, not the `-fg` half, and that differs from lib/icons.tsx on
+// purpose: these drive emissive materials on LEDs in a 3D scene - light sources
+// a few pixels across seen against a dark rack - not text on a surface. The
+// contrast floors that make `-fg` the right answer for a glyph are a statement
+// about text on a background, and there is no background here.
+//
+// These names were `--ok/--warn/--down/--off/--unk` until the palette was
+// reorganised into `--st-*`, and the map was left behind. Because cssVar()
+// returns '' for an undefined property, every lookup fell through to the
+// STATUS_HEX fallback below and the "prefers the live computed values" promise
+// in that comment had been false ever since - which is why two of the five
+// fallbacks had drifted from the tokens they claim to mirror.
 const STATUS_VAR: Record<Status, string> = {
-  up: '--ok', starting: '--warn', down: '--down', stopped: '--off', unknown: '--unk',
+  up: '--st-up', starting: '--st-warn', down: '--st-down',
+  stopped: '--st-off', unknown: '--st-unknown',
 };
 
 // Read a CSS custom property off :root, trimmed. Returns '' if unavailable.
@@ -79,10 +99,22 @@ export interface ScenePalette {
   frame: string;       // rack cabinet frame + edge legs
   backPanel: string;   // rack back wall
   rail: string;        // rack rails
-  slab: string;        // 1U server body
+  slab: string;        // 1U server front bezel
+  // The slab's CHASSIS, behind the bezel, and its hover state. These were two
+  // literals inline on the mesh while the bezel one line below already read
+  // `pal.slab`, so a light theme lifted the bezel to mid-slate and left the body
+  // it sits on near-black. A palette with a hole in it is worse than no palette:
+  // the surrounding meshes move and the hole stays put, which reads as a
+  // rendering fault rather than as a missing value.
+  slabBody: string;
+  slabBodyHover: string;
   slabScreen: string;
   slabGlow: string;
   handle: string;
+  // The three faint activity LEDs on each slab, and the cyan point light that
+  // keys the scene. Emissive, so they need to stay bright against a dark rack
+  // and step down against a white page.
+  activity: string;
   machine: string;     // container-floor machine body
   vent: string;
   pad: string;         // grounding pad under the floor
@@ -99,7 +131,9 @@ const DARK: ScenePalette = {
   screen: '#0a1622', screenGlow: '#12405a',
   chassis: '#16203a', bezel: '#0c1324',
   frame: '#0d1119', backPanel: '#0a0d14', rail: '#2b3446',
-  slab: '#0f141f', slabScreen: '#0a1622', slabGlow: '#123449', handle: '#3c4a63',
+  slab: '#0f141f', slabBody: '#182031', slabBodyHover: '#26324a',
+  slabScreen: '#0a1622', slabGlow: '#123449', handle: '#3c4a63',
+  activity: '#22d3ee',
   machine: '#161d2c', vent: '#05070c',
   pad: '#0a0f18', padOpacity: 0.55,
   sky: '#d7e6ff', ground: '#0a0e16',
@@ -115,7 +149,13 @@ const LIGHT: ScenePalette = {
   screen: '#dbeafe', screenGlow: '#60a5fa',
   chassis: '#8fa0b5', bezel: '#aab6c7',
   frame: '#7d8b9e', backPanel: '#9aa7b8', rail: '#cbd5e1',
-  slab: '#b3bece', slabScreen: '#dbeafe', slabGlow: '#7dd3fc', handle: '#e2e8f0',
+  // slabBody sits a step DARKER than the bezel it carries, the same way the dark
+  // set does - the relationship is what makes it read as a body, not the value.
+  slab: '#b3bece', slabBody: '#9fabbb', slabBodyHover: '#c3ccd9',
+  slabScreen: '#dbeafe', slabGlow: '#7dd3fc', handle: '#e2e8f0',
+  // Cyan-600 rather than cyan-400: an emissive that glows against a black rack
+  // washes out to near-white against a white page.
+  activity: '#0891b2',
   machine: '#a8b4c4', vent: '#7c8aa3',
   pad: '#64748b', padOpacity: 0.16,
   sky: '#ffffff', ground: '#cbd5e1',

--- a/apps/portal-next/web/src/components/viz.tsx
+++ b/apps/portal-next/web/src/components/viz.tsx
@@ -104,7 +104,14 @@ export function BarGauge({
             <span className="vz-gauge-val">{r.display}</span>
           </>
         );
-        const style = { ['--acc' as string]: `var(${r.accent ?? '--primary'})` } as React.CSSProperties;
+        // `--accent`, not `--primary`: the latter has never been defined. That
+        // was not merely a dead fallback rescued by viz.css's `--acc:
+        // var(--accent)` default - an INLINE style wins over that rule, so on
+        // every gauge without an explicit accent this set `--acc` to the
+        // guaranteed-invalid value, and `var(--acc)` downstream resolved to
+        // `unset` rather than to the default. The default only ever protected
+        // the rows that never reached this line.
+        const style = { ['--acc' as string]: `var(${r.accent ?? '--accent'})` } as React.CSSProperties;
         const cls = `vz-gauge-row ${r.muted ? 'is-muted' : ''}`;
         return renderRow ? (
           <div key={r.key} className={cls} style={style}>{renderRow(r, body)}</div>

--- a/apps/portal-next/web/src/index.css
+++ b/apps/portal-next/web/src/index.css
@@ -133,6 +133,12 @@
   --border-w: 1px;
   --hover-opacity: .9;
   --disabled-opacity: .5;
+  /* An always-present control that is quiet until you reach for it (the per-row
+     action trigger). It belongs beside the other two rather than as a fallback
+     inside one component: this is the third state in the same family, and a
+     component-local `var(--rest-opacity, .55)` describing a token that does not
+     exist reads as configurable when nothing can configure it. */
+  --rest-opacity: .55;
 
   /* ── motion ─────────────────────────────────────────────────────────────── */
   --dur-fast: 120ms;   /* hover, colour */

--- a/apps/portal-next/web/src/lib/icons.tsx
+++ b/apps/portal-next/web/src/lib/icons.tsx
@@ -91,10 +91,26 @@ export const STATUS_ICON: Record<Status, LucideIcon> = {
 
 // A tiny variant used where a filled dot reads better than an outline (e.g. the
 
+// The reserved status tokens, by state.
+//
+// These were `--ok/--warn/--down/--off/--unk` until the palette was reorganised
+// into the `--st-*` family, and this map was not updated with it. Nothing threw:
+// an undefined custom property makes `var(--ok)` resolve to nothing, so
+// `StatusIcon` silently inherited its parent's colour and every status glyph in
+// the app had been rendering in body text for as long as the rename was old.
+// That is the failure mode to remember - a dead token name is not an error, it
+// is a colour that quietly stops being applied.
+// The `-fg` half of each pair, NOT the bare fill, because line 126 sets `color`
+// on a 15px glyph. index.css measures the two halves separately and says so: the
+// fills are legal at 2.50/1.94/1.46 to 1 in light mode only because they are
+// large solid areas beside a track, and it warns in as many words to "re-verify
+// if any of these is ever used for a small glyph". This is that glyph. The `-fg`
+// values are the ones held at >= 4.5:1.
 export const STATUS_VAR: Record<Status, string> = {
-  // --off is the muted token: a stopped service must recede, not compete with
-  // the things that are actually broken.
-  up: '--ok', starting: '--warn', down: '--down', stopped: '--off', unknown: '--unk',
+  // --st-off-fg is the muted token: a stopped service must recede, not compete
+  // with the things that are actually broken.
+  up: '--st-up-fg', starting: '--st-warn-fg', down: '--st-down-fg',
+  stopped: '--st-off-fg', unknown: '--st-unknown-fg',
 };
 
 const STATUS_LABEL: Record<Status, string> = {

--- a/apps/portal-next/web/src/pages/Topology.css
+++ b/apps/portal-next/web/src/pages/Topology.css
@@ -35,7 +35,10 @@
 }
 .topo-view-btn:hover { color: var(--fg); }
 .topo-view-btn.is-on {
-  color: #fff;
+  /* --on-accent, not #fff: this text sits on a filled --accent, which is what
+     that token is for and what .btn.primary already uses. The literal was white
+     in both themes, so on the light theme it was white on a light-blue gradient. */
+  color: var(--on-accent);
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
 }
 

--- a/apps/portal-next/web/src/pages/Topology.tsx
+++ b/apps/portal-next/web/src/pages/Topology.tsx
@@ -2,7 +2,19 @@ import { lazy, Suspense, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePortal } from '../lib/data';
 import { panelize } from '../lib/panels';
-import { STATUS_HEX } from '../components/three/webgl';
+// The flat map paints in TOKENS, not in the 3D scene's hex mirror.
+//
+// It used to import STATUS_HEX from webgl.ts and inline it into `style`, which
+// made this the one view in the app that could not re-theme: every edge, halo,
+// dot, legend swatch and container square stayed on the dark palette on a white
+// page. The hexes belong to the 3D scene, which paints with real materials and
+// genuinely cannot read CSS; an SVG in the document can, so it should.
+//
+// STATUS_VAR is the `-fg` half of each pair - see the note on it - and that is
+// the right half here for the same reason it is right for StatusIcon: these are
+// 7px dots and 14px squares, not the large filled areas the bare fills were
+// measured for.
+import { STATUS_VAR } from '../lib/icons';
 import { serviceLink } from '../lib/links';
 import { conditionLabel, resolveEdges, type PortalNode } from '../lib/discover';
 import './Topology.css';
@@ -50,7 +62,7 @@ export function Topology() {
           </div>
           <div className="topo-legend">
             {(['up', 'starting', 'down', 'unknown'] as const).map((s) => (
-              <span key={s} className="leg"><span className="leg-dot" style={{ background: STATUS_HEX[s] }} /> {s}</span>
+              <span key={s} className="leg"><span className="leg-dot" style={{ background: `var(${STATUS_VAR[s]})` }} /> {s}</span>
             ))}
             {/* Only meaningful on the flat map - the 3D scene has no dependency
                 lines to explain, and a legend for something not on screen is
@@ -165,7 +177,7 @@ function FlatMap() {
         {/* edges: hub -> service (routed), service -> container */}
         {placed.map(({ node, y }) => {
           const lit = isLit(node.id);
-          const hex = STATUS_HEX[node.status];
+          const hex = `var(${STATUS_VAR[node.status]})`;
           const hasRoute = !!node.route;
           const hasCtr = !!node.container;
           const active = hover === node.id;
@@ -242,7 +254,7 @@ function FlatMap() {
 
         {/* service nodes */}
         {placed.map(({ node, y }) => {
-          const hex = STATUS_HEX[node.status];
+          const hex = `var(${STATUS_VAR[node.status]})`;
           const lit = isLit(node.id);
           const active = hover === node.id;
           return (
@@ -271,7 +283,7 @@ function FlatMap() {
 
         {/* container nodes */}
         {placed.filter((p) => p.node.container).map(({ node, y }) => {
-          const hex = STATUS_HEX[node.status];
+          const hex = `var(${STATUS_VAR[node.status]})`;
           const active = hover === node.id;
           return (
             <g key={`c-${node.id}`} className={`topo-ctr ${active ? 'on' : ''}`} transform={`translate(${CTR_X} ${y})`} style={{ opacity: isLit(node.id) ? 1 : 0.18 }}>

--- a/apps/portal-next/web/src/pages/control/control.css
+++ b/apps/portal-next/web/src/pages/control/control.css
@@ -79,7 +79,13 @@
   overflow-x: hidden;
   padding: 14px 10px 18px;
   border-right: 1px solid var(--line);
-  background: var(--surface-0, transparent);
+  /* `transparent`, stated rather than reached for through an undefined token.
+     This read `var(--surface-0, transparent)`, and --surface-0 has never
+     existed - the elevation ladder starts at --bg / --bg-2 and then
+     --surface-1..4. The fallback was doing all the work, so the rail was always
+     transparent and the reference only suggested a token someone might define
+     later and change this by accident. */
+  background: transparent;
   transition: width var(--dur) var(--ease);
 }
 


### PR DESCRIPTION
Phase 0 of the theme work: before named themes can exist, the tokens have to actually reach the pixels. Four places where they had stopped, all silent, all only visible on the theme you are not currently looking at.

## What was broken

| | |
|---|---|
| `STATUS_VAR` in `lib/icons.tsx` and `three/webgl.ts` | pointed at `--ok/--warn/--down/--off/--unk`, renamed to `--st-*` some time ago. An undefined custom property is not an error, so **every status glyph in the app was uncoloured** and inherited body text. In the 3D scene the same dead names meant `cssVar()` always fell through to the hardcoded mirror — which is why two of those five fallbacks had drifted from the tokens they claim to copy. |
| `cssVar('--primary')` in `StackScene.tsx` and `viz.tsx` | a token that has never existed. Three point lights and the rack emissive stayed on the accent from *before* the palette was replaced. In `viz.tsx` it was worse than dead: the inline style shadows `viz.css`'s `--acc` default, so every gauge without an explicit accent set `--acc` to the guaranteed-invalid value. |
| `pages/Topology.tsx` | imported the 3D scene's hex mirror and inlined it into `style`, so the SVG map was the one view that could not re-theme at all. |
| `color: #fff` ×2 | white text on a filled accent, in both themes. |

Plus `--rest-opacity` and `--surface-0`, both referenced and never defined.

## Two judgement calls worth reviewing

**`icons.tsx` takes `--st-*-fg`, `webgl.ts` takes the bare `--st-*`.** `index.css` measures the two halves separately and says in as many words to re-verify before using a fill on a small glyph — the light-mode fills sit at 2.50 / 1.94 / 1.46 to 1. A 15px status icon is exactly that glyph; a 3D LED seen against a dark rack is not.

**The slab chassis** was two literals inline while its own bezel one line below already read `pal.slab`, so a light theme lifted the bezel and left the body near-black. Added to `ScenePalette` with the activity LEDs. A palette with a hole in it is worse than no palette — the surrounding meshes move and the hole stays put, which reads as a rendering fault.

## The check

`checks/stray-colour.mjs` turns the rule into a test: a colour literal may appear only in a file that *defines* tokens, inside a mask where black and white are alpha, or on a line carrying a `stray-colour-ok:` marker with a written reason. Four exemptions, each carrying the reason it is exempt. Deliberately requires prose — if the reason is hard to write, the honest answer was a token.

## Verified

- `stray-colour.mjs` — proved it **fails** on a planted `#ff00aa` / `rgb()` / `white` before trusting that it passes.
- `checks/run.sh` — full suite green, `tsc --noEmit` clean.
- Live, on a fresh load, reading computed values rather than eyeballing a screenshot:
  - status glyphs now resolve in both themes (`--st-up-fg` → `rgb(52,211,153)` dark / `rgb(4,120,87)` light), where before they resolved to nothing;
  - topology legend dots re-theme (`rgb(52,211,153)` → `rgb(4,120,87)`);
  - `.topo-view-btn.is-on` → `rgb(9,9,11)` on dark, white on light.

## Deliberately not here

The `theme-color` meta tags and `site.webmanifest` are still dark-only. Fixing them means editing the one inline script in `index.html`, which requires regenerating the CSP hash in `nginx.conf` — and Phase 1 rewrites that script anyway. Doing it twice would be two hash dances for one change.
