### PR TITLE
feat(theme): named themes, and a contract that decides whether one is legal

### DIFF
--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -63,6 +63,13 @@ for (const [k, v] of Object.entries(n)) console.log(\`  \${k.padEnd(9)} \${v.len
 "
 
 echo
+echo "── every theme keeps the palette's contract ────────────"
+# Reads index.css, shell.css and src/themes/*.css directly. Runs against the two
+# SHIPPED palettes as well as the named themes, on purpose: a rule that fails on
+# Bothy's own colours is a wrong rule, and this is where that gets found out.
+node "$HERE/theme-contract.mjs"
+
+echo
 echo "── every colour comes from a token ─────────────────────"
 # Reads the source tree directly - no compile step, because it is looking at the
 # text rather than at behaviour. Runs regardless of whether there is a build.

--- a/apps/portal-next/checks/theme-contract.mjs
+++ b/apps/portal-next/checks/theme-contract.mjs
@@ -1,0 +1,409 @@
+// A theme is legal or it is not, and the rules are already written down.
+//
+// index.css does not merely assert its palette is accessible - it records the
+// measurements, the bands, the orderings and the two historical bugs that
+// produced the rules. All of that is prose, which means it holds exactly as long
+// as the next person reads it. This turns it into a test, so that porting a
+// theme becomes mechanical: write the tokens, run this, fix what it names.
+//
+// It is deliberately run against the SHIPPED palette too. If a rule stated here
+// fails on Bothy's own dark and light themes, the rule is wrong - not the
+// palette - and this file is where that gets found out.
+//
+// WHAT A THEME OWES. Of the 73 custom properties in :root, 16 are DERIVED
+// (color-mix over another token, on the same element, so they re-evaluate for
+// free) and 16 are STRUCTURAL (radii, motion, fonts, widths - not colour, and
+// shared by every theme). The remaining 41 are the theme's own, and a theme must
+// declare all of them: a missing token silently inherits the base palette, which
+// is how you get a Gruvbox page with one blue button on it.
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const SRC = join(HERE, '..', 'web', 'src');
+
+// ── colour ──────────────────────────────────────────────────────────────────
+
+const srgbToLinear = (c) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+
+/** Parse the value forms that actually appear in these files: #rgb, #rrggbb,
+ *  #rrggbbaa, rgb()/rgba() in both comma and space syntax. Returns
+ *  {r,g,b,a} in 0..1, or null for anything else (a var(), a gradient, a
+ *  shadow recipe) - callers decide whether "not a flat colour" is a failure. */
+function parseColour(v) {
+  const s = String(v).trim();
+  const hex = s.match(/^#([0-9a-fA-F]{3,8})$/);
+  if (hex) {
+    let h = hex[1];
+    if (h.length === 3 || h.length === 4) h = [...h].map((c) => c + c).join('');
+    if (h.length !== 6 && h.length !== 8) return null;
+    const n = (i) => parseInt(h.slice(i, i + 2), 16) / 255;
+    return { r: n(0), g: n(2), b: n(4), a: h.length === 8 ? n(6) : 1 };
+  }
+  const fn = s.match(/^rgba?\(([^)]+)\)$/i);
+  if (fn) {
+    const parts = fn[1].replace(/\//g, ' ').split(/[\s,]+/).filter(Boolean);
+    if (parts.length < 3) return null;
+    const num = (p) => (p.endsWith('%') ? parseFloat(p) / 100 * 255 : parseFloat(p));
+    const alpha = (p) => (p == null ? 1 : p.endsWith('%') ? parseFloat(p) / 100 : parseFloat(p));
+    const [r, g, b] = parts.slice(0, 3).map(num);
+    if ([r, g, b].some(Number.isNaN)) return null;
+    return { r: r / 255, g: g / 255, b: b / 255, a: alpha(parts[3]) };
+  }
+  return null;
+}
+
+/** Flatten a translucent colour onto an opaque one. --line and the shadow
+ *  recipes are alpha over a surface, and comparing them un-composited would
+ *  measure a colour that is never on screen. */
+const over = (fg, bg) => ({
+  r: fg.r * fg.a + bg.r * (1 - fg.a),
+  g: fg.g * fg.a + bg.g * (1 - fg.a),
+  b: fg.b * fg.a + bg.b * (1 - fg.a),
+  a: 1,
+});
+
+const luminance = (c) =>
+  0.2126 * srgbToLinear(c.r) + 0.7152 * srgbToLinear(c.g) + 0.0722 * srgbToLinear(c.b);
+
+function contrast(a, b) {
+  const [x, y] = [luminance(a), luminance(b)].sort((p, q) => q - p);
+  return (x + 0.05) / (y + 0.05);
+}
+
+/** sRGB → OKLCH. The accent-legality rule is stated in OKLCH (hue degrees and
+ *  chroma), and index.css records every accent's coordinates in a comment, so
+ *  this is the space the contract is written in. */
+function oklch(c) {
+  const [r, g, b] = [c.r, c.g, c.b].map(srgbToLinear);
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+  const L = 0.2104542553 * l + 0.7936177850 * m - 0.0040720468 * s;
+  const A = 1.9779984951 * l - 2.4285922050 * m + 0.4505937099 * s;
+  const B = 0.0259040371 * l + 0.7827717662 * m - 0.8086757660 * s;
+  const C = Math.hypot(A, B);
+  let H = (Math.atan2(B, A) * 180) / Math.PI;
+  if (H < 0) H += 360;
+  return { L, C, H };
+}
+
+/** Shortest angular distance, because hue is a circle and 355° is 20° away from
+ *  15°, not 340°. The --a5/--st-down pair is only legal by this reading. */
+const hueGap = (a, b) => { const d = Math.abs(a - b) % 360; return d > 180 ? 360 - d : d; };
+
+// ── the token blocks ────────────────────────────────────────────────────────
+
+/** Split a stylesheet into { sel, toks } with a BRACE COUNTER, not a flat regex.
+ *
+ *  The flat version - `/(^|})([^{}]+)\{([^{}]*)\}/g` - is the obvious thing to
+ *  write and it is wrong here, silently. index.css has eleven @media blocks, and
+ *  a nested `}` puts the pattern out of step with the real block structure: it
+ *  found ONE :root block where the file has two, so the eleven derived tint
+ *  tokens in the second one were invisible to the check. That happened not to
+ *  change the required set (all eleven are derived), which is precisely why it
+ *  would have gone unnoticed - a parser that is wrong about a file it currently
+ *  agrees with is a check waiting to stop working.
+ *
+ *  At-rules are recursed into and their prelude is prefixed onto the selector,
+ *  so a `:root` inside `@media (prefers-color-scheme: dark)` is reported as
+ *  distinct from the bare `:root` rather than merged into it. */
+function blocks(css) {
+  const src = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const out = [];
+
+  const scan = (text, prefix) => {
+    let i = 0, start = 0;
+    while (i < text.length) {
+      const c = text[i];
+      if (c === '{') {
+        const prelude = text.slice(start, i).trim();
+        let depth = 1, j = i + 1;
+        while (j < text.length && depth) {
+          if (text[j] === '{') depth++;
+          else if (text[j] === '}') depth--;
+          j++;
+        }
+        const body = text.slice(i + 1, j - 1);
+        if (prelude.startsWith('@')) {
+          scan(body, `${prefix}${prelude} `);
+        } else {
+          const toks = {};
+          // Only declarations at THIS level: strip any nested block first, so a
+          // token inside a nested rule is not attributed to its parent.
+          const flat = body.replace(/\{[^{}]*\}/g, '');
+          for (const t of flat.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/g)) toks[t[1]] = t[2].trim();
+          // `color-scheme` is not a custom property but it is how a theme
+          // declares its appearance, so it is carried alongside rather than
+          // inferred from the id - "tokyo-night" does not say dark, and a
+          // convention that it should would break on the first exception.
+          const cs = flat.match(/color-scheme\s*:\s*(dark|light)/);
+          if (Object.keys(toks).length) {
+            out.push({ sel: prefix + prelude, toks, scheme: cs ? cs[1] : null });
+          }
+        }
+        i = j; start = j;
+        continue;
+      }
+      if (c === '}') { i++; start = i; continue; }
+      i++;
+    }
+  };
+
+  scan(src, '');
+  return out;
+}
+
+const indexCss = readFileSync(join(SRC, 'index.css'), 'utf8');
+const shellCss = readFileSync(join(SRC, 'pages', 'files', 'shell.css'), 'utf8');
+const idx = blocks(indexCss);
+
+const merge = (...sets) => Object.assign({}, ...sets);
+const pick = (pred) => merge(...idx.filter((b) => pred(b.sel)).map((b) => b.toks));
+
+const BASE = pick((s) => s === ':root');
+const LIGHT = pick((s) => /^:root\[data-theme=['"]?light/.test(s));
+
+// The syntax palette lives beside the editor it serves rather than in index.css.
+// A theme that restyles everything except code is not a theme, so it is part of
+// the contract - but as an OPTIONAL group, because a theme that omits it falls
+// back to a set that is already contrast-checked for its appearance.
+const hlBlocks = blocks(shellCss).filter((b) => b.sel.includes('bothy-files'));
+const HL_DARK = merge(...hlBlocks.filter((b) => !b.sel.includes('light')).map((b) => b.toks));
+const HL_LIGHT = merge(...hlBlocks.filter((b) => b.sel.includes('light')).map((b) => b.toks));
+
+const DERIVED = new Set(Object.entries(BASE).filter(([, v]) => v.includes('var(')).map(([k]) => k));
+const STRUCTURAL = new Set([
+  '--r-xs', '--r-sm', '--r-md', '--r-lg', '--r-full', '--border-w', '--wrap',
+  '--scrollbar-w', '--dur-fast', '--dur', '--dur-slow', '--ease', '--font', '--mono',
+  '--disabled-opacity', '--rest-opacity',
+]);
+// Required of every theme: literal, not derived, not structural.
+const REQUIRED = Object.keys(BASE)
+  .filter((k) => !DERIVED.has(k) && !STRUCTURAL.has(k))
+  .sort();
+
+// ── the rules ───────────────────────────────────────────────────────────────
+
+const STATUSES = ['up', 'warn', 'down', 'unknown', 'off'];
+const ACCENTS = ['--a1', '--a2', '--a3', '--a4', '--a5'];
+const CHARTS = ['--chart-1', '--chart-2', '--chart-3', '--chart-4', '--chart-5'];
+
+// Written into index.css as measurements, reproduced here as thresholds.
+const AA = 4.5;              // text
+const ACCENT_ON_SURFACE = 4.6; // --a1..--a5 are painted as 12px bold text
+const CHART_VS_CARD = 3.0;
+const CHROMATIC_C = 0.06;    // a status at or above this is "chromatic"
+const HUE_SEPARATION = 45;   // degrees, against a chromatic status
+const CHROMA_MARGIN = 0.06;  // against a near-grey status
+const BAND = { dark: [0.48, 0.67], light: [0.43, 0.77] };
+
+// Three light-mode status FILLS sit below 3:1 on purpose: they are large solid
+// areas beside a track, never small glyphs or 1px borders, and status is never
+// encoded by colour alone. Recorded as an allowance WITH its reason so that a
+// new theme cannot quietly widen it - the allowance is per token, not a blanket
+// "fills are exempt".
+const FILL_ALLOWANCE = {
+  '--st-up': 'large filled area beside a track; the -fg half carries any text',
+  '--st-unknown': 'as --st-up',
+  '--st-off': 'as --st-up, and deliberately the quietest thing on the page',
+};
+
+let failures = 0, passes = 0;
+const say = (ok, label, detail = '') => {
+  if (ok) passes++; else failures++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? `  ${detail}` : ''}`);
+};
+
+function checkTheme(name, appearance, toks, hl) {
+  console.log(`\n── ${name}  (${appearance}) ─────────────────────────────────`);
+
+  // 1. completeness
+  const missing = REQUIRED.filter((k) => !(k in toks));
+  say(!missing.length, 'declares every required token',
+    missing.length ? `missing ${missing.length}: ${missing.slice(0, 6).join(' ')}` : `${REQUIRED.length} tokens`);
+  if (missing.length) return;
+
+  const C = (k) => {
+    const p = parseColour(toks[k]);
+    return p;
+  };
+  const s1 = C('--surface-1'), s2 = C('--surface-2'), bg2 = C('--bg-2');
+  const on = (fg, bg) => contrast(fg.a < 1 ? over(fg, bg) : fg, bg);
+
+  // A foreground is measured against every ground it is PAINTED on, not against
+  // one canonical background. That distinction is not pedantry: the first thing
+  // this check found was that the two quietest status foregrounds had been
+  // measured on a card while being used mostly in the file explorer and the
+  // reader's index, both of which sit on --bg-2 - a darker ground, so the real
+  // ratios were ~0.35 lower than the ones written into index.css, and below AA.
+  const GROUNDS = [['surface-1', s1], ['surface-2', s2], ['bg-2', bg2]];
+  const worst = (fg) => GROUNDS.reduce(
+    (acc, [n, g]) => { const v = on(fg, g); return v < acc.v ? { n, v } : acc; },
+    { n: '', v: Infinity },
+  );
+
+  // 2. foreground contrast
+  for (const k of ['--fg', '--fg-muted', '--fg-subtle']) {
+    const w = worst(C(k));
+    say(w.v >= AA, `${k} >= ${AA}:1 on every ground it is painted on`,
+      `worst ${w.v.toFixed(2)} on ${w.n}`);
+  }
+  {
+    const a = on(C('--accent-fg'), s1);
+    say(a >= AA, `--accent-fg >= ${AA}:1 on surface-1`, a.toFixed(2));
+    const o = on(C('--on-accent'), C('--accent'));
+    say(o >= 3.0, '--on-accent >= 3:1 on --accent (button text)', o.toFixed(2));
+  }
+
+  // 3. status: -fg is the text-safe half, the fill is not asserted where the
+  //    palette says out loud that it is a large area.
+  for (const s of STATUSES) {
+    const w = worst(C(`--st-${s}-fg`));
+    say(w.v >= AA, `--st-${s}-fg >= ${AA}:1 on every ground it is painted on`,
+      `worst ${w.v.toFixed(2)} on ${w.n}`);
+  }
+  for (const s of STATUSES) {
+    const key = `--st-${s}`;
+    const v = on(C(key), s1);
+    if (key in FILL_ALLOWANCE) {
+      console.log(`ALLOW ${key} fill at ${v.toFixed(2)}:1 - ${FILL_ALLOWANCE[key]}`);
+      passes++;
+    } else {
+      say(v >= CHART_VS_CARD, `${key} fill >= 3:1 on surface-1`, v.toFixed(2));
+    }
+  }
+
+  // 4. light-mode status weight must run down > warn > up > unknown > stopped.
+  //    Not asserted on dark: a saturated red is intrinsically darker than a
+  //    saturated green and index.css forbids "fixing" it by brightening the red
+  //    into the amber's territory.
+  if (appearance === 'light') {
+    const order = ['down', 'warn', 'up', 'unknown', 'off'];
+    const w = order.map((s) => ({ s, L: oklch(C(`--st-${s}`)).L }));
+    const ok = w.every((x, i) => i === 0 || w[i - 1].L <= x.L + 1e-9);
+    say(ok, 'light status weight runs down > warn > up > unknown > stopped',
+      w.map((x) => `${x.s} ${x.L.toFixed(3)}`).join(' < '));
+  }
+
+  // 5. accent legality - the whole reason --a4 stopped being #34d399
+  const stats = STATUSES.map((s) => ({ s, ...oklch(C(`--st-${s}`)) }));
+  for (const k of ACCENTS) {
+    const a = oklch(C(k));
+    const bad = [];
+    for (const st of stats) {
+      if (st.C >= CHROMATIC_C) {
+        const g = hueGap(a.H, st.H);
+        if (g < HUE_SEPARATION) bad.push(`${st.s}: hue gap ${g.toFixed(0)}° < ${HUE_SEPARATION}°`);
+      } else if (a.C - st.C < CHROMA_MARGIN) {
+        bad.push(`${st.s}: chroma margin ${(a.C - st.C).toFixed(3)} < ${CHROMA_MARGIN}`);
+      }
+    }
+    say(!bad.length, `${k} is legal against every status`,
+      bad.length ? bad.join('; ') : `L ${a.L.toFixed(2)} C ${a.C.toFixed(3)} H ${a.H.toFixed(0)}°`);
+  }
+  for (const k of ACCENTS) {
+    const v = on(C(k), s2);
+    say(v >= ACCENT_ON_SURFACE, `${k} >= ${ACCENT_ON_SURFACE}:1 on surface-2 (12px bold text)`,
+      v.toFixed(2));
+  }
+
+  // 6. charts - band, and separation against the card. Slot ORDER is part of
+  //    what was validated upstream, so the check reads them in order and never
+  //    sorts them.
+  const [lo, hi] = BAND[appearance];
+  for (const k of CHARTS) {
+    const c = oklch(C(k));
+    say(c.L >= lo && c.L <= hi, `${k} inside the ${appearance} lightness band ${lo}-${hi}`,
+      `L ${c.L.toFixed(3)}`);
+  }
+  for (const k of CHARTS) {
+    const v = on(C(k), s1);
+    say(v >= CHART_VS_CARD, `${k} >= 3:1 on surface-1`, v.toFixed(2));
+  }
+
+  // 7. the syntax palette, when the theme carries one
+  if (hl && Object.keys(hl).length) {
+    for (const [k, v] of Object.entries(hl)) {
+      const c = parseColour(v);
+      if (!c) continue; // --hl-com is var(--fg-subtle); already checked above
+      const a = contrast(c, bg2);
+      say(a >= AA, `${k} >= ${AA}:1 on --bg-2`, a.toFixed(2));
+    }
+  }
+}
+
+// ── run ─────────────────────────────────────────────────────────────────────
+
+console.log(`  contract: ${REQUIRED.length} required tokens · `
+  + `${DERIVED.size} derived (re-evaluate for free) · ${STRUCTURAL.size} structural (shared)`);
+
+checkTheme('Bothy Dark', 'dark', BASE, HL_DARK);
+checkTheme('Bothy Light', 'light', merge(BASE, LIGHT), merge(HL_DARK, HL_LIGHT));
+
+// The five swatch copies the picker paints for the two built-ins. They exist
+// because a :root palette cannot be applied to a card in a list; they are safe
+// only while they still equal what they claim to preview.
+console.log('\n── picker swatches match the palettes they preview ─────');
+{
+  const PREVIEWS = [['--sw-1', '--accent'], ['--sw-2', '--st-up'], ['--sw-3', '--st-warn'],
+    ['--sw-4', '--st-down'], ['--sw-5', '--a5']];
+  // They live in Settings.css, scoped to .theme-swatch, because unscoped they
+  // matched the root element and leaked --sw-1..5 into the whole document.
+  const settings = blocks(readFileSync(join(SRC, 'pages', 'Settings.css'), 'utf8'));
+  for (const [id, toks] of [['bothy-dark', BASE], ['bothy-light', merge(BASE, LIGHT)]]) {
+    const want = `.theme-swatch[data-bothy-theme='${id}']`;
+    const sw = merge(...settings
+      .filter((b) => b.sel.split(',').some((p) => p.trim() === want))
+      .map((b) => b.toks));
+    for (const [k, real] of PREVIEWS) {
+      const a = (sw[k] ?? '').toLowerCase();
+      const b = (toks[real] ?? '').toLowerCase();
+      say(!!a && a === b, `${id} ${k} still equals ${real}`, a === b ? a : `${a || '(missing)'} vs ${b}`);
+    }
+  }
+}
+
+// Every file in src/themes is a theme. Adding one is adding a file; the check
+// finds it without being told.
+const themeDir = join(SRC, 'themes');
+if (existsSync(themeDir)) {
+  // A theme file holds two kinds of block and they must not be confused: the
+  // PALETTE, whose selector is the doubled root attribute and nothing else, and
+  // the optional SYNTAX block, which is a descendant selector ending in
+  // .bothy-files. Matching on `data-bothy-theme` alone matched both, so each
+  // theme was checked twice - the second time with five syntax tokens layered
+  // over the BASE palette, which of course passed, because it was measuring
+  // Bothy Dark and calling it Tokyo Night. A check that reports a PASS for a
+  // thing it did not look at is worse than one that reports nothing.
+  const PALETTE = /^:?(?:root)?\[data-bothy-theme=['"]?([a-z0-9-]+)['"]?\](?:\[data-bothy-theme\])?$/;
+  const SYNTAX = /^:root\[data-bothy-theme=['"]?([a-z0-9-]+)['"]?\]\s+\S/;
+  // A palette declares two selectors in one comma list (see any theme file), so
+  // matching has to look at each part rather than at the whole prelude.
+  const parts = (sel) => sel.split(',').map((s) => s.trim());
+  const matchAny = (sel, re) => parts(sel).map((s) => s.match(re)).find(Boolean);
+
+  for (const f of readdirSync(themeDir).filter((n) => n.endsWith('.css')).sort()) {
+    const bs = blocks(readFileSync(join(themeDir, f), 'utf8'));
+    const hl = {};
+    for (const b of bs) {
+      const m = matchAny(b.sel, SYNTAX);
+      if (m) Object.assign(hl, { [m[1]]: merge(hl[m[1]] ?? {}, b.toks) });
+    }
+    for (const b of bs) {
+      const m = matchAny(b.sel, PALETTE);
+      if (!m) continue;
+      if (!b.scheme) {
+        console.log(`FAIL  ${m[1]} declares no color-scheme - the appearance is not guessable`);
+        failures++;
+        continue;
+      }
+      checkTheme(m[1], b.scheme, merge(BASE, b.toks), hl[m[1]] ?? null);
+    }
+  }
+}
+
+console.log(`\n  ${passes} pass · ${failures} fail`);
+process.exit(failures ? 1 : 0);

--- a/apps/portal-next/nginx.conf
+++ b/apps/portal-next/nginx.conf
@@ -46,7 +46,7 @@ server {
         # does NOT: no script here ever fetches those bytes, it only points an
         # element at them, and a fetch() to the sandbox would hand a hostile
         # document's bytes to this origin's JavaScript.
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-tjlZUI8n8zftOnKXGHeaG30U2mrcP6FWpo/LNiC0ELw='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http://$host:8100; media-src 'self' blob: http://$host:8100; frame-src http://$host:8100; connect-src 'self'; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-1/+a5nlren0s5fSLgjbA+g3LnAbqnaishAeoXih2ZZE='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http://$host:8100; media-src 'self' blob: http://$host:8100; frame-src http://$host:8100; connect-src 'self'; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'";
         # style-src keeps 'unsafe-inline' and cannot lose it yet: CodeMirror
         # injects its theme as a <style> element at runtime (style-mod), and
         # React writes inline style attributes for the pane sizes. Stated rather

--- a/apps/portal-next/web/index.html
+++ b/apps/portal-next/web/index.html
@@ -14,25 +14,53 @@
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <!-- Two values, one per scheme: this paints the browser/OS chrome around
-         the page (Android address bar, iOS status bar in standalone mode), so a
-         single dark value put white text on a white bar for light-mode users. -->
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#09090b" />
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
+    <!-- Paints the browser/OS chrome around the page (Android address bar, iOS
+         status bar in standalone mode). One tag, rewritten at runtime from the
+         resolved --bg by lib/theme.tsx.
+
+         It used to be two tags keyed on prefers-color-scheme. That was already
+         wrong for anyone who had PINNED a theme against their OS - the page went
+         light and the address bar stayed dark - and it cannot express a named
+         theme at all. This value is only the pre-paint default. -->
+    <meta name="theme-color" content="#09090b" />
     <!-- Stamp the resolved theme BEFORE first paint. index.css carries one light
          palette keyed on [data-theme='light'] (no prefers-color-scheme copy to
          drift out of sync), so without this a 'system' user on a light desktop
          would see a dark frame until React mounted. Kept deliberately tiny and
-         duplicated from lib/theme.tsx - an import would defeat the purpose. -->
+         duplicated from lib/theme.tsx - an import would defeat the purpose.
+
+         IT DELIBERATELY CARRIES NO LIST OF THEMES. A named theme's appearance is
+         read back from localStorage, written there by the app when the theme was
+         chosen, so adding a theme never means editing this script - which is the
+         one edit that would also force the CSP hash in nginx.conf to be
+         regenerated. The two BUILT-IN ids are known here because they are the
+         base palettes in index.css itself, not because this is a registry.
+
+         Editing this script at all means updating that hash; checks/csp_hash.mjs
+         fails the build otherwise. -->
     <script>
       (function () {
+        var e = document.documentElement;
         try {
-          var t = localStorage.getItem('portal-theme') || 'dark';
-          if (t === 'system')
-            t = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-          document.documentElement.setAttribute('data-theme', t === 'light' ? 'light' : 'dark');
-        } catch (e) {
-          document.documentElement.setAttribute('data-theme', 'dark');
+          var sel = localStorage.getItem('portal-theme') || 'bothy-dark';
+          if (sel === 'dark') sel = 'bothy-dark';
+          if (sel === 'light') sel = 'bothy-light';
+          var app;
+          if (sel === 'system') {
+            app = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            sel = app === 'dark' ? 'bothy-dark' : 'bothy-light';
+          } else if (sel === 'bothy-light') {
+            app = 'light';
+          } else if (sel === 'bothy-dark') {
+            app = 'dark';
+          } else {
+            app = localStorage.getItem('portal-theme-appearance') === 'light' ? 'light' : 'dark';
+          }
+          e.setAttribute('data-theme', app);
+          e.setAttribute('data-bothy-theme', sel);
+        } catch (err) {
+          e.setAttribute('data-theme', 'dark');
+          e.setAttribute('data-bothy-theme', 'bothy-dark');
         }
       })();
     </script>

--- a/apps/portal-next/web/src/components/AppShell.tsx
+++ b/apps/portal-next/web/src/components/AppShell.tsx
@@ -27,12 +27,17 @@ const NAV = [
   { to: '/files', label: 'Files', Icon: FolderTree, end: false },
 ];
 
+// The topbar control stays a one-tap toggle over the two built-ins and System,
+// not a menu of every theme. Cycling through the whole list to get back to where
+// you started is the failure mode of putting a registry behind a single button;
+// the full picker lives in Settings, where choosing is the point.
 function ThemeToggle() {
-  const { theme, cycle } = useTheme();
-  const Icon = theme === 'light' ? Sun : theme === 'dark' ? Moon : Monitor;
+  const { selection, theme, cycle } = useTheme();
+  const Icon = selection === 'system' ? Monitor : theme.appearance === 'light' ? Sun : Moon;
+  const label = selection === 'system' ? `System, currently ${theme.name}` : theme.name;
   return (
-    <Tooltip label={`Theme: ${theme} - click to change`} align="end">
-      <button className="icon-btn" onClick={cycle} aria-label={`Theme: ${theme}. Click to change.`}>
+    <Tooltip label={`Theme: ${label} - click to change`} align="end">
+      <button className="icon-btn" onClick={cycle} aria-label={`Theme: ${label}. Click to change.`}>
         <Icon size={18} />
       </button>
     </Tooltip>

--- a/apps/portal-next/web/src/index.css
+++ b/apps/portal-next/web/src/index.css
@@ -249,12 +249,24 @@
      large solid areas beside a track, not controls whose boundary must be
      discernible. Safe only because status is never encoded by colour alone.
      Re-verify if any of these is ever used for a small glyph or a 1px border.
-     The -fg values are all ≥ 4.5:1 and are the ones safe for text. */
+     The -fg values are all ≥ 4.5:1 and are the ones safe for text.
+
+     THE TWO QUIET ONES WERE MEASURED AGAINST THE WRONG GROUND (fixed 2026-08-17
+     by checks/theme-contract.mjs, the first thing it found). The ratios recorded
+     above were taken on a CARD; the two quietest foregrounds are painted mostly
+     on --bg-2 - the file explorer's `.fx-ro` and `.fx-ico.t-denied`, the
+     reader's `.rd-root-ro` - which is darker than a card, so the real numbers
+     were lower than the ones written down: unknown 4.33 and stopped 4.18, both
+     below AA, on 12px text. Darkened until they clear 4.5 on --bg-2 while
+     keeping the ordering that matters (stopped stays the quietest thing on the
+     page, and quieter than unknown). This is why the check measures a token
+     against the surfaces it is actually used on rather than against one
+     canonical background. */
   --st-up:      #10b981;  --st-up-fg:      #047857;  /* fg 5.39 · fill 2.50 */
   --st-warn:    #d97706;  --st-warn-fg:    #92400e;  /* fg 6.97 · fill 3.13 */
   --st-down:    #e11d48;  --st-down-fg:    #be123c;  /* fg 6.18 · fill 4.62 */
-  --st-unknown: #adbac7;  --st-unknown-fg: #64748b;  /* fg 4.68 · fill 1.94 */
-  --st-off:     #cbd5e1;  --st-off-fg:     #6b7688;  /* fg 4.52 · fill 1.46 */
+  --st-unknown: #adbac7;  --st-unknown-fg: #5f6a7d;  /* fg 4.97 on --bg-2 · fill 1.94 */
+  --st-off:     #cbd5e1;  --st-off-fg:     #666f7d;  /* fg 4.62 on --bg-2 · fill 1.46 */
 
   /* The accents' FIRST light remap. They were never redefined here, so the DARK
      values were rendering on #fafafa - and .svc-group-idx paints an accent as
@@ -1102,3 +1114,4 @@ a.card:hover { transform: translateY(-3px); border-color: var(--line-strong);
      leave an element at opacity:0 - that was the old .reveal failure mode. */
   *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
 }
+

--- a/apps/portal-next/web/src/lib/theme.tsx
+++ b/apps/portal-next/web/src/lib/theme.tsx
@@ -1,77 +1,141 @@
-// Theme: dark (default) / light / system. Persisted to localStorage and stamped
-// onto <html data-theme>.
+// Theme selection. Persisted to localStorage and stamped onto <html>.
 //
-// The choice ('dark' | 'light' | 'system') and the RESOLVED theme
-// ('dark' | 'light') are different things, and only the resolved one reaches
-// the DOM: 'system' is resolved here against matchMedia and stamped as a
-// concrete attribute. index.css therefore carries ONE light palette
-// (:root[data-theme='light']) instead of the two copies it used to maintain -
-// one for the pinned case and one inside @media (prefers-color-scheme: light).
-// Those two had already drifted apart (--ok-ink was in both, --unk in neither),
-// which is exactly the failure a single source of truth prevents.
+// The SELECTION ('system' or a theme id) and the RESOLVED theme are different
+// things, and only the resolved one reaches the DOM: 'system' is collapsed here
+// against matchMedia and stamped as concrete attributes. index.css therefore
+// carries ONE light palette (:root[data-theme='light']) instead of the two
+// copies it used to maintain - one for the pinned case and one inside
+// @media (prefers-color-scheme: light). Those two had already drifted apart
+// (--ok-ink was in both, --unk in neither), which is exactly the failure a
+// single source of truth prevents.
 //
-// index.html stamps the same attribute before first paint, so resolving in JS
-// costs no flash.
+// Two attributes are stamped, and lib/themes.ts explains why: `data-theme`
+// carries the APPEARANCE, so everything already keyed on it keeps working, and
+// `data-bothy-theme` carries the theme id, which is what the palette blocks in
+// src/themes/*.css select on.
+//
+// index.html stamps the same pair before first paint, so resolving in JS costs
+// no flash. That script is duplicated from here ON PURPOSE - an import would
+// defeat the point - and it is allowed by an exact CSP hash in nginx.conf, so
+// editing it means regenerating that hash. checks/csp_hash.mjs enforces both
+// halves.
 
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import {
+  DEFAULT_SELECTION, migrate, resolveSelection, THEMES,
+  type Appearance, type Selection, type ThemeDef,
+} from './themes';
 
-export type Theme = 'dark' | 'light' | 'system';
-export type Resolved = 'dark' | 'light';
+export type { Selection, Appearance, ThemeDef };
+/** Kept as a name because the rest of the app talks about 'dark' | 'light'. */
+export type Resolved = Appearance;
 
 const KEY = 'portal-theme';
+/** Read only by the pre-paint script in index.html. Never read back here - this
+ *  module computes the appearance from the registry, which is the source. */
+const APPEARANCE_KEY = 'portal-theme-appearance';
 const DARK_QUERY = '(prefers-color-scheme: dark)';
 
-const systemTheme = (): Resolved =>
-  typeof matchMedia !== 'undefined' && matchMedia(DARK_QUERY).matches ? 'dark' : 'light';
+const prefersDark = (): boolean =>
+  typeof matchMedia !== 'undefined' && matchMedia(DARK_QUERY).matches;
 
-export const resolve = (t: Theme): Resolved => (t === 'system' ? systemTheme() : t);
+export const resolve = (sel: Selection): ThemeDef => resolveSelection(sel, prefersDark());
 
-function apply(t: Theme) {
-  document.documentElement.setAttribute('data-theme', resolve(t));
+/** The browser/OS chrome around the page - Android's address bar, iOS's status
+ *  bar in standalone mode - is painted from <meta name="theme-color">.
+ *
+ *  It used to be two static tags keyed on prefers-color-scheme, which was
+ *  already wrong for anyone who had PINNED a theme against their OS, and is
+ *  hopeless once a theme can be any of several palettes. Reading the resolved
+ *  --bg back out of the document is the only version that cannot disagree with
+ *  what is on screen, because it IS what is on screen. */
+function paintChrome() {
+  const bg = getComputedStyle(document.documentElement).getPropertyValue('--bg').trim();
+  if (!bg) return;
+  let tag = document.querySelector('meta[name="theme-color"]');
+  if (!tag) {
+    tag = document.createElement('meta');
+    tag.setAttribute('name', 'theme-color');
+    document.head.appendChild(tag);
+  }
+  tag.setAttribute('content', bg);
+}
+
+function apply(sel: Selection) {
+  const t = resolve(sel);
+  const el = document.documentElement;
+  el.setAttribute('data-theme', t.appearance);
+  el.setAttribute('data-bothy-theme', t.id);
+  // Persist the RESOLVED appearance beside the selection, for the pre-paint
+  // script in index.html. That script has no registry - it cannot know whether
+  // 'gruvbox' is dark or light - and without this it would guess dark and flash
+  // the wrong frame at anyone using a light named theme. Writing it here means
+  // the answer is always the one the app itself computed.
+  try { localStorage.setItem(APPEARANCE_KEY, t.appearance); } catch { /* private mode */ }
+  paintChrome();
 }
 
 interface ThemeCtx {
-  theme: Theme;
+  /** What the user chose: 'system' or a theme id. */
+  selection: Selection;
   /** What is actually painted right now - 'system' already collapsed. */
+  theme: ThemeDef;
+  /** The appearance of the painted theme. */
   resolved: Resolved;
-  setTheme: (t: Theme) => void;
+  themes: readonly ThemeDef[];
+  setSelection: (s: Selection) => void;
+  /** Dark -> Light -> System, over the two built-ins. The header control is a
+   *  one-tap toggle for the common case; the full list lives in Settings, so
+   *  cycling through eight themes to get back to where you were is not a thing
+   *  this can do to you. */
   cycle: () => void;
 }
 const Ctx = createContext<ThemeCtx | null>(null);
 
-const read = (): Theme => {
-  const v = (typeof localStorage !== 'undefined' && localStorage.getItem(KEY)) as Theme | null;
-  return v === 'light' || v === 'dark' || v === 'system' ? v : 'dark';
+const read = (): Selection => {
+  try { return migrate(localStorage.getItem(KEY)); } catch { return DEFAULT_SELECTION; }
 };
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>(read);
-  const [resolved, setResolved] = useState<Resolved>(() => resolve(read()));
+  const [selection, setSel] = useState<Selection>(read);
+  const [theme, setTheme] = useState<ThemeDef>(() => resolve(read()));
 
   useEffect(() => {
-    apply(theme);
-    setResolved(resolve(theme));
-  }, [theme]);
+    apply(selection);
+    setTheme(resolve(selection));
+  }, [selection]);
 
   // Track a live OS flip. Without this, 'system' only ever sampled the OS at
   // mount, so switching the desktop to light left the portal dark until reload
   // - the one behaviour 'system' exists to provide.
   useEffect(() => {
-    if (theme !== 'system' || typeof matchMedia === 'undefined') return;
+    if (selection !== 'system' || typeof matchMedia === 'undefined') return;
     const mq = matchMedia(DARK_QUERY);
-    const onChange = () => { apply('system'); setResolved(systemTheme()); };
+    const onChange = () => { apply('system'); setTheme(resolve('system')); };
     mq.addEventListener('change', onChange);
     return () => mq.removeEventListener('change', onChange);
-  }, [theme]);
+  }, [selection]);
 
-  const setTheme = (t: Theme) => {
-    try { localStorage.setItem(KEY, t); } catch { /* private mode */ }
-    setThemeState(t);
+  const setSelection = (s: Selection) => {
+    try { localStorage.setItem(KEY, s); } catch { /* private mode */ }
+    setSel(s);
   };
-  const order: Theme[] = ['dark', 'light', 'system'];
-  const cycle = () => setTheme(order[(order.indexOf(theme) + 1) % order.length]);
 
-  return <Ctx.Provider value={{ theme, resolved, setTheme, cycle }}>{children}</Ctx.Provider>;
+  const order: Selection[] = ['bothy-dark', 'bothy-light', 'system'];
+  const cycle = () => {
+    const i = order.indexOf(selection);
+    // A named theme is not on the cycle, so the first tap from one lands on
+    // Light rather than nowhere.
+    setSelection(order[(i + 1) % order.length] ?? 'bothy-light');
+  };
+
+  return (
+    <Ctx.Provider value={{
+      selection, theme, resolved: theme.appearance, themes: THEMES, setSelection, cycle,
+    }}>
+      {children}
+    </Ctx.Provider>
+  );
 }
 
 export function useTheme(): ThemeCtx {

--- a/apps/portal-next/web/src/lib/themes.ts
+++ b/apps/portal-next/web/src/lib/themes.ts
@@ -1,0 +1,94 @@
+// The theme registry.
+//
+// A theme is a NAME, an APPEARANCE, and a block of CSS custom properties. This
+// file holds the first two; src/themes/*.css holds the third. Adding a theme is
+// adding a row here and a file there - deliberately not a switch statement
+// somewhere, because the set of themes is data and the moment it stops being
+// data is the moment adding one means touching four files.
+//
+// TWO ATTRIBUTES, NOT ONE, and the distinction is what keeps this change small:
+//
+//   data-theme="dark|light"        the APPEARANCE
+//   data-bothy-theme="tokyo-night" the THEME
+//
+// Everything that already keys on data-theme keeps working untouched - the
+// editor's syntax palette (pages/files/shell.css), the 3D scene's palette
+// observer (components/three/StackScene.tsx), and `color-scheme`, which is what
+// tells the browser to paint form controls and scrollbars dark. A named theme
+// layers over that base rather than replacing the mechanism.
+//
+// WHY THEMES WIN BY SPECIFICITY AND NOT BY SOURCE ORDER. `:root[data-theme=
+// 'light']` and `:root[data-bothy-theme='x']` both score 0,2,0, so which one
+// applies would come down to which is emitted last - and Vite hoists and
+// rewrites @import, so that is a build detail, not a decision. Theme blocks
+// therefore double the attribute:
+//
+//   :root[data-bothy-theme='tokyo-night'][data-bothy-theme]   -> 0,3,0
+//
+// which wins from anywhere in the bundle. shell.css already uses exactly this
+// trick (`.bothy-files.bothy-files`) for the same reason.
+
+export type Appearance = 'dark' | 'light';
+
+export interface ThemeDef {
+  /** Stamped as data-bothy-theme, and stored. Stable forever once shipped. */
+  id: string;
+  name: string;
+  appearance: Appearance;
+  /** One line for the picker. Where the palette came from, or what it is for. */
+  note: string;
+  /** The two palettes that live in index.css itself and need no theme file.
+   *  They are the base every other theme is layered over. */
+  builtin?: boolean;
+}
+
+export const THEMES: readonly ThemeDef[] = [
+  {
+    id: 'bothy-dark',
+    name: 'Bothy Dark',
+    appearance: 'dark',
+    note: 'The default. Neutral zinc, control-room contrast.',
+    builtin: true,
+  },
+  {
+    id: 'bothy-light',
+    name: 'Bothy Light',
+    appearance: 'light',
+    note: 'The same palette re-measured for a white page.',
+    builtin: true,
+  },
+  {
+    id: 'tokyo-night',
+    name: 'Tokyo Night',
+    appearance: 'dark',
+    note: 'After the editor theme by enkia. Cooler and bluer than Bothy Dark.',
+  },
+];
+
+/** `'system'` is a SELECTION, never a theme: it means "follow the OS", and it
+ *  resolves to one of the two built-ins. Keeping it out of THEMES is what stops
+ *  it being offered as something a stylesheet could target. */
+export type Selection = 'system' | (string & {});
+
+export const DEFAULT_SELECTION: Selection = 'bothy-dark';
+
+export const byId = (id: string): ThemeDef | undefined => THEMES.find((t) => t.id === id);
+
+/** Older builds stored 'dark' | 'light' | 'system' under the same key. Mapping
+ *  rather than discarding matters: a stored 'light' is a user who chose light,
+ *  and dropping it on upgrade would silently flip them back to dark. */
+export function migrate(stored: string | null): Selection {
+  if (!stored) return DEFAULT_SELECTION;
+  if (stored === 'system') return 'system';
+  if (stored === 'dark') return 'bothy-dark';
+  if (stored === 'light') return 'bothy-light';
+  return byId(stored) ? stored : DEFAULT_SELECTION;
+}
+
+/** What a selection actually paints, with `system` collapsed against the OS.
+ *  `prefersDark` is passed in rather than read here so this module stays free of
+ *  browser globals and can be compiled and tested on its own. */
+export function resolveSelection(sel: Selection, prefersDark: boolean): ThemeDef {
+  if (sel === 'system') return byId(prefersDark ? 'bothy-dark' : 'bothy-light')!;
+  return byId(sel) ?? byId(DEFAULT_SELECTION)!;
+}

--- a/apps/portal-next/web/src/main.tsx
+++ b/apps/portal-next/web/src/main.tsx
@@ -6,6 +6,18 @@ import { DataProvider } from './lib/data';
 import { ThemeProvider } from './lib/theme';
 import './index.css';
 
+// Every palette in src/themes, pulled in by glob rather than by a list of
+// imports, so that adding a theme is adding ONE file - the same promise
+// lib/themes.ts makes and checks/theme-contract.mjs enforces. An import list
+// here would be a third place to remember, and the failure would be a theme
+// that appears in the picker and changes nothing when chosen.
+//
+// Order does not matter: every theme block doubles its attribute selector to
+// score 0,3,0, which beats the base palettes from anywhere in the bundle. That
+// is deliberate, because Vite hoists and rewrites @import and betting on
+// emission order would be betting on a build detail.
+import.meta.glob('./themes/*.css', { eager: true });
+
 // HashRouter (not BrowserRouter): the app is served as static files by nginx
 // with no client-routing rewrite, so deep links must live after the '#'.
 createRoot(document.getElementById('root')!).render(

--- a/apps/portal-next/web/src/pages/Settings.css
+++ b/apps/portal-next/web/src/pages/Settings.css
@@ -81,3 +81,93 @@
   .settings-page .kv-list { grid-template-columns: 1fr; }
   .settings-page .kv { gap: 2px; }
 }
+
+/* ── the theme picker ────────────────────────────────────────────────────────
+   A grid of cards rather than a <select>: the choice is visual, and a dropdown
+   would hide every option behind a click and show none of their colours. */
+.settings-page .theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(224px, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.settings-page .theme-card {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  align-items: flex-start;
+  text-align: left;
+  padding: 11px 13px 12px;
+  border: var(--border-w) solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: border-color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease);
+}
+.settings-page .theme-card:hover { border-color: var(--line-strong); background: var(--surface-3); }
+.settings-page .theme-card.is-on {
+  border-color: var(--accent-line);
+  background: var(--accent-bg);
+}
+
+.settings-page .theme-name { font-size: 13px; font-weight: 650; color: var(--fg); }
+.settings-page .theme-note {
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--fg-muted);
+  /* The note is what distinguishes two themes with similar swatches, so it is
+     never truncated to one line - the row heights vary and that is correct. */
+}
+
+/* The swatch row carries the theme's OWN tokens (the element sets
+   data-bothy-theme), so these rules must not paint any colour themselves. */
+.settings-page .theme-swatch { display: flex; gap: 4px; margin-top: 3px; }
+.settings-page .theme-swatch i {
+  width: 18px;
+  height: 8px;
+  border-radius: var(--r-xs);
+  /* An outline rather than a border, so the swatch keeps its measured size and
+     a near-background colour (a light theme's surface, a stopped grey) still
+     reads as a chip rather than dissolving into the card. */
+  outline: 1px solid var(--line);
+  outline-offset: -1px;
+}
+
+/* ── swatch palettes for the theme picker ───────────────────────────────────
+   The two built-in palettes above live on :root, because that is where a theme
+   is applied. The picker in Settings needs them on a SUBTREE as well, so a card
+   can paint its own five swatches in the theme it is advertising rather than in
+   whatever theme happens to be active.
+
+   A theme FILE solves this by declaring both selectors (see src/themes/*.css).
+   The built-ins cannot: their palettes are the :root blocks at the top of this
+   file, and repeating 41 tokens twice to make them subtree-applicable would be
+   the duplication the token model exists to prevent.
+
+   So this repeats FIVE values, and checks/theme-contract.mjs asserts each one
+   still equals the token it previews. Five guarded copies beat eighty-two
+   unguarded ones, and the guard is what makes it a cache rather than a fork.
+
+   SCOPED TO .theme-swatch, and that is not tidiness. Unscoped, these matched
+   the ROOT element - which carries data-bothy-theme too - so --sw-1..5 were
+   inherited by the whole document and shadowed the `var(--sw-1, var(--accent))`
+   fallback everywhere, including inside the cards for OTHER themes. Every
+   swatch on the page painted the active theme's colours while looking
+   entirely correct. */
+.theme-swatch[data-bothy-theme='bothy-dark'] {
+  --sw-1: #60a5fa;  /* --accent  */
+  --sw-2: #34d399;  /* --st-up   */
+  --sw-3: #fbbf24;  /* --st-warn */
+  --sw-4: #fb7185;  /* --st-down */
+  --sw-5: #e169fc;  /* --a5      */
+}
+.theme-swatch[data-bothy-theme='bothy-light'] {
+  --sw-1: #2563eb;  /* --accent  */
+  --sw-2: #10b981;  /* --st-up   */
+  --sw-3: #d97706;  /* --st-warn */
+  --sw-4: #e11d48;  /* --st-down */
+  --sw-5: #b921d6;  /* --a5      */
+}

--- a/apps/portal-next/web/src/pages/Settings.tsx
+++ b/apps/portal-next/web/src/pages/Settings.tsx
@@ -23,6 +23,7 @@
 import { Ban, Circle, CircleCheck, LogIn } from 'lucide-react';
 import { ROLES, ROLE_MEANING, signInHref, type Me, type Role } from '../lib/me';
 import { useMe } from '../components/UserMenu';
+import { useTheme } from '../lib/theme';
 import { Skeleton } from '../components/states';
 import './Settings.css';
 
@@ -40,6 +41,18 @@ export function Settings() {
 
       {loading ? <Skeleton variant="panels" /> : me ? <You me={me} /> : <SignedOut />}
 
+      {/* Appearance is the ONE control on this page, and it is here because the
+          topbar button stopped being able to express the choice. A cycle button
+          works for two states; with a registry of themes behind it, cycling to
+          get back to where you started is the whole interaction. The button
+          stays as the quick dark/light/system toggle, and the list lives here.
+
+          It is not a contradiction of the read-only rule. That rule is about a
+          SERVER-side preference store - a write path, an audit trail, a
+          boundary. This writes one key to localStorage in this browser, which is
+          the same thing the topbar button has always done. */}
+      <Appearance />
+
       {/* Both of these are statements about the box, not about the visitor, so
           they render whether or not there is a session to describe. Someone
           signed out is the reader most likely to want to know where the sign-in
@@ -47,6 +60,71 @@ export function Settings() {
       <Session />
       <Storage />
     </div>
+  );
+}
+
+function Appearance() {
+  const { selection, theme, themes, setSelection } = useTheme();
+
+  // System first, then the themes. It is the only entry that is not a palette -
+  // it is a rule for picking one - so it gets said in words rather than given a
+  // swatch row that would imply it had colours of its own.
+  return (
+    <section className="panel">
+      <h2 className="panel-h">Appearance</h2>
+      <div className="panel-b">
+        <p className="set-lede">
+          Kept in this browser. The topbar button still toggles dark, light and system;
+          this is where the rest of them live.
+        </p>
+
+        <div className="theme-grid" role="radiogroup" aria-label="Theme">
+          <button
+            type="button"
+            role="radio"
+            aria-checked={selection === 'system'}
+            className={`theme-card ${selection === 'system' ? 'is-on' : ''}`}
+            onClick={() => setSelection('system')}
+          >
+            <span className="theme-name">System</span>
+            <span className="theme-note">
+              Follow the desktop. Currently {theme.name.replace(/^Bothy /, '').toLowerCase()}.
+            </span>
+          </button>
+
+          {themes.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              role="radio"
+              aria-checked={selection === t.id}
+              className={`theme-card ${selection === t.id ? 'is-on' : ''}`}
+              onClick={() => setSelection(t.id)}
+            >
+              <span className="theme-name">{t.name}</span>
+              <span className="theme-note">{t.note}</span>
+              {/* The swatches are painted BY the theme they advertise, so a card
+                  cannot show colours the theme does not actually have.
+
+                  `--sw-N` with the real token as the FALLBACK, which resolves
+                  both cases in one expression: a theme file applies its whole
+                  palette to this subtree, so var(--accent) is already right and
+                  --sw-1 is undefined; the two built-ins live on :root only, so
+                  they supply --sw-1..5 instead (index.css, guarded by the
+                  contract check). Neither case needs the component to know
+                  which kind of theme it is rendering. */}
+              <span className="theme-swatch" data-bothy-theme={t.id} aria-hidden="true">
+                <i style={{ background: 'var(--sw-1, var(--accent))' }} />
+                <i style={{ background: 'var(--sw-2, var(--st-up))' }} />
+                <i style={{ background: 'var(--sw-3, var(--st-warn))' }} />
+                <i style={{ background: 'var(--sw-4, var(--st-down))' }} />
+                <i style={{ background: 'var(--sw-5, var(--a5))' }} />
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/apps/portal-next/web/src/themes/tokyo-night.css
+++ b/apps/portal-next/web/src/themes/tokyo-night.css
@@ -1,0 +1,150 @@
+/* ============================================================================
+   Tokyo Night - after the editor theme by enkia.
+
+   THE REFERENCE IMPLEMENTATION OF THE THEME FORMAT. Read this before writing
+   another one; everything the format requires is visible here, in order.
+
+   A theme declares all 41 of its own tokens and nothing else:
+
+     · NOT the 16 DERIVED tokens (--accent-bg, --st-*-bg, --st-*-line, --ring,
+       --track, the scrollbar thumbs). Those are color-mix() over the tokens
+       below, defined once in index.css and evaluated on the SAME element, so
+       they re-compute against whatever this file sets. Redeclaring one here
+       would be a copy that stops following its source.
+     · NOT the 16 STRUCTURAL tokens (radii, motion, fonts, widths). Those are
+       the product's shape, not its palette, and a theme that changed them would
+       be a different application wearing the same name.
+
+   The doubled attribute selector is not a typo. `:root[data-bothy-theme='x']`
+   ties with `:root[data-theme='light']` at 0,2,0, so which wins would depend on
+   emission order, and Vite hoists @import. Doubling takes it to 0,3,0 and makes
+   it deterministic from anywhere in the bundle. shell.css uses the same trick.
+
+   Every value below is checked by checks/theme-contract.mjs: text at >= 4.5:1 on
+   every ground it is painted on, the five accents legal against every status
+   (>= 45 degrees of hue from a chromatic one, >= 0.06 more chroma than a
+   near-grey one), the chart slots inside the dark lightness band and >= 3:1 on a
+   card. Run it before committing a palette; it is faster than looking.
+
+   WHERE THIS DEPARTS FROM UPSTREAM, and why. Tokyo Night's own palette is an
+   editor palette - it has no notion of a reserved status set, so several of its
+   signature colours sit exactly where this design system forbids chrome to be:
+
+     · Its green #9ece6a and red #f7768e are the status hues here. They are used
+       ONLY as --st-up and --st-down, never as an accent or a chart slot.
+     · Its cyan #7dcfff sits at H 224, which is --a1's slot, so the accents run
+       from it through the blues and violets to magenta - inside the single legal
+       120-degree window (208-328) that the status set leaves free.
+     · Its yellow #e0af68 is --st-warn and nothing else.
+
+   The rule bends the palette; the palette never bends the rule. That is the
+   whole reason the contract is a check and not a paragraph.
+   ========================================================================== */
+
+/* TWO SELECTORS, and both are load-bearing.
+
+   The `:root` one scores 0,3,0 and is what beats the base palettes on the
+   document element. The bare one scores 0,2,0 and exists so the palette can also
+   be applied to a SUBTREE - which the theme picker in Settings relies on to
+   paint each card's swatches in the theme it is advertising. Without it a
+   preview would have to hardcode five colours per theme, and a hardcoded
+   preview is the first thing to disagree with the palette it claims to show. */
+:root[data-bothy-theme='tokyo-night'][data-bothy-theme],
+[data-bothy-theme='tokyo-night'][data-bothy-theme] {
+  color-scheme: dark;
+
+  /* ── elevation ladder ──────────────────────────────────────────────────────
+     Tokyo Night's own backgrounds are #1a1b26 (normal) and #16161e (storm's
+     darker inset). Extended to four steps the way index.css does, because two
+     steps is what forces one-off mixes wherever a third is needed. */
+  --bg:        #1a1b26;
+  --bg-2:      #16161e;
+  --surface-1: #1f2233;
+  --surface-2: #24283b;
+  --surface-3: #2f334d;
+  --surface-4: #373b54;
+  /* The page wash. Kept far dimmer than a card so the elevation ladder still
+     reads as a ladder - a tinted, position-dependent backdrop is the one thing
+     index.css records as forbidden here. */
+  --bg-glow:   radial-gradient(60% 50% at 50% 0%, #2a2f4a 0%, transparent 70%);
+
+  /* ── foreground pairs ────────────────────────────────────────────────────── */
+  --fg:        #c0caf5;   /* 11.62 on surface-1 */
+  --fg-muted:  #a9b1d6;   /*  8.94 */
+  /* Upstream's comment grey (#565f89) measures 2.05 here - far below AA at the
+     11-12px sizes this token is used at. Lifted, exactly as index.css lifts
+     zinc-500 for the same reason. The original survives as --hl-com, where it
+     is a comment and is meant to recede. */
+  --fg-subtle: #8b93b8;   /*  5.34 */
+  --on-accent: #16161e;   /* text on a filled --accent */
+
+  --line:        rgb(192 202 245 / 11%);
+  --line-strong: rgb(192 202 245 / 19%);
+
+  /* ── accent (chrome only - never encodes state) ────────────────────────── */
+  --accent:      #7aa2f7;
+  --accent-2:    #5d80e6;
+  --accent-fg:   #9eb8ff;
+
+  /* ── chart series (chrome, never state) ──────────────────────────────────
+     Slot ORDER is part of what the contract validates - series are assigned
+     1,2,3... in order and never reordered or cycled - so these are listed in the
+     order they will be used, not in the order they look nicest as a row.
+
+     Every one of these is DARKER than the Tokyo Night colour it is named after.
+     Upstream's chart-ish hues sit at L 0.72-0.79 - they are editor foregrounds,
+     meant to sit on a dark editor background at full brightness - and the dark
+     band here has a 0.67 ceiling, because a series line that bright glares
+     against a card. Measured: the literal upstream set failed all five slots. */
+  --chart-1: #5b8ae6;   /* blue    L .643 */
+  --chart-2: #1f9fb8;   /* cyan    L .649 */
+  --chart-3: #c96a2a;   /* orange  L .624 */
+  --chart-4: #8f6ae0;   /* violet  L .616 */
+  --chart-5: #d94f6a;   /* rose    L .620 */
+
+  /* ── status (RESERVED - never used as chrome) ───────────────────────────── */
+  --st-up:      #9ece6a;  --st-up-fg:      #9ece6a;
+  --st-warn:    #e0af68;  --st-warn-fg:    #e0af68;
+  --st-down:    #f7768e;  --st-down-fg:    #f7768e;
+  --st-unknown: #545c7e;  --st-unknown-fg: #949dc6;  /* fg 5.48 on surface-2 */
+  --st-off:     #3b4261;  --st-off-fg:     #8890b5;  /* fg 4.65 - quieter than unknown */
+
+  /* ── panel accents (chrome only - never encode state) ─────────────────────
+     Five slots across the one legal window the status hues leave open
+     (208-328), spaced so no spine is louder than another. */
+  --a1: #2ac3de;  /* H 208 */
+  --a2: #7aa2f7;  /* H 248 */
+  --a3: #9d86f9;  /* H 276 */
+  --a4: #bb9af7;  /* H 296 */
+  --a5: #cf8ae0;  /* H 320 - 51 from --st-down; #e57ce0 was 41, inside the floor */
+
+  /* ── shadows ──────────────────────────────────────────────────────────────
+     Theme-specific recipes, never a hardcoded black: the drop is tuned to the
+     page it falls on, and the inset hairline is what stops a raised surface
+     reading as a flat rectangle. */
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 42%), inset 0 1px 0 rgb(192 202 245 / 4%);
+  --shadow-md: 0 4px 14px rgb(0 0 0 / 46%), inset 0 1px 0 rgb(192 202 245 / 5%);
+  --shadow-lg: 0 18px 44px rgb(0 0 0 / 54%), inset 0 1px 0 rgb(192 202 245 / 6%);
+
+  /* ── scroll affordance ──────────────────────────────────────────────────── */
+  --scroll-shade: rgb(22 22 30 / 82%);
+  --hover-opacity: .9;
+}
+
+/* The five syntax tokens, on the same doubled-specificity idiom shell.css uses.
+   OPTIONAL for a theme - omitting them falls back to a set already checked for
+   this appearance - but a theme that restyles everything except the code in the
+   editor is a theme with a hole in it. These are close to upstream, which is
+   already built to keep keywords and strings out of the status hues. */
+:root[data-bothy-theme='tokyo-night'] .bothy-files.bothy-files {
+  /* Upstream's comment grey is #565f89, which measures 2.91 on this theme's
+     --bg-2. A comment is meant to recede, but it is still text you are expected
+     to be able to read, and 2.91 is not readable - it is decoration. Pointed at
+     --fg-subtle, which is the same decision index.css makes for its own
+     --hl-com, and which this theme has already lifted for exactly this reason. */
+  --hl-com: var(--fg-subtle);
+  --hl-kw:  #bb9af7;
+  --hl-str: #9ece6a;
+  --hl-num: #ff9e64;
+  --hl-key: #7dcfff;
+}

--- a/apps/portal-next/web/tsconfig.json
+++ b/apps/portal-next/web/tsconfig.json
@@ -4,8 +4,18 @@
   // "typecheck clean" claim made against that command was hollow; only
   // `npm run build` (which runs `tsc -b`) was ever catching anything.
   //
-  // The references stay, because `tsc -b` and the build depend on them. What
-  // changes is that `npx tsc --noEmit` now reports the truth instead of silence.
+  // The references stay, because `tsc -b` and the build depend on them.
+  //
+  // WHAT WAS ACTUALLY FIXED, corrected 2026-08-17: not the bare command. This
+  // note used to end "...what changes is that `npx tsc --noEmit` now reports the
+  // truth instead of silence", and that was never true - `"files": []` still
+  // makes it check nothing and exit 0, verified again by planting an error and
+  // watching it pass. What the fix added was the `typecheck` script and CI's
+  // `npx tsc -b --noEmit`, both of which do check.
+  //
+  // So: the working commands are `npm run typecheck` and `npm run build`.
+  // `npx tsc --noEmit` is still a lie, and a comment claiming it had been fixed
+  // is worse than no comment - it is what made a second person trust it.
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },


### PR DESCRIPTION
Phase 1 of the theme work: the engine, the picker, and — the part that matters — a check that decides whether a palette is allowed to ship.

## The contract

`index.css` already recorded its measurements, lightness bands, orderings and the two historical bugs behind its rules. That was prose, which holds as long as the next person reads it. `checks/theme-contract.mjs` makes it executable, so porting a theme is mechanical: write the tokens, run it, fix what it names.

Of the 73 custom properties in `:root`: **16 derived** (`color-mix` over another token, on the same element, so they re-evaluate for free), **16 structural** (radii, motion, fonts — the product's shape, not its palette), **41 a theme's own**. A theme must declare all 41; a missing one silently inherits the base, which is how you get a Gruvbox page with one blue button on it.

It checks accent legality in OKLCH (≥45° of hue from a chromatic status, ≥0.06 more chroma than a near-grey one), text at ≥4.5:1 on every ground it is painted on, accents at ≥4.6:1 on `--surface-2` (they are painted as 12px bold text), the chart slots inside the mode's lightness band and ≥3:1 on a card, and the light-mode status weight ordering. Three light fills sit below 3:1 **by design** and are recorded as a per-token allowance *with its reason*, so a future theme cannot quietly widen it.

## It was pointed at the shipped palette first

On the principle that a rule which fails on Bothy's own colours is a wrong rule. **It found one.** `--st-unknown-fg` and `--st-off-fg` were measured on a card, but they are painted mostly on `--bg-2` — the file explorer's `.fx-ro`, the reader's `.rd-root-ro` — which is darker. The real ratios were **4.33 and 4.18**, not the 4.68 and 4.52 written down: below AA, on 12px text. Both darkened until they clear on every ground they actually appear on. That is why the check measures against all of them rather than one canonical background.

## Tokyo Night, as the reference implementation

Shipped in Phase 1 rather than Phase 2 on purpose — a format with no real consumer is a format that has not been tested. Writing it proved the check earns its keep:

| | |
|---|---|
| all five chart slots | upstream sits at L 0.72–0.79; the dark band ends at **0.67**. Darkened. |
| the magenta accent | **41°** from `--st-down`, against a floor of 45. Moved. |
| the comment grey | **2.91:1**. Pointed at `--fg-subtle`, as index.css does for its own. |

The rule bends the palette; the palette never bends the rule.

## Mechanism

`data-theme` keeps carrying the **appearance**, so everything already keyed on it — the editor's syntax palette, the 3D scene's observer, `color-scheme` — is untouched. `data-bothy-theme` carries the id. Theme blocks **double their attribute selector** to score 0,3,0: a single one ties with `:root[data-theme='light']` at 0,2,0, and the winner would then depend on emission order, which Vite decides.

The pre-paint script in `index.html` deliberately carries **no list of themes** — it reads the resolved appearance back from localStorage — so adding a theme never forces the CSP hash to move again. This PR does move it once, since the script changed.

## Three bugs found on the way

- **The picker's swatches** paint in the theme they advertise. Scoped to `.theme-swatch`, because unscoped they matched the **root** (which carries `data-bothy-theme` too), leaked `--sw-1..5` into the whole document, and made every card show the *active* theme while looking entirely correct.
- **The block parser** began as a flat regex and was wrong: `index.css` has eleven `@media` blocks and nested braces put it out of step, so it found one `:root` block where there are two. It happened not to change the required set — which is exactly why it would have gone unnoticed.
- **`tsconfig.json` claimed `npx tsc --noEmit` had been fixed** to report the truth. It had not; `"files": []` still makes it check nothing and exit 0, verified by planting an error. What was actually added was the `typecheck` script and CI's `tsc -b`. Corrected, because a comment claiming a check works is worse than no comment — it is what makes the next person trust it.

## Verified

- `checks/run.sh` green end to end, exit 0. Contract check: **131 pass, 0 fail**.
- Proved it **fails**: replanting the exact historical bug (`--a4` = `--st-up`) gives `hue gap 0° < 45°` and exit 1.
- Live, on a fresh load: selecting Tokyo Night stamps both attributes, repaints `--bg` to `#1a1b26`, drives the browser chrome via `theme-color`, persists across reload through the pre-paint path, and themes the status glyphs (`#949dc6`). All three swatch rows read back distinct and correct.

## Not here

The remaining three ports (Catppuccin Mocha + Latte, Gruvbox, Nord) are Phase 2. `site.webmanifest` keeps the Bothy dark values — it is static JSON used for the install splash, and cannot follow a runtime theme.
