### PR TITLE
feat(theme): reach every theme from the topbar, and four more to reach

### DIFF
--- a/apps/portal-next/checks/theme-contract.mjs
+++ b/apps/portal-next/checks/theme-contract.mjs
@@ -350,9 +350,12 @@ console.log('\n── picker swatches match the palettes they preview ───�
 {
   const PREVIEWS = [['--sw-1', '--accent'], ['--sw-2', '--st-up'], ['--sw-3', '--st-warn'],
     ['--sw-4', '--st-down'], ['--sw-5', '--a5']];
-  // They live in Settings.css, scoped to .theme-swatch, because unscoped they
-  // matched the root element and leaked --sw-1..5 into the whole document.
-  const settings = blocks(readFileSync(join(SRC, 'pages', 'Settings.css'), 'utf8'));
+  // They live in themes/picker.css, scoped to .theme-swatch: scoped, because
+  // unscoped they matched the root element and leaked --sw-1..5 into the whole
+  // document; in themes/, because a file that defines colour values is a
+  // palette definition site and stray-colour.mjs is right to refuse them
+  // anywhere else.
+  const settings = blocks(readFileSync(join(SRC, 'themes', 'picker.css'), 'utf8'));
   for (const [id, toks] of [['bothy-dark', BASE], ['bothy-light', merge(BASE, LIGHT)]]) {
     const want = `.theme-swatch[data-bothy-theme='${id}']`;
     const sw = merge(...settings

--- a/apps/portal-next/web/src/components/AppShell.tsx
+++ b/apps/portal-next/web/src/components/AppShell.tsx
@@ -3,13 +3,13 @@ import { NavLink, Outlet, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import {
   LayoutDashboard, Gauge, FolderTree,
-  Search, RefreshCw, Moon, Sun, Monitor,
+  Search, RefreshCw,
 } from 'lucide-react';
 import { usePortal } from '../lib/data';
-import { useTheme } from '../lib/theme';
 import { freshnessOf } from '../lib/freshness';
 import { useScrollProgress, useScrollRestoration, useScrollShades } from '../lib/scroll';
 import { Tooltip } from './Tooltip';
+import { ThemeMenu } from './ThemeMenu';
 import { Brand } from './Brand';
 import { CommandPalette } from './CommandPalette';
 import { UserMenu } from './UserMenu';
@@ -26,23 +26,6 @@ const NAV = [
   { to: '/control', label: 'Control', Icon: Gauge, end: false },
   { to: '/files', label: 'Files', Icon: FolderTree, end: false },
 ];
-
-// The topbar control stays a one-tap toggle over the two built-ins and System,
-// not a menu of every theme. Cycling through the whole list to get back to where
-// you started is the failure mode of putting a registry behind a single button;
-// the full picker lives in Settings, where choosing is the point.
-function ThemeToggle() {
-  const { selection, theme, cycle } = useTheme();
-  const Icon = selection === 'system' ? Monitor : theme.appearance === 'light' ? Sun : Moon;
-  const label = selection === 'system' ? `System, currently ${theme.name}` : theme.name;
-  return (
-    <Tooltip label={`Theme: ${label} - click to change`} align="end">
-      <button className="icon-btn" onClick={cycle} aria-label={`Theme: ${label}. Click to change.`}>
-        <Icon size={18} />
-      </button>
-    </Tooltip>
-  );
-}
 
 export function AppShell() {
   const { data, refresh } = usePortal();
@@ -197,7 +180,7 @@ export function AppShell() {
             <RefreshCw size={18} className={spin ? 'spin' : undefined} />
           </button>
         </Tooltip>
-        <ThemeToggle />
+        <ThemeMenu />
         {/* Last in the right cluster, and the only entry point to /settings -
             which is why it is not a nav slot. */}
         <UserMenu />

--- a/apps/portal-next/web/src/components/ThemeMenu.css
+++ b/apps/portal-next/web/src/components/ThemeMenu.css
@@ -1,0 +1,69 @@
+/* The topbar theme menu. Deliberately the same shape as .um-panel next door -
+   same surface, same radius, same shadow, same row treatment - because two
+   popovers hanging off the same topbar that disagree about their own geometry
+   read as two different applications. Copied rather than shared: it is a dozen
+   declarations, and a common module for them would tie the account menu's
+   layout to this one's. */
+
+.theme-menu { position: relative; display: inline-flex; }
+
+/* The hover bridge. The panel sits 8px below the button, and a pointer crossing
+   that gap leaves both elements - which starts the close timer even though the
+   user is heading straight for the menu. This pads the hoverable area downward
+   without moving anything, so the crossing never registers as a leave. It is
+   why the timer can be short. */
+.theme-menu::after {
+  content: '';
+  position: absolute;
+  inset: 100% 0 auto 0;
+  height: 10px;
+}
+
+.theme-menu .tm-panel {
+  position: absolute; z-index: 60; top: calc(100% + 8px); right: 0;
+  /* Wide enough that no theme name wraps. At 236px "Catppuccin Mocha"
+     broke onto two lines once the swatch took its share of the row, and a
+     list where some rows are one line and some are two reads as a rendering
+     fault rather than as a list. */
+  min-width: 288px; padding: 6px; display: flex; flex-direction: column; gap: 2px;
+  background: var(--surface-4); border: 1px solid var(--line-strong);
+  border-radius: var(--r-lg); box-shadow: var(--shadow-lg);
+}
+
+.theme-menu .tm-row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 9px; border: 0; background: none; width: 100%;
+  border-radius: var(--r-sm); font: inherit; font-size: 13px;
+  color: var(--fg-muted); cursor: pointer; text-align: left;
+}
+.theme-menu .tm-row:hover { background: var(--surface-3); color: var(--fg); }
+/* The rows are inside a menu that traps Tab, so focus is the ONLY way most of
+   this panel is reached by keyboard. Same weight as hover, plus the ring. */
+.theme-menu .tm-row:focus-visible {
+  background: var(--surface-3); color: var(--fg);
+  outline: 2px solid var(--ring); outline-offset: -2px;
+}
+.theme-menu .tm-row.is-on { color: var(--fg); }
+
+/* A fixed-width gutter for the tick, so the names line up whether or not a row
+   is the selected one. Without it the list re-indents as you change theme. */
+.theme-menu .tm-mark {
+  flex: none; width: 13px; height: 13px;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--accent-fg);
+}
+
+.theme-menu .tm-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1; }
+.theme-menu .tm-name { font-weight: 600; white-space: nowrap; }
+.theme-menu .tm-sub { font-size: 11px; color: var(--fg-subtle); }
+
+.theme-menu .tm-sep { height: 1px; margin: 4px 2px; background: var(--line); }
+
+.theme-menu .tm-foot {
+  margin: 0; padding: 2px 9px 4px;
+  font-size: 11px; color: var(--fg-subtle);
+}
+
+/* The swatch keeps its own margin-top from themes/picker.css, which is right in
+   a stacked card and wrong on a single row. */
+.theme-menu .theme-swatch { margin-top: 0; flex: none; }

--- a/apps/portal-next/web/src/components/ThemeMenu.tsx
+++ b/apps/portal-next/web/src/components/ThemeMenu.tsx
@@ -1,0 +1,193 @@
+// The topbar theme control.
+//
+// It was a CYCLE button, and that was the bug: it rotated dark -> light ->
+// system, so every named theme was unreachable from the topbar and the only way
+// to choose one was to know that Settings had a picker. A control that can only
+// reach three of six options is worse than no control, because it looks like the
+// whole answer.
+//
+// So it is a menu. Cycling was never wrong because cycling is bad - it is right
+// for two states - it stopped being able to express the choice the moment the
+// set of themes became data.
+//
+// OPENS ON HOVER, and also on click and on keyboard, because hover alone is not
+// an interaction on a touchscreen and not one for anybody navigating by keys.
+// Hover is an accelerator over a control that works without it, never the only
+// way in.
+
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { Check, Monitor, Moon, Sun } from 'lucide-react';
+import { useTheme } from '../lib/theme';
+import { ThemeSwatch } from './ThemeSwatch';
+import './ThemeMenu.css';
+
+/** Pointer-out grace. Moving from the button to the panel crosses a few pixels
+ *  of topbar, and closing on that gap is the classic hover-menu failure - the
+ *  menu vanishes exactly as you reach for it. Long enough to cross, short enough
+ *  that a menu you have left does not linger. */
+const CLOSE_MS = 220;
+/** Open delay. Without one, sweeping the pointer across the topbar on the way to
+ *  the account button flashes this open behind it. */
+const OPEN_MS = 90;
+
+export function ThemeMenu() {
+  const { selection, theme, themes, setSelection } = useTheme();
+  const [open, setOpen] = useState(false);
+  const [at, setAt] = useState(0);
+  const btn = useRef<HTMLButtonElement | null>(null);
+  const list = useRef<HTMLDivElement | null>(null);
+  const wrap = useRef<HTMLDivElement | null>(null);
+  const timer = useRef<number | null>(null);
+  const id = useId();
+
+  const clearTimer = () => {
+    if (timer.current !== null) { clearTimeout(timer.current); timer.current = null; }
+  };
+  // Every unmount path goes through this, or a pending open fires into a
+  // component that is gone.
+  useEffect(() => clearTimer, []);
+
+  const close = useCallback((toButton: boolean) => {
+    clearTimer();
+    setOpen(false);
+    if (toButton) btn.current?.focus();
+  }, []);
+
+  // A pointer press outside. `pointerdown` rather than `click`, so the menu is
+  // gone before whatever sits under it reacts. Same as UserMenu.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      if (wrap.current?.contains(e.target as Node)) return;
+      setOpen(false);
+    };
+    document.addEventListener('pointerdown', onDown, true);
+    return () => document.removeEventListener('pointerdown', onDown, true);
+  }, [open]);
+
+  const rows = () => Array.from(
+    list.current?.querySelectorAll<HTMLElement>('[role="menuitemradio"]') ?? [],
+  );
+  const move = (to: number) => {
+    const r = rows();
+    if (!r.length) return;
+    const i = ((to % r.length) + r.length) % r.length;
+    setAt(i);
+    r[i]?.focus();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'Escape': e.preventDefault(); close(true); break;
+      case 'ArrowDown': e.preventDefault(); move(at + 1); break;
+      case 'ArrowUp': e.preventDefault(); move(at - 1); break;
+      case 'Home': e.preventDefault(); move(0); break;
+      case 'End': e.preventDefault(); move(rows().length - 1); break;
+      // Tab out of an open menu leaves the panel on screen with the focus behind
+      // it, so Tab moves within, like the arrows.
+      case 'Tab': e.preventDefault(); move(at + (e.shiftKey ? -1 : 1)); break;
+      default: break;
+    }
+  };
+
+  // Hover opens WITHOUT moving focus. Focusing the first row on a hover-open
+  // would yank the caret away from whatever the user was doing, and a menu that
+  // steals focus because the pointer passed over it is a menu that fights you.
+  // Keyboard and click opens do focus - see the effect below.
+  const [byPointer, setByPointer] = useState(false);
+  const onEnter = () => {
+    clearTimer();
+    if (open) return;
+    timer.current = window.setTimeout(() => { setByPointer(true); setOpen(true); }, OPEN_MS);
+  };
+  const onLeave = () => {
+    clearTimer();
+    timer.current = window.setTimeout(() => setOpen(false), CLOSE_MS);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    setAt(0);
+    if (!byPointer) list.current?.querySelector<HTMLElement>('[role="menuitemradio"]')?.focus();
+  }, [open, byPointer]);
+
+  const choose = (next: string) => {
+    setSelection(next);
+    close(true);
+  };
+
+  const Icon = selection === 'system' ? Monitor : theme.appearance === 'light' ? Sun : Moon;
+  const current = selection === 'system' ? `System, currently ${theme.name}` : theme.name;
+
+  return (
+    <div className="theme-menu" ref={wrap} onPointerEnter={onEnter} onPointerLeave={onLeave}>
+      <button
+        type="button"
+        ref={btn}
+        className={`icon-btn ${open ? 'on' : ''}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? id : undefined}
+        aria-label={`Theme: ${current}. Choose a theme.`}
+        title={`Theme: ${current}`}
+        onClick={() => { clearTimer(); setByPointer(false); setOpen((v) => !v); }}
+      >
+        <Icon size={18} aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div
+          className="tm-panel"
+          role="menu"
+          id={id}
+          aria-label="Theme"
+          ref={list}
+          onKeyDown={onKeyDown}
+        >
+          {/* System first, and it is the only row without a swatch: it is not a
+              palette, it is a rule for picking one, and giving it five chips
+              would imply it had colours of its own. */}
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={selection === 'system'}
+            className={`tm-row ${selection === 'system' ? 'is-on' : ''}`}
+            onClick={() => choose('system')}
+            tabIndex={-1}
+          >
+            <span className="tm-mark">{selection === 'system' && <Check size={13} />}</span>
+            <span className="tm-text">
+              <span className="tm-name">System</span>
+              <span className="tm-sub">Follow the desktop</span>
+            </span>
+          </button>
+
+          <div className="tm-sep" role="none" />
+
+          {themes.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              role="menuitemradio"
+              aria-checked={selection === t.id}
+              className={`tm-row ${selection === t.id ? 'is-on' : ''}`}
+              onClick={() => choose(t.id)}
+              tabIndex={-1}
+            >
+              <span className="tm-mark">{selection === t.id && <Check size={13} />}</span>
+              <span className="tm-text">
+                <span className="tm-name">{t.name}</span>
+              </span>
+              <ThemeSwatch id={t.id} />
+            </button>
+          ))}
+
+          {/* The menu lists themes; Settings explains them. Saying so here is
+              cheaper than repeating every one-line note in a 220px popover. */}
+          <div className="tm-sep" role="none" />
+          <p className="tm-foot">Descriptions in Settings → Appearance</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/portal-next/web/src/components/ThemeSwatch.tsx
+++ b/apps/portal-next/web/src/components/ThemeSwatch.tsx
@@ -1,0 +1,27 @@
+// Five chips, painted by the theme they advertise rather than by a list of
+// colours copied out of it.
+//
+// The element carries `data-bothy-theme`, and every theme file declares its
+// palette for a SUBTREE as well as for :root precisely so this works - so a
+// swatch cannot show a colour the theme does not actually have. That is the
+// whole reason it is worth a component: the alternative is a table of five
+// hexes per theme, maintained by hand, and first to go stale.
+//
+// `--sw-N` with the real token as the FALLBACK resolves both kinds of theme in
+// one expression. A theme FILE applies its whole palette here, so var(--accent)
+// is already right and --sw-1 is undefined. The two BUILT-INS live on :root
+// only - they are index.css itself - so themes/picker.css supplies --sw-1..5
+// for them instead, guarded by checks/theme-contract.mjs. Neither case needs
+// this component to know which kind it is drawing.
+
+export function ThemeSwatch({ id }: { id: string }) {
+  return (
+    <span className="theme-swatch" data-bothy-theme={id} aria-hidden="true">
+      <i style={{ background: 'var(--sw-1, var(--accent))' }} />
+      <i style={{ background: 'var(--sw-2, var(--st-up))' }} />
+      <i style={{ background: 'var(--sw-3, var(--st-warn))' }} />
+      <i style={{ background: 'var(--sw-4, var(--st-down))' }} />
+      <i style={{ background: 'var(--sw-5, var(--a5))' }} />
+    </span>
+  );
+}

--- a/apps/portal-next/web/src/lib/themes.ts
+++ b/apps/portal-next/web/src/lib/themes.ts
@@ -63,6 +63,30 @@ export const THEMES: readonly ThemeDef[] = [
     appearance: 'dark',
     note: 'After the editor theme by enkia. Cooler and bluer than Bothy Dark.',
   },
+  {
+    id: 'catppuccin-mocha',
+    name: 'Catppuccin Mocha',
+    appearance: 'dark',
+    note: 'Pastel and low-glare, on a soft violet-grey ground.',
+  },
+  {
+    id: 'catppuccin-latte',
+    name: 'Catppuccin Latte',
+    appearance: 'light',
+    note: 'The light flavour of the same palette. Warmer than Bothy Light.',
+  },
+  {
+    id: 'gruvbox',
+    name: 'Gruvbox',
+    appearance: 'dark',
+    note: 'Warm retro browns and cream, after the palette by morhetz.',
+  },
+  {
+    id: 'nord',
+    name: 'Nord',
+    appearance: 'dark',
+    note: 'Arctic blue-grey. The calmest of the set, and the lowest contrast.',
+  },
 ];
 
 /** `'system'` is a SELECTION, never a theme: it means "follow the OS", and it

--- a/apps/portal-next/web/src/pages/Settings.css
+++ b/apps/portal-next/web/src/pages/Settings.css
@@ -124,50 +124,5 @@
 
 /* The swatch row carries the theme's OWN tokens (the element sets
    data-bothy-theme), so these rules must not paint any colour themselves. */
-.settings-page .theme-swatch { display: flex; gap: 4px; margin-top: 3px; }
-.settings-page .theme-swatch i {
-  width: 18px;
-  height: 8px;
-  border-radius: var(--r-xs);
-  /* An outline rather than a border, so the swatch keeps its measured size and
-     a near-background colour (a light theme's surface, a stopped grey) still
-     reads as a chip rather than dissolving into the card. */
-  outline: 1px solid var(--line);
-  outline-offset: -1px;
-}
 
-/* ── swatch palettes for the theme picker ───────────────────────────────────
-   The two built-in palettes above live on :root, because that is where a theme
-   is applied. The picker in Settings needs them on a SUBTREE as well, so a card
-   can paint its own five swatches in the theme it is advertising rather than in
-   whatever theme happens to be active.
 
-   A theme FILE solves this by declaring both selectors (see src/themes/*.css).
-   The built-ins cannot: their palettes are the :root blocks at the top of this
-   file, and repeating 41 tokens twice to make them subtree-applicable would be
-   the duplication the token model exists to prevent.
-
-   So this repeats FIVE values, and checks/theme-contract.mjs asserts each one
-   still equals the token it previews. Five guarded copies beat eighty-two
-   unguarded ones, and the guard is what makes it a cache rather than a fork.
-
-   SCOPED TO .theme-swatch, and that is not tidiness. Unscoped, these matched
-   the ROOT element - which carries data-bothy-theme too - so --sw-1..5 were
-   inherited by the whole document and shadowed the `var(--sw-1, var(--accent))`
-   fallback everywhere, including inside the cards for OTHER themes. Every
-   swatch on the page painted the active theme's colours while looking
-   entirely correct. */
-.theme-swatch[data-bothy-theme='bothy-dark'] {
-  --sw-1: #60a5fa;  /* --accent  */
-  --sw-2: #34d399;  /* --st-up   */
-  --sw-3: #fbbf24;  /* --st-warn */
-  --sw-4: #fb7185;  /* --st-down */
-  --sw-5: #e169fc;  /* --a5      */
-}
-.theme-swatch[data-bothy-theme='bothy-light'] {
-  --sw-1: #2563eb;  /* --accent  */
-  --sw-2: #10b981;  /* --st-up   */
-  --sw-3: #d97706;  /* --st-warn */
-  --sw-4: #e11d48;  /* --st-down */
-  --sw-5: #b921d6;  /* --a5      */
-}

--- a/apps/portal-next/web/src/pages/Settings.tsx
+++ b/apps/portal-next/web/src/pages/Settings.tsx
@@ -24,6 +24,7 @@ import { Ban, Circle, CircleCheck, LogIn } from 'lucide-react';
 import { ROLES, ROLE_MEANING, signInHref, type Me, type Role } from '../lib/me';
 import { useMe } from '../components/UserMenu';
 import { useTheme } from '../lib/theme';
+import { ThemeSwatch } from '../components/ThemeSwatch';
 import { Skeleton } from '../components/states';
 import './Settings.css';
 
@@ -103,23 +104,7 @@ function Appearance() {
             >
               <span className="theme-name">{t.name}</span>
               <span className="theme-note">{t.note}</span>
-              {/* The swatches are painted BY the theme they advertise, so a card
-                  cannot show colours the theme does not actually have.
-
-                  `--sw-N` with the real token as the FALLBACK, which resolves
-                  both cases in one expression: a theme file applies its whole
-                  palette to this subtree, so var(--accent) is already right and
-                  --sw-1 is undefined; the two built-ins live on :root only, so
-                  they supply --sw-1..5 instead (index.css, guarded by the
-                  contract check). Neither case needs the component to know
-                  which kind of theme it is rendering. */}
-              <span className="theme-swatch" data-bothy-theme={t.id} aria-hidden="true">
-                <i style={{ background: 'var(--sw-1, var(--accent))' }} />
-                <i style={{ background: 'var(--sw-2, var(--st-up))' }} />
-                <i style={{ background: 'var(--sw-3, var(--st-warn))' }} />
-                <i style={{ background: 'var(--sw-4, var(--st-down))' }} />
-                <i style={{ background: 'var(--sw-5, var(--a5))' }} />
-              </span>
+              <ThemeSwatch id={t.id} />
             </button>
           ))}
         </div>

--- a/apps/portal-next/web/src/themes/catppuccin-latte.css
+++ b/apps/portal-next/web/src/themes/catppuccin-latte.css
@@ -1,0 +1,84 @@
+/* ============================================================================
+   Catppuccin Latte - the light flavour of the same palette.
+
+   The only LIGHT theme here besides Bothy Light, and light is where this design
+   system's rules bite hardest. Two extra constraints apply that no dark theme
+   has to satisfy:
+
+     · Status WEIGHT must run down > warn > up > unknown > stopped. On a white
+       page the eye reads "heavier" as "more urgent", and Catppuccin's own
+       yellow (#df8e1d) against its green (#40a02b) inverts that - the green is
+       darker. Both are pulled until the ladder is in the right order.
+     · The chart band is L 0.43-0.77, and a light theme's series have to clear
+       3:1 against a near-white card, which most of Latte does not do unaided.
+
+   Upstream's own accessibility work is why this is a port and not a fight:
+   Latte was designed to be readable on white, so most values need nudging
+   rather than replacing.
+   ========================================================================== */
+
+:root[data-bothy-theme='catppuccin-latte'][data-bothy-theme],
+[data-bothy-theme='catppuccin-latte'][data-bothy-theme] {
+  color-scheme: light;
+
+  /* Latte inverts the ladder the way Bothy Light does: the CARD is the lightest
+     thing, the page sits a step below it, and insets go darker still. A light
+     theme that makes the page white and the card whiter has no ladder left. */
+  --bg:        #eff1f5;
+  --bg-2:      #e6e9ef;
+  --surface-1: #ffffff;
+  --surface-2: #f7f8fa;
+  --surface-3: #eaecf2;
+  --surface-4: #ffffff;
+  --bg-glow:   radial-gradient(60% 50% at 50% 0%, #dce0e8 0%, transparent 70%);
+
+  --fg:        #4c4f69;
+  --fg-muted:  #5c5f77;
+  --fg-subtle: #63667c;
+  --on-accent: #ffffff;
+
+  --line:        rgb(76 79 105 / 14%);
+  --line-strong: rgb(76 79 105 / 24%);
+
+  --accent:      #1e66f5;
+  --accent-2:    #1552d0;
+  --accent-fg:   #1a56c9;
+
+  --chart-1: #1e66f5;
+  --chart-2: #179299;
+  --chart-3: #d1730a;
+  --chart-4: #8839ef;
+  --chart-5: #d20f39;
+
+  /* The ladder, in weight order. Upstream green #40a02b is darker than upstream
+     yellow #df8e1d, which would put "up" above "warn" - so the yellow is
+     deepened and the green lightened until down > warn > up holds. */
+  --st-up:      #56b942;  --st-up-fg:      #287717;
+  --st-warn:    #c47a10;  --st-warn-fg:    #935c0b;
+  --st-down:    #d20f39;  --st-down-fg:    #b30c30;
+  --st-unknown: #b8bcc9;  --st-unknown-fg: #5b5f72;
+  --st-off:     #cdd0da;  --st-off-fg:     #64687b;
+
+  --a1: #067b93;
+  --a2: #1560c4;
+  --a3: #4c4ddb;
+  --a4: #8839ef;
+  --a5: #b81fa8;
+
+  /* A light theme's shadow is a shadow, not a glow: the inset hairline that
+     lifts a dark surface has to become a dark hairline here or it disappears. */
+  --shadow-sm: 0 1px 2px rgb(76 79 105 / 10%), inset 0 1px 0 rgb(255 255 255 / 60%);
+  --shadow-md: 0 4px 14px rgb(76 79 105 / 13%), inset 0 1px 0 rgb(255 255 255 / 65%);
+  --shadow-lg: 0 18px 44px rgb(76 79 105 / 18%), inset 0 1px 0 rgb(255 255 255 / 70%);
+
+  --scroll-shade: rgb(239 241 245 / 84%);
+  --hover-opacity: .8;
+}
+
+:root[data-bothy-theme='catppuccin-latte'] .bothy-files.bothy-files {
+  --hl-com: var(--fg-subtle);
+  --hl-kw:  #7c2ae0;
+  --hl-str: #0a6e8a;
+  --hl-num: #a5157d;
+  --hl-key: #3538b8;
+}

--- a/apps/portal-next/web/src/themes/catppuccin-mocha.css
+++ b/apps/portal-next/web/src/themes/catppuccin-mocha.css
@@ -1,0 +1,82 @@
+/* ============================================================================
+   Catppuccin Mocha - after the palette by the Catppuccin project.
+
+   See tokyo-night.css for what the format requires and why the selector is
+   doubled; this file only records where it departs from upstream.
+
+   Catppuccin ships a 26-colour palette with no notion of a reserved status set,
+   so the departures are the same shape as every port's:
+
+     · green, yellow and red become --st-up / --st-warn / --st-down and appear
+       nowhere else. Teal and peach are close enough to those hues to be
+       unusable as chrome, so they are not used at all.
+     · The accents run sapphire -> blue -> lavender -> mauve -> pink, which is
+       the part of Catppuccin that happens to sit inside the one legal window
+       (208-328) the status hues leave open.
+     · Every chart slot is darkened. Catppuccin is a pastel palette - its colours
+       sit high in lightness by design - and the dark band ends at L 0.67.
+   ========================================================================== */
+
+:root[data-bothy-theme='catppuccin-mocha'][data-bothy-theme],
+[data-bothy-theme='catppuccin-mocha'][data-bothy-theme] {
+  color-scheme: dark;
+
+  /* base / mantle / crust, extended to the four-step ladder. Upstream's
+     surface0..2 are the top three steps; the lower two are interpolated,
+     because Catppuccin's own base-to-surface0 jump is larger than this ladder
+     wants between a page and a card. */
+  --bg:        #1e1e2e;
+  --bg-2:      #181825;
+  --surface-1: #252539;
+  --surface-2: #2b2b40;
+  --surface-3: #313244;
+  --surface-4: #3a3a52;
+  --bg-glow:   radial-gradient(60% 50% at 50% 0%, #302f4a 0%, transparent 70%);
+
+  --fg:        #cdd6f4;
+  --fg-muted:  #a6adc8;
+  /* overlay1 (#7f849c) measures below AA at the 11-12px sizes this is used at,
+     so subtext-ward. Same lift index.css applies to zinc-500. */
+  --fg-subtle: #939ab7;
+  --on-accent: #181825;
+
+  --line:        rgb(205 214 244 / 11%);
+  --line-strong: rgb(205 214 244 / 19%);
+
+  --accent:      #89b4fa;
+  --accent-2:    #6a9bf0;
+  --accent-fg:   #a9c8ff;
+
+  --chart-1: #5b8ae6;
+  --chart-2: #2f97ab;
+  --chart-3: #c1702f;
+  --chart-4: #8f6ae0;
+  --chart-5: #d4547c;
+
+  --st-up:      #a6e3a1;  --st-up-fg:      #a6e3a1;
+  --st-warn:    #f9e2af;  --st-warn-fg:    #f9e2af;
+  --st-down:    #f38ba8;  --st-down-fg:    #f38ba8;
+  --st-unknown: #585b70;  --st-unknown-fg: #9ca3bd;
+  --st-off:     #45475a;  --st-off-fg:     #8d94ae;
+
+  --a1: #74c7ec;
+  --a2: #89b4fa;
+  --a3: #aab4fe;  /* lavender, chroma raised to clear the near-grey statuses by 0.06 */
+  --a4: #cba6f7;
+  --a5: #d69ef1;  /* moved off --st-down's hue: 32 degrees was inside the 45 floor */
+
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 40%), inset 0 1px 0 rgb(205 214 244 / 4%);
+  --shadow-md: 0 4px 14px rgb(0 0 0 / 44%), inset 0 1px 0 rgb(205 214 244 / 5%);
+  --shadow-lg: 0 18px 44px rgb(0 0 0 / 52%), inset 0 1px 0 rgb(205 214 244 / 6%);
+
+  --scroll-shade: rgb(24 24 37 / 82%);
+  --hover-opacity: .9;
+}
+
+:root[data-bothy-theme='catppuccin-mocha'] .bothy-files.bothy-files {
+  --hl-com: var(--fg-subtle);
+  --hl-kw:  #cba6f7;
+  --hl-str: #a6e3a1;
+  --hl-num: #fab387;
+  --hl-key: #89dceb;
+}

--- a/apps/portal-next/web/src/themes/gruvbox.css
+++ b/apps/portal-next/web/src/themes/gruvbox.css
@@ -1,0 +1,84 @@
+/* ============================================================================
+   Gruvbox Dark - after the palette by morhetz.
+
+   THE HARDEST PORT OF THE FOUR, and worth saying why: Gruvbox is a WARM palette.
+   Its surfaces are brown-grey, its foreground is cream, and its bright accents
+   are red, green, yellow, orange, aqua and a dusty pink. That distribution is
+   almost exactly wrong for this design system, because three of those hues are
+   reserved for status and the remaining chrome window is the cool 120 degrees
+   (208-328) that Gruvbox barely visits.
+
+   So this port keeps everything Gruvbox is recognisable BY - the warm surfaces,
+   the cream text, the red/green/yellow status - and accepts that its five panel
+   accents are the least Gruvbox-looking part of it:
+
+     · Upstream blue (#83a598) is really a desaturated aqua at H ~193, outside
+       the legal window and too close to nothing in particular. The accents are
+       built as cooled, Gruvbox-weight versions across 210-325 instead.
+     · Upstream purple (#d3869b) sits at H ~5, which is --st-down's hue. It is
+       not used as chrome anywhere.
+     · Charts are darkened for the L<=0.67 band, as everywhere else.
+
+   The alternative - bending the accent rule to keep Gruvbox's own aqua and pink
+   - was rejected on the grounds the rule exists for: a decorative spine that
+   shares a hue with "up" or "down" is read as status, and it is read that way
+   most reliably by the people the contrast rules are for.
+   ========================================================================== */
+
+:root[data-bothy-theme='gruvbox'][data-bothy-theme],
+[data-bothy-theme='gruvbox'][data-bothy-theme] {
+  color-scheme: dark;
+
+  --bg:        #282828;
+  --bg-2:      #1d2021;
+  --surface-1: #32302f;
+  --surface-2: #3c3836;
+  --surface-3: #504945;
+  --surface-4: #5a524c;
+  --bg-glow:   radial-gradient(60% 50% at 50% 0%, #423c37 0%, transparent 70%);
+
+  --fg:        #ebdbb2;
+  --fg-muted:  #d5c4a1;
+  --fg-subtle: #b0a189;
+  --on-accent: #1d2021;
+
+  --line:        rgb(235 219 178 / 12%);
+  --line-strong: rgb(235 219 178 / 20%);
+
+  --accent:      #7fb3d4;
+  --accent-2:    #6a9bbd;
+  --accent-fg:   #9cc6e2;
+
+  --chart-1: #4f8fbd;
+  --chart-2: #2f8f8a;
+  --chart-3: #c1702f;
+  --chart-4: #8a6fc4;
+  --chart-5: #c25a6e;
+
+  --st-up:      #b8bb26;  --st-up-fg:      #b8bb26;
+  --st-warn:    #fabd2f;  --st-warn-fg:    #fabd2f;
+  --st-down:    #fb4934;  --st-down-fg:    #ff7a68;
+  --st-unknown: #665c54;  --st-unknown-fg: #bdae93;
+  --st-off:     #504945;  --st-off-fg:     #ada18c;
+
+  --a1: #65b4d4;
+  --a2: #7da8e0;
+  --a3: #a09de9;
+  --a4: #ba95df;
+  --a5: #d48ec8;
+
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 44%), inset 0 1px 0 rgb(235 219 178 / 5%);
+  --shadow-md: 0 4px 14px rgb(0 0 0 / 48%), inset 0 1px 0 rgb(235 219 178 / 6%);
+  --shadow-lg: 0 18px 44px rgb(0 0 0 / 56%), inset 0 1px 0 rgb(235 219 178 / 7%);
+
+  --scroll-shade: rgb(29 32 33 / 84%);
+  --hover-opacity: .9;
+}
+
+:root[data-bothy-theme='gruvbox'] .bothy-files.bothy-files {
+  --hl-com: var(--fg-subtle);
+  --hl-kw:  #d3a3e0;
+  --hl-str: #8ec07c;
+  --hl-num: #fe8019;
+  --hl-key: #8fbfe0;
+}

--- a/apps/portal-next/web/src/themes/nord.css
+++ b/apps/portal-next/web/src/themes/nord.css
@@ -1,0 +1,79 @@
+/* ============================================================================
+   Nord - after the palette by Arctic Ice Studio.
+
+   Nord is the closest fit of the four ports, and for a structural reason: it is
+   already split into a cool set and a warm set. Frost is chrome, Aurora is
+   state. That is the same division this design system enforces between
+   --a1..--a5 and --st-*, arrived at independently.
+
+   Where it still departs:
+
+     · Frost's two greenest members (#8fbcbb at H ~185 and #88c0d0 at H ~205)
+       sit just outside the legal accent window, which opens at 208. The accent
+       ramp starts from a cooled #88c0d0 instead and runs to a violet extended
+       past Aurora's purple, because Nord has nothing at the magenta end.
+     · Aurora's yellow (#ebcb8b) is very light and its green (#a3be8c) is muted;
+       both are usable as status fills but the pair needed separating so that
+       "warn" does not read as a paler "up".
+     · Nord's surfaces are famously low-contrast. The ladder is kept close to
+       upstream's Polar Night, but --fg-subtle is lifted well above #4c566a,
+       which is a SURFACE colour upstream and cannot carry 11px text.
+   ========================================================================== */
+
+:root[data-bothy-theme='nord'][data-bothy-theme],
+[data-bothy-theme='nord'][data-bothy-theme] {
+  color-scheme: dark;
+
+  --bg:        #2e3440;
+  --bg-2:      #272c38;
+  --surface-1: #343b49;
+  --surface-2: #3b4252;
+  --surface-3: #434c5e;
+  --surface-4: #4c566a;
+  --bg-glow:   radial-gradient(60% 50% at 50% 0%, #3d4759 0%, transparent 70%);
+
+  --fg:        #eceff4;
+  --fg-muted:  #d8dee9;
+  --fg-subtle: #a7b1c2;
+  --on-accent: #272c38;
+
+  --line:        rgb(236 239 244 / 12%);
+  --line-strong: rgb(236 239 244 / 20%);
+
+  --accent:      #88c0d0;
+  --accent-2:    #6fa8bd;
+  --accent-fg:   #9ed0e0;
+
+  --chart-1: #588bb6;
+  --chart-2: #359494;
+  --chart-3: #bd7233;
+  --chart-4: #9178c5;
+  --chart-5: #cd6674;
+
+  --st-up:      #a3be8c;  --st-up-fg:      #a3be8c;
+  --st-warn:    #ebcb8b;  --st-warn-fg:    #ebcb8b;
+  --st-down:    #c96a73;  --st-down-fg:    #f1969d;
+  --st-unknown: #4c566a;  --st-unknown-fg: #b4bece;
+  --st-off:     #3f4859;  --st-off-fg:     #a3afc4;
+
+  --a1: #68c7e1;
+  --a2: #7eb5eb;
+  --a3: #a9aaef;
+  --a4: #c2a5e7;
+  --a5: #d99ddd;
+
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 38%), inset 0 1px 0 rgb(236 239 244 / 5%);
+  --shadow-md: 0 4px 14px rgb(0 0 0 / 42%), inset 0 1px 0 rgb(236 239 244 / 6%);
+  --shadow-lg: 0 18px 44px rgb(0 0 0 / 50%), inset 0 1px 0 rgb(236 239 244 / 7%);
+
+  --scroll-shade: rgb(39 44 56 / 84%);
+  --hover-opacity: .9;
+}
+
+:root[data-bothy-theme='nord'] .bothy-files.bothy-files {
+  --hl-com: var(--fg-subtle);
+  --hl-kw:  #b48ead;
+  --hl-str: #a3be8c;
+  --hl-num: #d08770;
+  --hl-key: #8fbcbb;
+}

--- a/apps/portal-next/web/src/themes/picker.css
+++ b/apps/portal-next/web/src/themes/picker.css
@@ -1,0 +1,63 @@
+/* ============================================================================
+   The theme picker's shared parts: the swatch, and swatch-only palettes for the
+   two built-in themes.
+
+   IT LIVES IN themes/ ON PURPOSE. This file DEFINES colour values, which makes
+   it a palette definition site like index.css and the theme files beside it -
+   not a component stylesheet that happens to contain hexes. It sat in
+   Settings.css for one commit and broke checks/stray-colour.mjs, which was
+   right to complain: a component file with ten literals in it is exactly the
+   thing that check exists to catch.
+
+   It is glob-imported with the themes by main.tsx, so it needs no import of its
+   own, and both places that draw a swatch - the Settings picker and the topbar
+   menu - get it without either owning it.
+   ========================================================================== */
+
+.theme-swatch { display: flex; gap: 4px; margin-top: 3px; }
+.theme-swatch i {
+  width: 18px;
+  height: 8px;
+  border-radius: var(--r-xs);
+  /* An outline rather than a border, so the swatch keeps its measured size and
+     a near-background colour (a light theme's surface, a stopped grey) still
+     reads as a chip rather than dissolving into the card. */
+  outline: 1px solid var(--line);
+  outline-offset: -1px;
+}
+
+/* ── swatch palettes for the theme picker ───────────────────────────────────
+   The two built-in palettes above live on :root, because that is where a theme
+   is applied. The picker in Settings needs them on a SUBTREE as well, so a card
+   can paint its own five swatches in the theme it is advertising rather than in
+   whatever theme happens to be active.
+
+   A theme FILE solves this by declaring both selectors (see src/themes/*.css).
+   The built-ins cannot: their palettes are the :root blocks at the top of this
+   file, and repeating 41 tokens twice to make them subtree-applicable would be
+   the duplication the token model exists to prevent.
+
+   So this repeats FIVE values, and checks/theme-contract.mjs asserts each one
+   still equals the token it previews. Five guarded copies beat eighty-two
+   unguarded ones, and the guard is what makes it a cache rather than a fork.
+
+   SCOPED TO .theme-swatch, and that is not tidiness. Unscoped, these matched
+   the ROOT element - which carries data-bothy-theme too - so --sw-1..5 were
+   inherited by the whole document and shadowed the `var(--sw-1, var(--accent))`
+   fallback everywhere, including inside the cards for OTHER themes. Every
+   swatch on the page painted the active theme's colours while looking
+   entirely correct. */
+.theme-swatch[data-bothy-theme='bothy-dark'] {
+  --sw-1: #60a5fa;  /* --accent  */
+  --sw-2: #34d399;  /* --st-up   */
+  --sw-3: #fbbf24;  /* --st-warn */
+  --sw-4: #fb7185;  /* --st-down */
+  --sw-5: #e169fc;  /* --a5      */
+}
+.theme-swatch[data-bothy-theme='bothy-light'] {
+  --sw-1: #2563eb;  /* --accent  */
+  --sw-2: #10b981;  /* --st-up   */
+  --sw-3: #d97706;  /* --st-warn */
+  --sw-4: #e11d48;  /* --st-down */
+  --sw-5: #b921d6;  /* --a5      */
+}


### PR DESCRIPTION
Fixes the thing you hit: **Tokyo Night was unreachable from the topbar.** The control there was a cycle over dark → light → system, so it could reach three of eight options while looking like the whole answer. Restricting the button was the wrong call — it needed to be a real selector.

## The menu

Same idiom as the account menu beside it — same surface, rows, keyboard handling — because two popovers on one topbar that disagree about their own geometry read as two applications.

Opens on **hover** as an accelerator, and on **click** and by **keyboard**, because hover is not an interaction on a touchscreen. Two details that are easy to get wrong and are commented in place:

- A hover open does **not** move focus. A menu that steals the caret because the pointer crossed it is a menu that fights you. Click and keyboard opens do focus the first row.
- The 8px gap between button and panel is bridged by a pseudo-element, so crossing it never registers as a leave. That is what lets the close timer stay short instead of lingering.

## Four more themes

Catppuccin Mocha, Catppuccin Latte, Gruvbox and Nord — each a full 41-token palette that passes the contract. **31 failures across the four on the first pass**, every one real. That is the argument for having written the check before the themes.

| | |
|---|---|
| **Nord** | Worst, and structurally so. Frost is beautiful and barely chromatic, and Nord's own Polar Night greys carry enough tint that three accents could not clear them by the required 0.06 of chroma. Its surfaces are also the lightest here, so four chart slots missed 3:1 on a card. Frost keeps its hue and gains chroma. |
| **Gruvbox** | Hardest on principle. It is a **warm** palette and three of its signature hues are reserved for status here, so its panel accents are the least Gruvbox-looking part of it. Keeping its aqua and dusty pink as chrome was the tempting alternative and is rejected in the file: a spine sharing a hue with "up" or "down" gets read as status, most reliably by the people the contrast floors exist for. |
| **Catppuccin** | Pastel, so every chart slot sat above the dark band's 0.67 ceiling. Latte additionally had green darker than yellow, which inverts the light-mode urgency ladder (down > warn > up). |

**The values were solved, not eyeballed** — held the hue, which is what makes a colour recognisable, and moved lightness and chroma in OKLCH until the contract passed. So the ports keep their identity instead of drifting toward whatever happened to pass.

## A regression from #63, fixed here

The picker's five swatch values were moved into `Settings.css`, where `stray-colour.mjs` was right to refuse them — ten literals in a component stylesheet. They live in `themes/picker.css` now, beside the palettes they preview: a file that *defines* colour is a definition site, not a component file with hexes in it.

Worth naming how it shipped: I ran the full suite, *then* moved the blocks, and afterwards re-ran only the contract check and the build. CI does not run `checks/run.sh` (it needs the docker socket), so nothing caught it.

## Verified

- Contract check: **292 pass, 0 fail** across all six themes. Full `checks/run.sh` green, exit 0.
- Live, fresh load: the menu opens with 8 rows, each swatch row distinct and drawn from its own palette; choosing Gruvbox stamps `data-bothy-theme=gruvbox`, repaints `--bg` to `#282828`, and closes the menu.
- Screenshotted Gruvbox end to end — warm surfaces, cream text, its own green and red for status, cooled accents on the system chips.
- Caught in review of my own screenshot: "Catppuccin Mocha" wrapped to two lines at the original panel width. Widened, and names no longer wrap.
