### PR TITLE
feat(files): refuse less, explain more

### DIFF
--- a/apps/portal-files/app.py
+++ b/apps/portal-files/app.py
@@ -325,9 +325,14 @@ def listing(root_key: str) -> tuple[list[dict], bool]:
                 "dir": os.path.dirname(res.relpath),   # so a UI can build a tree
                 "size": st.st_size,
                 "mtime": int(st.st_mtime),
-                "writable": (writable_root
-                             and os.path.splitext(fn)[1].lower()
-                             in safepath.WRITABLE_SUFFIXES),
+                # Writable now means only "the root allows writes". The suffix
+                # allowlist that used to narrow this is gone - see [write] in
+                # policy.toml - so the explorer no longer greys out a compose
+                # file it is perfectly able to save.
+                "writable": writable_root,
+                # The LABEL, not a refusal. A name-shaped credential is served
+                # and marked; the client decides how loudly to say so.
+                "sensitive": safepath.is_sensitive_name(fn),
                 "lang": LANGS.get(os.path.splitext(fn)[1].lower())
                         or LANGS.get(fn),
             })
@@ -733,7 +738,7 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, {"roots": [
                     {"key": k,
                      "readOnly": k in READONLY_ROOTS,
-                     "writableSuffixes": sorted(safepath.WRITABLE_SUFFIXES)}
+                     }
                     for k in sorted(safepath.ROOTS)
                 ]})
 
@@ -780,9 +785,11 @@ class Handler(BaseHTTPRequestHandler):
                     "versioned": res.git_root is not None,
                     "lang": LANGS.get(os.path.splitext(res.abspath)[1].lower())
                             or LANGS.get(os.path.basename(res.abspath)),
-                    "writable": (res.root_key not in READONLY_ROOTS
-                                 and os.path.splitext(res.abspath)[1].lower()
-                                 in safepath.WRITABLE_SUFFIXES),
+                    "writable": res.root_key not in READONLY_ROOTS,
+                    # What this edit costs, if anything, decided from the path
+                    # alone so it is known before a byte is read. None for the
+                    # ordinary case.
+                    "caution": safepath.caution_for(res.relpath),
                 }
                 # Binary is decided BEFORE the size check: a 40 MB png should
                 # report "binary" rather than "too large to edit", which would
@@ -798,9 +805,20 @@ class Handler(BaseHTTPRequestHandler):
                 # Advisory, never a refusal - see scan_for_secret's docstring for
                 # the measurement that settled it. The UI shows a caution; the
                 # file still opens.
+                #
+                # TWO SOURCES, and the NAME is checked first because it is the
+                # one that catches an empty or as-yet-unwritten credential file.
+                # The content scan reads what is actually there; the name scan
+                # knows what the file is FOR. `.env` with one commented line is
+                # still the place secrets go, and only the name says so.
+                sensitive = (
+                    "the filename is the shape of a credential store"
+                    if safepath.is_sensitive_name(os.path.basename(res.abspath))
+                    else safepath.scan_for_secret(content)
+                )
                 return self._send(200, {**base, "binary": False,
                                         "content": content,
-                                        "sensitive": safepath.scan_for_secret(content),
+                                        "sensitive": sensitive,
                                         "history": history(res)})
 
             if route == "/history":
@@ -1160,7 +1178,10 @@ class Handler(BaseHTTPRequestHandler):
             return
         try:
             # Phase 1: everything that can fail cleanly.
-            members, skipped = safepath.collect(q.get("root", ""), q.get("path", ""))
+            # for_archive=True is what excludes credential files from the zip.
+            # They remain readable one at a time; see the comment on that check.
+            members, skipped = safepath.collect(q.get("root", ""), q.get("path", ""),
+                                                for_archive=True)
             if not members:
                 return self._send(404, {"error": "nothing to archive here",
                                         "skipped": len(skipped)})

--- a/apps/portal-files/checks/bytes_e2e.py
+++ b/apps/portal-files/checks/bytes_e2e.py
@@ -52,10 +52,19 @@ check("?download=1 downgrades to attachment",
       and r2.headers["Content-Type"] == "application/octet-stream")
 
 print("\n── /raw: the guards still hold ─────────────────────────────────────")
+# The two SECRET rows moved from 403 to 200 on 2026-08-17, and that is the whole
+# of what [sensitive] in policy.toml changed. They stay in this table rather than
+# being deleted, because "the raw endpoint serves a credential file" is exactly
+# the assertion someone will want to re-read the day they wonder whether it was
+# deliberate.
+#
+# Everything else in this table is a BOUNDARY and did not move: traversal, the
+# object store, and a directory where a file is expected. Those are what make the
+# two 200s safe to have here at all.
 for label, root, path, want in [
-    ("a denied secret (.env)", "stacks", ".env", 403),
-    ("a private key", "projects",
-     "army/monorepo-inherited/apps/site-relay-app/cert/key.pem", 403),
+    ("a secret, now SERVED (.env)", "stacks", ".env", 200),
+    ("a private key, now SERVED", "projects",
+     "army/monorepo-inherited/apps/site-relay-app/cert/key.pem", 200),
     ("traversal", "stacks", "../../etc/passwd", 403),
     ("the repo .git", "stacks", ".git/config", 403),
     ("a directory, not a file", "stacks", "docs", 403),

--- a/apps/portal-files/checks/bytes_e2e.py
+++ b/apps/portal-files/checks/bytes_e2e.py
@@ -36,7 +36,7 @@ s.post(m.group(1).replace("&amp;", "&"),
 
 print("── /raw: real bytes ────────────────────────────────────────────────")
 r = s.get(f"{SANDBOX}/-/api/files/raw",
-          params={"root": "stacks", "path": "docs/assets/portal-overview.png"}, timeout=30)
+          params={"root": "stacks", "path": "docs/assets/overview.png"}, timeout=30)
 check("a PNG is served inline as image/png",
       r.status_code == 200 and r.headers["Content-Type"] == "image/png"
       and "inline" in r.headers["Content-Disposition"])
@@ -45,7 +45,7 @@ check("the bytes are a REAL png (magic intact)",
 check("Content-Length matches the body", int(r.headers["Content-Length"]) == len(r.content))
 
 r2 = s.get(f"{SANDBOX}/-/api/files/raw",
-           params={"root": "stacks", "path": "docs/assets/portal-overview.png",
+           params={"root": "stacks", "path": "docs/assets/overview.png",
                    "download": "1"}, timeout=30)
 check("?download=1 downgrades to attachment",
       "attachment" in r2.headers["Content-Disposition"]
@@ -68,7 +68,7 @@ print("\n── Range: implemented narrowly, and each refusal is its own path �
 # nothing inline needed it. Video changed the balance. Each case below is a
 # separate branch of the parser, so each gets its own assertion - a single
 # "ranges work" check would pass with three of them broken.
-PNG = {"root": "stacks", "path": "docs/assets/portal-overview.png"}
+PNG = {"root": "stacks", "path": "docs/assets/overview.png"}
 full = s.get(f"{SANDBOX}/-/api/files/raw", params=PNG, timeout=30)
 size = len(full.content)
 

--- a/apps/portal-files/checks/search_denied.py
+++ b/apps/portal-files/checks/search_denied.py
@@ -92,7 +92,17 @@ try:
           any(c.name.startswith("_oauth2_proxy") for c in s.cookies))
 
     # ── the boundary ────────────────────────────────────────────────────────
-    print("\n── denied files must not appear in results ─────────────────────────")
+    #
+    # THIS ASSERTION INVERTED ON 2026-08-17. Files matching the credential name
+    # patterns are served now and marked instead - see [sensitive] in
+    # policy.toml - so search finds them, and the thing being tested is that the
+    # walk still agrees with resolve(). It always did; what changed is what
+    # resolve() permits.
+    #
+    # The DIRECTORY rule did not change, and that is the half still worth
+    # guarding: `node_modules` is pruned during the walk, so nothing inside it
+    # can surface no matter what the content is.
+    print("\n── search agrees with what resolve() now permits ────────────────────")
     r = s.get(f"{API}/search",
               params={"root": "stacks", "path": PROBE_REL, "q": TOKEN}, timeout=30)
     check("search answers", r.status_code == 200, f"got {r.status_code}")
@@ -101,18 +111,19 @@ try:
 
     check("the served file IS found",
           f"{PROBE_REL}/found.md" in hit_paths, f"{sorted(hit_paths)}")
-    for denied, why in (("secret-probe.txt", "*secret* name pattern"),
-                        (".env.probe", ".env.* name pattern"),
-                        ("node_modules/x.md", "denied path component")):
-        check(f"NOT found: {denied}",
-              f"{PROBE_REL}/{denied}" not in hit_paths, why)
+    for now_served, why in (("secret-probe.txt", "*secret* is a label, not a wall"),
+                            (".env.probe", ".env.* is a label, not a wall")):
+        check(f"now found: {now_served}",
+              f"{PROBE_REL}/{now_served}" in hit_paths, why)
+    check("NOT found: node_modules/x.md",
+          f"{PROBE_REL}/node_modules/x.md" not in hit_paths,
+          "denied path component - unchanged")
 
     # The name half of the response goes through the same walk, so it gets the
-    # same assertion - a denied file must not surface by NAME either.
+    # same assertion: a PRUNED DIRECTORY must not surface by name either.
     name_paths = {m["path"] for m in body.get("names", [])}
-    check("no denied file surfaces as a NAME hit",
-          not any(p.startswith(f"{PROBE_REL}/") and not p.endswith("found.md")
-                  for p in name_paths),
+    check("no file from a pruned directory surfaces as a NAME hit",
+          not any(p.startswith(f"{PROBE_REL}/node_modules/") for p in name_paths),
           f"{sorted(name_paths)}")
 
     # ── the overlapping root ────────────────────────────────────────────────

--- a/apps/portal-files/checks/served-secrets.baseline
+++ b/apps/portal-files/checks/served-secrets.baseline
@@ -3,7 +3,7 @@
 # repository is public, and the list of files that look like they
 # hold credentials is exactly the map not to publish.
 #
-# 40 accepted. Regenerate with --update after INSPECTING
+# 54 accepted. Regenerate with --update after INSPECTING
 # what changed; accepting a finding you have not opened defeats it.
 09bd00fe3b494d2c
 0b369f3dd592e4d5
@@ -14,34 +14,48 @@
 2b17b218db6035b0
 2b9a36cf67aff1a3
 2cc5f9a33314a9de
+2d55439e9c72ad2f
+3c0ee2bea7103fff
 408383f9aa7e15e3
 47cbbcd938d1e12c
+53263bcbfccd9412
 5cc3fdf6d968d496
+6f4511225bb1201f
+72918d9657d6d44d
 87c700b1043f09cd
 8b297ae1c1ace14f
+90102920eaa47b82
 97ae27fc0c4ea59d
 97dc2f1ec0f61ccc
 9966ff6c4ca865bc
-9c61ac105ca93d83
 9c6286ed57d579ba
+9d16008b9d190d68
 a1df19965e6e3dbe
 a2b463ed450bb0f6
+a3e49c0d89f75c12
 a65603b7cd77be4f
 a75f6b18d839f8dc
 a7b9038c66d46da4
 a931334b1e91f37c
 b09a6f73c1d5c83f
 b18e0848fe10b9c8
+b52dd76cfd3e4246
 b6a16075766e0adf
 b86c5bbe66974197
 bc168c8c21141199
 bf061670a27c77ae
 c60a6e0e0b407109
 c7cf1fa943399bc5
+cabf8231ba06debf
 cffc4ea1aae07052
+daf494bbc8e78474
 e377d661809dea30
 e3bbf1e86c3dd950
-e7b37ddf9dc329aa
+e5c5a9e98f6299e6
 e9c19230e911d9b8
+ea7af8404ae54065
 eb5985fecec89d78
+efb7631e9558e415
+f07089128c76b523
+fab3c54bb281ba37
 fb5018dce95c930f

--- a/apps/portal-files/checks/test_safepath.py
+++ b/apps/portal-files/checks/test_safepath.py
@@ -39,6 +39,7 @@ with open(_POLICY, "w") as _f:
         f'components = [".git", ".ssh", ".gnupg", "node_modules", ".venv", "venv",'
         f' "__pycache__", ".mypy_cache", ".pytest_cache", "dist", "build",'
         f' ".next", ".turbo", ".cache", "target"]\n'
+        f'[sensitive]\n'
         f'file_patterns = [".env", ".env.*", "*.env", "*.pem", "*.key", "*.p12",'
         f' "*.pfx", "*.jks", "*.keystore", "id_rsa", "id_dsa", "id_ecdsa",'
         f' "id_ed25519", "*.ppk", "*.kdbx", "*.gpg", "*.asc", ".netrc", ".pgpass",'
@@ -50,8 +51,10 @@ with open(_POLICY, "w") as _f:
         f'allow_files = [".env.example", ".env.sample", ".env.template",'
         f' ".env.test.example", ".env.local.template", ".env.production.template",'
         f' ".env.defaults"]\n'
-        f'[write]\nsuffixes = [".md", ".markdown", ".txt", ".rst", ".svg",'
-        f' ".html", ".htm", ".xml"]\n'
+        f'[[write.caution]]\nmatch = ["edge/dynamic/*.yml"]\n'
+        f'level = "critical"\nnote = "go templates"\n'
+        f'[[write.caution]]\nmatch = ["**/*.yml"]\n'
+        f'level = "caution"\nnote = "service config"\n'
         f'[snapshots]\npath = "{_BOOT}"\n')
 os.environ.setdefault("POLICY_FILE", _POLICY)
 
@@ -128,10 +131,19 @@ print("\n── the name-prefix trap ──────────────�
 # starts with "/tmp/x/docs" and this would be served.
 check("sibling dir sharing a prefix",    R("../docs-secret/keys.md"), expect_refused=True)
 
-print("\n── write is narrower than read ─────────────────────────────────────")
+print("\n── write is no longer narrower than read, by extension ─────────────")
+# It used to be: an allowlist of prose suffixes meant a shell script or a compose
+# file could be READ and not WRITTEN. That is gone - [write] in policy.toml has
+# the reasoning - so these now assert the OPPOSITE of what they used to, which is
+# the point of leaving them here rather than deleting them. If a future change
+# re-narrows writes by extension, these are what notice.
+#
+# Write is still narrower than read in every way that is a boundary rather than a
+# preference: a read-only root, a symlink, and anything outside a root. Those are
+# tested above and did not move.
 check("reading a shell script",          R("script.sh"),        expect_refused=False)
-check("WRITING a shell script",          R("script.sh", True),  expect_refused=True)
-check("writing a compose file",          R("compose.yml", True), expect_refused=True)
+check("WRITING a shell script",          R("script.sh", True),  expect_refused=False)
+check("writing a compose file",          R("compose.yml", True), expect_refused=False)
 
 print("\n── repo is mounted, but only the content dir is editable ───────────")
 # The compose file mounts the WHOLE stacks repo, because git needs .git at the
@@ -164,18 +176,26 @@ bad += (0 if gr_ok else 1) + (0 if rel_ok else 1)
 safepath.ROOTS["docs"] = root      # restore for the remaining cases
 safepath.GIT_ROOTS["docs"] = root
 
-print("\n── SECRETS: the control that widening the roots made necessary ─────")
-# The roots used to be two markdown trees. They are now the whole box, and a
-# survey of the new scope found ~/stacks/.env holding 19 real secret values and
-# a real TLS private key under ~/projects. Matching only path COMPONENTS - which
-# is what the first version did - would have served both, because `.env` is a
-# FILE and `key.pem` is a FILE.
+print("\n── SECRETS: served, and MARKED rather than hidden ──────────────────")
+# These used to be REFUSED. They are served now and labelled instead - see
+# [sensitive] in policy.toml for the decision and for its one consequence that
+# is not "my box, my files": ~/stacks/.env carries OAUTH2_COOKIE_SECRET, so
+# being able to read it is equivalent to holding every role.
+#
+# What is tested here is therefore the LABEL, on exactly the names that used to
+# be refused. A mark that silently stopped matching would restore none of the
+# old protection and remove all of the new warning, and would look like nothing
+# at all in a diff.
 for name in [".env", ".env.production", ".env.local", "id_ed25519", "id_rsa",
              "key.pem", "cert.key", "server.p12", ".netrc", ".pgpass",
              ".git-credentials", "credentials.json", "my-secrets.yml",
              "db_password.txt", "sessions.sqlite", "app.db", "Key.PEM"]:
     open(os.path.join(root, name), "w").write("SENSITIVE\n")
-    check(f"secret refused: {name}", R(name), expect_refused=True)
+    check(f"secret served: {name}", R(name), expect_refused=False)
+    marked = safepath.is_sensitive_name(name)
+    bad += 0 if marked else 1
+    print(f"{'PASS' if marked else 'FAIL'}  {'  ...and marked sensitive: ' + name:<52} "
+          f"want=True    {marked}")
 
 # ...but a committed template is the file you READ to learn what to set, and
 # hiding it makes the explorer worse for no gain. Allowed BY NAME so the
@@ -195,13 +215,20 @@ print("\n── prose is not a secret just because of a word in its name ──�
 # "Change Password.md" was being hidden as a secret by the `*password*` pattern.
 # `.md`/`.rst` are formats you write ABOUT credentials in; `.txt` is a format
 # people leave them in, so it stays denied.
-for name, want_refused in [
+for name, want_marked in [
     ("Change Password.md", False), ("secrets.md", False), ("password.rst", False),
     ("db_password.txt", True), ("my-secrets.yml", True), ("api_secret.json", True),
 ]:
     open(os.path.join(root, name), "w").write("x\n")
-    check(f"{'refused' if want_refused else 'served '}: {name}",
-          R(name), expect_refused=want_refused)
+    # Everything is served now, so the question is only whether it is LABELLED -
+    # and a label on every page that merely mentions a password is a label
+    # nobody reads, which is the same failure the refusal had.
+    check(f"served: {name}", R(name), expect_refused=False)
+    got = safepath.is_sensitive_name(name)
+    ok = got is want_marked
+    bad += 0 if ok else 1
+    print(f"{'PASS' if ok else 'FAIL'}  {'  marked: ' + name:<52} "
+          f"want={str(want_marked):<7} {got}")
 
 print("\n── archive manifests: collect() == what resolve() allows ───────────")
 # THE invariant. collect() owns the walk precisely so a second implementation
@@ -210,14 +237,49 @@ print("\n── archive manifests: collect() == what resolve() allows ───�
 # members instead of 641, .env present).
 os.makedirs(os.path.join(root, "sub"), exist_ok=True)
 open(os.path.join(root, "sub", "ok.md"), "w").write("fine\n")
-members, skipped = safepath.collect("docs", "", max_entries=10_000, max_total=10**12)
+members, skipped = safepath.collect("docs", "", max_entries=10_000, max_total=10**12,
+                                    for_archive=True)
 names = {m.res.relpath for m in members}
 denied_reasons = {s["path"]: s["why"] for s in skipped}
-for planted in [".env", "key.pem", "id_ed25519", "realm-devbox.json", ".git/config"]:
+# AN ARCHIVE IS NOT A READ. Credential files are SERVED now - open ~/stacks/.env
+# in the explorer and you get it - but they are still excluded from bulk
+# downloads, because a zip is produced by one click on a parent folder and then
+# travels somewhere nobody re-reads it. This is the single place where the
+# `sensitive` mark is a refusal rather than a label, and it is the assertion that
+# keeps the two apart.
+for planted in [".env", "key.pem", "id_ed25519"]:
     ok = planted not in names
     bad += 0 if ok else 1
-    print(f"{'PASS' if ok else 'FAIL'}  {'never in a manifest: ' + planted:<52} "
-          f"want=absent  {denied_reasons.get(planted, 'pruned')[:28]}")
+    print(f"{'PASS' if ok else 'FAIL'}  {'excluded from a manifest: ' + planted:<52} "
+          f"want=absent  {denied_reasons.get(planted, 'MISSING REASON')[:30]}")
+# ...and the omission is REPORTED, not silent. An archive that quietly drops
+# files is discovered by whoever restores it.
+ok = all("credential" in denied_reasons.get(p, "") for p in [".env", "key.pem"])
+bad += 0 if ok else 1
+print(f"{'PASS' if ok else 'FAIL'}  {'...and each says why it was left out':<52} "
+      f"want=stated  {denied_reasons.get('.env', '(none)')[:30]}")
+# A DIRECTORY component is a different rule and did not change. `.git` is pruned
+# during the walk, so nothing inside it is ever a member.
+ok = ".git/config" not in names
+bad += 0 if ok else 1
+print(f"{'PASS' if ok else 'FAIL'}  {'still never in a manifest: .git/config':<52} "
+      f"want=absent  {denied_reasons.get('.git/config', 'pruned')[:28]}")
+# But a sensitive NAME is not a sensitive ROOT: ordinary files beside it are
+# still collected, or the exclusion would be a folder-level denial by accident.
+ok = "sub/ok.md" in names and "index.md" in names
+bad += 0 if ok else 1
+print(f"{'PASS' if ok else 'FAIL'}  {'neighbours of a secret are still collected':<52} "
+      f"want=present {sorted(n for n in names if n.endswith('.md'))[:3]}")
+# The SAME walk without for_archive keeps them, because search runs through it
+# and a search that cannot see .env is a search that lies about the filesystem.
+# This pair is the entire difference between "readable" and "downloadable in
+# bulk", so it is asserted rather than left to the flag's name.
+_search_members, _ = safepath.collect("docs", "", max_entries=10_000, max_total=10**12)
+_search_names = {m.res.relpath for m in _search_members}
+ok = ".env" in _search_names and "key.pem" in _search_names
+bad += 0 if ok else 1
+print(f"{'PASS' if ok else 'FAIL'}  {'...but the SEARCH walk still sees them':<52} "
+      f"want=present {'.env' in _search_names}")
 ok = "sub/ok.md" in names
 bad += 0 if ok else 1
 print(f"{'PASS' if ok else 'FAIL'}  {'but ordinary files ARE collected':<52} want=present {len(members)} members")
@@ -362,26 +424,28 @@ def _load(policy_text, label, want_fail):
 # FAIL CLOSED. Each of these must stop the service, because the alternative is a
 # service running with a policy nobody wrote - and the only safe fallback is
 # "serve nothing", which looks broken and gets worked around.
+_DENY = '[deny]\ncomponents=[]\n'
+_SENS = '[sensitive]\nfile_patterns=[]\n'
 _load("this is not toml [[[", "malformed policy is refused", True)
-_load('[deny]\ncomponents=[]\nfile_patterns=[]\n[write]\nsuffixes=[]\n',
-      "a policy with no roots is refused", True)
-_load('[roots.x]\npath="/nope/not/here"\n[deny]\ncomponents=[]\n'
-      'file_patterns=[]\n[write]\nsuffixes=[]\n',
+_load(_DENY + _SENS, "a policy with no roots is refused", True)
+_load('[roots.x]\npath="/nope/not/here"\n' + _DENY + _SENS,
       "a root that is not mounted is refused", True)
-_load('[roots.x]\npath="/tmp"\n[deny]\ncomponents=[]\nfile_patterns=[]\n'
-      '[snapshots]\npath="/tmp"\n',
-      "a policy missing [write] is refused", True)
+# [write] is now OPTIONAL - it carries only the caution table, and a policy with
+# no cautions is a policy that warns about nothing, not one that permits nothing.
+# [sensitive] is the one that must be present, because a missing marker list
+# would silently stop labelling credentials.
+_load('[roots.x]\npath="/tmp"\n' + _DENY + '[snapshots]\npath="/tmp"\n',
+      "a policy missing [sensitive] is refused", True)
+_load('[roots.x]\npath="/tmp"\n' + _DENY + _SENS + '[snapshots]\npath="/tmp"\n',
+      "a policy with no [write] LOADS - cautions are optional", False)
 # The undo net is checked like a root: declared but not mounted stops the
 # service. A net that is silently absent is discovered on the day it was needed.
-_load('[roots.x]\npath="/tmp"\n[deny]\ncomponents=[]\nfile_patterns=[]\n'
-      '[write]\nsuffixes=[".md"]\n',
+_load('[roots.x]\npath="/tmp"\n' + _DENY + _SENS,
       "a policy with no [snapshots] is refused", True)
-_load('[roots.x]\npath="/tmp"\n[deny]\ncomponents=[]\nfile_patterns=[]\n'
-      '[write]\nsuffixes=[".md"]\n[snapshots]\npath="/nope/not/here"\n',
+_load('[roots.x]\npath="/tmp"\n' + _DENY + _SENS + '[snapshots]\npath="/nope/not/here"\n',
       "an unmounted snapshot directory is refused", True)
 # ...and a valid one loads, or the five above would pass for the wrong reason.
-_load('[roots.x]\npath="/tmp"\n[deny]\ncomponents=[]\nfile_patterns=[]\n'
-      '[write]\nsuffixes=[".md"]\n[snapshots]\npath="/tmp"\n',
+_load('[roots.x]\npath="/tmp"\n' + _DENY + _SENS + '[snapshots]\npath="/tmp"\n',
       "a valid policy loads", False)
 
 # The shipped policy must still say what the boundary needs it to say.
@@ -398,10 +462,45 @@ ok = _ship["roots"]["home"].get("deny_toplevel_dots") is True
 bad += 0 if ok else 1
 print(f"{'PASS' if ok else 'FAIL'}  {'home still denies top-level dot entries':<52} "
       f"want=True    {_ship['roots']['home'].get('deny_toplevel_dots')}")
-ok = ".toml" not in _ship["write"]["suffixes"]
+# The write allowlist is gone on purpose; assert it has not crept back, because
+# re-adding it would silently make every non-prose file read-only again.
+ok = "suffixes" not in _ship.get("write", {})
 bad += 0 if ok else 1
-print(f"{'PASS' if ok else 'FAIL'}  {'the policy file cannot rewrite itself':<52} "
-      f"want=absent  .toml in write.suffixes: {'.toml' in _ship['write']['suffixes']}")
+print(f"{'PASS' if ok else 'FAIL'}  {'no extension allowlist has crept back':<52} "
+      f"want=absent  {sorted(_ship.get('write', {}))}")
+# policy.toml is writable now, so the thing that used to be a refusal has to be
+# a warning instead - and the warning has to be the loud one.
+#
+# Asserted against the SHIPPED table rather than through caution_for(), which is
+# bound to this file's small fixture policy. Getting that wrong would have made
+# these pass by describing the fixture.
+def _ship_caution(rel):
+    """First matching shipped rule, by the same first-match-wins order."""
+    import fnmatch as _fn
+    for r in _ship.get("write", {}).get("caution", []):
+        for pat in r["match"]:
+            tail = pat[3:] if pat.startswith("**/") else None
+            hit = (_fn.fnmatch(rel, tail) or _fn.fnmatch(rel, "*/" + tail)) if tail \
+                else _fn.fnmatch(rel, pat)
+            if hit:
+                return r
+    return None
+
+for rel, want_level, needle in [
+    ("apps/portal-files/policy.toml", "critical", "fails closed"),
+    # The ordering that makes the whole table correct: the most dangerous file in
+    # the repo must not fall through to the generic YAML rule below it.
+    ("edge/dynamic/portal-api.yml", "critical", "template"),
+    ("monitoring/prometheus.yml", "caution", "running service"),
+    ("scripts/backup.sh", "critical", "runs as a command"),
+    ("docs/kb/access.md", None, ""),
+]:
+    _c = _ship_caution(rel)
+    got = _c["level"] if _c else None
+    ok = got == want_level and (not needle or needle in " ".join(_c["note"].split()).lower())
+    bad += 0 if ok else 1
+    print(f"{'PASS' if ok else 'FAIL'}  {'caution: ' + rel:<52} "
+          f"want={str(want_level):<8} {got}")
 
 print("\n── the advisory scanner: ADVISORY, and measured ────────────────────")
 # scan_for_secret marks a file; it never refuses one. That was decided by running
@@ -436,9 +535,16 @@ for label, text in _tp:
 
 # The file that proved a name-based list is a filter, not a boundary: it was
 # served to an authenticated viewer WITH a live client secret in it, and nothing
-# in its name suggested anything. Now denied by name.
+# in its name suggested anything.
+#
+# It is served again now, deliberately, and the same fact reads differently: a
+# name list was a poor WALL and is a perfectly good LABEL, because a label that
+# misses a file costs a missing warning rather than a leak.
 open(os.path.join(root, "realm-devbox.json"), "w").write('{"secret":"x"}')
-check("keycloak realm export refused",  R("realm-devbox.json"), expect_refused=True)
+check("keycloak realm export served",   R("realm-devbox.json"), expect_refused=False)
+_m = safepath.is_sensitive_name("realm-devbox.json")
+bad += 0 if _m else 1
+print(f"{'PASS' if _m else 'FAIL'}  {'  ...and marked sensitive':<52} want=True    {_m}")
 
 print("\n── malformed input ─────────────────────────────────────────────────")
 check("empty path",                      R(""),                 expect_refused=True)

--- a/apps/portal-files/policy.toml
+++ b/apps/portal-files/policy.toml
@@ -260,6 +260,16 @@ the file is not applying it. `docker compose up -d` on that file is the apply \
 step; `docker restart` is not, because a label is fixed at creation time."""
 
 [[write.caution]]
+match = [".env", "**/.env"]
+level = "critical"
+note = """Every service reads this at START, so nothing here is live until the \
+stack it belongs to is brought up again. Two values bite harder than the rest: \
+BOX_IP is baked into Keycloak's issuer and redirect URI, so changing it without \
+re-running `just up-auth` makes every login fail with a mismatch nobody can read \
+from the error; and OAUTH2_COOKIE_SECRET invalidates every existing session the \
+moment it changes."""
+
+[[write.caution]]
 match = ["**/policy.toml"]
 level = "critical"
 note = """This file is the access model for the service that is about to write \

--- a/apps/portal-files/policy.toml
+++ b/apps/portal-files/policy.toml
@@ -15,9 +15,13 @@
 #      the file parses, every root exists, and the deny rules still refuse the
 #      things they were written for.
 #
-#   3. It is not editable through the explorer. `.toml` is not in
-#      [write].suffixes, so the file that defines the write rules cannot be
-#      rewritten by the thing it governs.
+#   3. IT IS NOW EDITABLE THROUGH THE EXPLORER, and it was not before. `.toml`
+#      used to be absent from [write].suffixes, so the file defining the write
+#      rules could not be rewritten by the thing it governs. That allowlist is
+#      gone (see [write]), so this file is writable like any other - and it is
+#      marked `critical` in [[write.caution]] for the reason rule 1 gives: it
+#      fails closed, so a bad edit here does not produce a permissive service,
+#      it produces one that will not start, repaired from a shell on the box.
 #
 # The paths below are CONTAINER paths. They are mounted in compose.yml, and a
 # root declared here that is not mounted there is a startup error rather than an
@@ -94,17 +98,37 @@ components = [
   ".next", ".turbo", ".cache", "target",
 ]
 
-# Files never served, matched on the FILENAME rather than a path component.
+# ── sensitive ───────────────────────────────────────────────────────────────
 #
-# This exists because a component-only list cannot see `.env` or `key.pem` -
-# both are FILES. That gap was live: a survey found ~/stacks/.env holding 19 real
-# secret values and a real TLS private key under ~/projects, and neither was
-# caught by the directory rules.
+# THESE FILES ARE SERVED. The list marks them; it no longer hides them.
 #
-# `realm-*.json` is here because auth/realm-devbox.json was served to an
-# authenticated viewer WITH a live Keycloak client secret in it. Nothing in its
-# name suggests anything, and every other pattern missed it. It is the case that
-# proves a name list catches the files somebody thought of, and nothing else.
+# It used to be `[deny].file_patterns` - a refusal - and the reasoning was that a
+# component-only list cannot see `.env` or `key.pem`, which is true and is why
+# the patterns are still here. What changed on 2026-08-17 is what happens when
+# one matches: the file is labelled, not withheld. This is one box, reached over
+# a tailnet, owned by the person reading it, and a file explorer that hides the
+# owner's own `.env` from them is not protecting anybody - it is teaching them
+# that Bothy cannot be trusted with the interesting half of the box.
+#
+# ONE CONSEQUENCE THAT IS NOT "MY BOX, MY FILES", and it should be read before
+# deciding this was obvious: ~/stacks/.env contains OAUTH2_COOKIE_SECRET. Anyone
+# who can read it can mint a session cookie for any role, so on this deployment
+# `viewer` is now worth the same as `operator`. That is fine while one person
+# holds all four roles and it stops being fine the moment a second person holds
+# only `viewer`. If that day comes, the answer is a role gate on this list -
+# `operator` to read a marked file - not a return to hiding them.
+#
+# The second thing worth naming: ~ holds credentials to OTHER systems - SSH
+# keys, a GitHub token, Claude's OAuth credentials. Tailscale protects the wire,
+# not the blast radius, and those keys open machines that are not this one.
+# `~` is a read-only root, so they cannot be changed through Bothy, only read.
+#
+# `realm-*.json` is here because auth/realm-devbox.json carries a live Keycloak
+# client secret and nothing in its name suggests it. It is the case that proves a
+# name list catches the files somebody thought of and nothing else - which is now
+# an argument about the LABEL being incomplete rather than about the wall being
+# incomplete, and a label that is sometimes missing is a much cheaper failure.
+[sensitive]
 file_patterns = [
   ".env", ".env.*", "*.env",
   "*.pem", "*.key", "*.p12", "*.pfx", "*.jks", "*.keystore",
@@ -125,7 +149,9 @@ file_patterns = [
 
 # Patterns above that describe a WORD rather than a file format, and so must not
 # apply to prose. Found by running the walk over the real tree: a documentation
-# page called "Change Password.md" was being hidden as a secret.
+# page called "Change Password.md" was being MARKED as a secret. It mattered more
+# when the mark was a refusal; it still matters, because a label on every page
+# that mentions a password is a label nobody reads.
 #
 # Only true documentation formats are exempt. `.txt` deliberately is NOT -
 # `db_password.txt` is exactly the shape of a file someone leaves a credential
@@ -133,10 +159,10 @@ file_patterns = [
 wordy_patterns = ["*secret*", "*password*"]
 prose_suffixes = [".md", ".markdown", ".rst"]
 
-# Explicit exceptions, by exact name. A committed `.env.example` is a TEMPLATE
-# full of placeholders - the file you read to learn what to set - and hiding it
-# makes the explorer worse for no gain. Listed by NAME so the exception can never
-# widen: `.env.example` is served, `.env.production` is not.
+# Explicit exceptions, by exact name: files that match a pattern above but carry
+# no credential. A committed `.env.example` is a TEMPLATE full of placeholders -
+# the file you read to learn what to set - so marking it would be crying wolf on
+# the one .env-shaped file that is safe by construction.
 allow_files = [
   ".env.example", ".env.sample", ".env.template", ".env.test.example",
   ".env.local.template", ".env.production.template", ".env.defaults",
@@ -171,14 +197,108 @@ max_age_days = 30
 # ── write ───────────────────────────────────────────────────────────────────
 
 [write]
-# A blast-radius limit, not a parsing concern. Without it, "edit a doc" also
-# means "rewrite compose.yml", "rewrite a shell script that cron runs", or "drop
-# a .py that something imports".
+# THERE IS NO EXTENSION ALLOWLIST. Removed 2026-08-17, on purpose.
 #
-# `.svg` and `.html` are here because they have viewers now. Worth stating: a
-# writable .html in a repo that some OTHER app serves is a stored-XSS vector in
-# THAT app. That is a property of the repo rather than of this service, but it is
-# a real widening of what the editor can reach.
-suffixes = [
-  ".md", ".markdown", ".txt", ".rst", ".svg", ".html", ".htm", ".xml",
-]
+# There used to be one - .md, .txt, .rst, .svg, .html, .xml - justified as a
+# blast-radius limit: "without it, edit a doc also means rewrite compose.yml".
+# That is true, and it is not this project's call to make. Bothy is dev-box
+# tooling for the person who owns the box. If they want to edit a compose file
+# and restart it, that is the job, not an accident to be prevented - and a tool
+# that refuses is a tool they work around with `vim`, which has none of the
+# things this write path provides.
+#
+# WHAT THE REFUSAL WAS ACTUALLY COSTING. Every write through this service gets a
+# role gate at the edge, a baseMtime conflict check, a snapshot of the outgoing
+# bytes, and an audit line naming who did it. Editing the same file by any other
+# means gets none of those. So the allowlist did not stop the dangerous edit; it
+# stopped the dangerous edit from being SAFE and ATTRIBUTED.
+#
+# WHAT IS STILL REFUSED, and why those are different in kind:
+#   · [deny] below. Secrets are not "risky to edit", they are files this service
+#     must never hand out AT ALL, read or write. Unchanged.
+#   · Paths outside a root, and writes through a symlink. Containment is not a
+#     policy preference, it is the boundary the whole service rests on.
+#   · Read-only roots (~/projects, ~). Declared, not incidental.
+#   · Anyone without the `editor` role. Enforced at the edge, not here.
+#
+# In place of refusing, the service now SAYS WHAT WILL HAPPEN - see
+# [[write.caution]]. Arch's bargain: you may do it, and you will be told what it
+# does first.
+#
+# STILL MISSING, and worth naming rather than implying it is handled: if an edit
+# does break something, the repair paths today are the snapshot this service
+# takes (see [snapshots]) and git, and both are file-level. There is no terminal
+# in Bothy - `shell` is a role granted to nobody - so a change that stops a
+# container from starting is repaired from a real shell on the box. That is the
+# gap a terminal would close, and it is the reason to build one.
+
+# What an edit COSTS, stated before it is made. These do not refuse anything.
+#
+# Ordered most specific first; the first match wins, so a rule for one file
+# inside a directory goes above the rule for the directory. `match` globs are
+# matched against the path RELATIVE TO ITS ROOT, with `**` crossing directories.
+#
+# The note is the whole point, so it says what breaks and how it is noticed -
+# not "be careful". A warning that does not name a consequence is decoration,
+# and it trains people to click past the ones that matter.
+
+[[write.caution]]
+match = ["edge/dynamic/*.yml", "edge/dynamic/*.yaml"]
+level = "critical"
+note = """Traefik renders these as Go templates BEFORE parsing the YAML, and it \
+does not skip comments. A doubled brace anywhere in the file - including inside \
+a comment - voids the whole file: no routers, no middlewares, while the file on \
+disk still looks perfect. Nothing errors and the routes simply stop existing. \
+Run `just verify` after saving; check 5b exists to catch exactly this."""
+
+[[write.caution]]
+match = ["**/compose.yml", "**/compose.yaml", "**/compose.*.yml", "docker-compose*.yml"]
+level = "critical"
+note = """This defines containers. A YAML error stops the stack coming up, and a \
+changed label or port does nothing until the container is RECREATED - editing \
+the file is not applying it. `docker compose up -d` on that file is the apply \
+step; `docker restart` is not, because a label is fixed at creation time."""
+
+[[write.caution]]
+match = ["**/policy.toml"]
+level = "critical"
+note = """This file is the access model for the service that is about to write \
+it. It fails closed - a malformed policy stops the service starting rather than \
+starting it permissively - so the failure mode is an editor that will not come \
+back, repaired from a shell on the box."""
+
+[[write.caution]]
+match = ["**/*.sh", "scripts/**", "host/**", ".github/workflows/**", "justfile", "Justfile"]
+level = "critical"
+note = """This runs as a command, some of it on a schedule and some of it as \
+root. An edit here is not configuration, it is code that something will execute \
+without being asked again."""
+
+[[write.caution]]
+match = ["**/Dockerfile", "**/Dockerfile.*", "**/nginx.conf", "**/*.conf"]
+level = "critical"
+note = """This is built or served rather than read. It takes effect on a rebuild \
+or a reload, so a mistake here is usually noticed as "the container will not \
+start" some time after the edit that caused it."""
+
+[[write.caution]]
+match = ["monitoring/**", "auth/**", "data/**", "**/*.yml", "**/*.yaml", "**/*.toml", "**/*.json", "**/*.ini"]
+level = "caution"
+note = """Configuration for a running service. It is read when that service \
+starts or reloads, so the change is not live yet, and a syntax error surfaces as \
+a service that stops rather than as an error here."""
+
+[[write.caution]]
+match = ["**/*.css"]
+level = "caution"
+note = """A stylesheet the portal serves. Custom themes under \
+apps/portal-next/data/themes are picked up on reload; anything under src/ is \
+compiled into the bundle and needs a rebuild to take effect."""
+
+[[write.caution]]
+match = ["**/*.html", "**/*.htm", "**/*.svg"]
+level = "caution"
+note = """A document some OTHER application may serve. If it does, a script \
+inside it runs in THAT application's origin, with whatever session the reader \
+has there. Bothy serves raw bytes only from the sandbox origin on :8100, which \
+is why it is safe HERE and not necessarily safe there."""

--- a/apps/portal-files/safepath.py
+++ b/apps/portal-files/safepath.py
@@ -75,8 +75,8 @@ def _load_policy(path: str) -> dict:
                 f"root {name!r} points at {cfg['path']}, which is not a directory "
                 f"- is it mounted in compose.yml?")
 
-    for section, key in (("deny", "components"), ("deny", "file_patterns"),
-                         ("write", "suffixes")):
+    for section, key in (("deny", "components"),
+                         ("sensitive", "file_patterns")):
         if not isinstance(doc.get(section, {}).get(key), list):
             raise PolicyError(f"policy is missing [{section}].{key}")
 
@@ -116,18 +116,17 @@ ROOT_POLICY: dict[str, dict] = {
 }
 
 DENY_COMPONENTS = frozenset(POLICY["deny"]["components"])
-DENY_FILE_PATTERNS = tuple(POLICY["deny"]["file_patterns"])
-ALLOW_FILES = frozenset(POLICY["deny"].get("allow_files", []))
-_WORDY_PATTERNS = frozenset(POLICY["deny"].get("wordy_patterns", []))
-_PROSE_SUFFIXES = frozenset(POLICY["deny"].get("prose_suffixes", []))
-WRITABLE_SUFFIXES = frozenset(POLICY["write"]["suffixes"])
+SENSITIVE_PATTERNS = tuple(POLICY["sensitive"]["file_patterns"])
+NOT_SENSITIVE = frozenset(POLICY["sensitive"].get("allow_files", []))
+_WORDY_PATTERNS = frozenset(POLICY["sensitive"].get("wordy_patterns", []))
+_PROSE_SUFFIXES = frozenset(POLICY["sensitive"].get("prose_suffixes", []))
 
 SNAPSHOT_DIR: str = POLICY["snapshots"]["path"]
 SNAPSHOT_KEEP = int(POLICY["snapshots"].get("keep", 20))
 SNAPSHOT_MAX_AGE = int(POLICY["snapshots"].get("max_age_days", 30)) * 86400
-# A ceiling on what is worth keeping a copy of. Every writable suffix is a text
-# format, but nothing stops a 200 MB generated .html, and filling the disk to
-# protect an edit would be a poor trade.
+# A ceiling on what is worth keeping a copy of. Now that any suffix may be
+# written, this is the only thing standing between the undo net and a 200 MB
+# file, and filling the disk to protect one edit would be a poor trade.
 SNAPSHOT_MAX_BYTES = 16 * 1024 * 1024
 # Returned when a save destroys nothing, and distinct from None, which means the
 # copy was WANTED and did not happen. The caller logs the second and ignores the
@@ -495,22 +494,57 @@ class PathRefused(Exception):
 # in, while `.md` and `.rst` are formats you write ABOUT credentials in. The
 # content scanner still inspects these files and can flag them as sensitive; it
 # just no longer removes them from the explorer entirely.
-def is_denied_name(basename: str) -> bool:
-    """True if this filename must never be served.
+def is_sensitive_name(basename: str) -> bool:
+    """True if this filename is the shape of a credential store.
+
+    A LABEL, not a refusal - see [sensitive] in policy.toml. The client is told,
+    and decides how loudly to say so.
 
     Case-insensitive, because the filesystem here is case-sensitive but the
     person who named `Key.PEM` did not mean something different by it.
     """
     name = basename.lower()
-    if name in ALLOW_FILES:
+    if name in NOT_SENSITIVE:
         return False
     prose = os.path.splitext(name)[1] in _PROSE_SUFFIXES
-    for pat in DENY_FILE_PATTERNS:
+    for pat in SENSITIVE_PATTERNS:
         if prose and pat in _WORDY_PATTERNS:
             continue
         if fnmatch.fnmatch(name, pat):
             return True
     return False
+
+
+CAUTION_RULES = tuple(
+    {"match": tuple(r["match"]), "level": r["level"], "note": " ".join(r["note"].split())}
+    for r in POLICY.get("write", {}).get("caution", [])
+)
+
+
+def caution_for(relpath: str) -> dict | None:
+    """What editing this path costs, or None when the answer is "nothing".
+
+    FIRST MATCH WINS, so policy.toml is ordered most specific first - the rule
+    for `edge/dynamic/*.yml` sits above the one for `**/*.yml`, and reordering
+    them silently downgrades the most dangerous file in the repo to a generic
+    note. That ordering is the only thing making the table correct, which is why
+    it is stated here as well as there.
+
+    Matched against the path RELATIVE TO ITS ROOT. fnmatch has no notion of `**`
+    - its `*` already crosses `/` - so a `**/` prefix is normalised to "either
+    this file at the top, or anywhere below", which is what a reader means by it.
+    """
+    rel = relpath.lstrip("/")
+    for rule in CAUTION_RULES:
+        for pat in rule["match"]:
+            if pat.startswith("**/"):
+                tail = pat[3:]
+                hit = fnmatch.fnmatch(rel, tail) or fnmatch.fnmatch(rel, "*/" + tail)
+            else:
+                hit = fnmatch.fnmatch(rel, pat)
+            if hit:
+                return {"level": rule["level"], "note": rule["note"]}
+    return None
 
 
 def content_policy(basename: str, head: bytes) -> tuple[str, str]:
@@ -859,17 +893,25 @@ def resolve(root_key: str, rel: str, *, for_write: bool = False) -> Resolved:
                 "top-level dot entries are excluded in this root - they are "
                 "config and credentials")
 
-    # Then the FILENAME, which is where secrets actually live. Checked on the
-    # resolved basename for the same reason: a symlink named `notes.md` pointing
-    # at `.env` must be refused for what it reaches, not for what it is called.
-    if is_denied_name(os.path.basename(candidate)):
-        raise PathRefused("this file is excluded as a possible secret")
+    # The FILENAME is no longer a refusal. It used to be - a name matching the
+    # secret patterns was excluded outright - and [sensitive] in policy.toml
+    # records why that became a LABEL instead. The check still runs, on the
+    # RESOLVED basename for the reason it always did: a symlink named `notes.md`
+    # pointing at `.env` must be judged by what it reaches, not what it is
+    # called. The result now travels to the client as `sensitive` rather than
+    # stopping here.
 
     if for_write:
-        if os.path.splitext(candidate)[1].lower() not in WRITABLE_SUFFIXES:
-            raise PathRefused(
-                "only " + ", ".join(sorted(WRITABLE_SUFFIXES)) + " files may be written"
-            )
+        # NO EXTENSION CHECK. There was one - an allowlist of prose formats - and
+        # [write] in policy.toml records why it is gone. In short: it did not
+        # stop the risky edit, it stopped the risky edit from going through the
+        # path that snapshots, attributes and conflict-checks it.
+        #
+        # Everything below this line still applies, and none of it is a
+        # preference: containment was proved above, the symlink rule is next, the
+        # root must be writable, and the edge decides whether this session holds
+        # `editor` at all.
+        #
         # Writing THROUGH a symlink would let someone plant a link inside the root
         # and have us overwrite its target. The realpath check above already
         # proves the destination is inside the root, so this only forbids the
@@ -915,6 +957,11 @@ def collect(
     max_member: int = ARCHIVE_MAX_MEMBER,
     max_depth: int = ARCHIVE_MAX_DEPTH,
     walk_seconds: float = ARCHIVE_WALK_SECONDS,
+    # True only for the two archive endpoints. See the `for_archive` check in the
+    # loop below: credential files are readable one at a time and excluded from
+    # bulk downloads, and this flag is the whole difference between those two
+    # statements. Defaulting it to True would silently make SEARCH lie.
+    for_archive: bool = False,
 ) -> tuple[list[Member], list[dict]]:
     """Walk a subtree and return (members, skipped) with every check applied.
 
@@ -1028,6 +1075,28 @@ def collect(
                 res = resolve(root_key, os.path.relpath(full, base.root_dir))
             except PathRefused as e:
                 skip(shown, str(e))
+                continue
+            # AN ARCHIVE IS NOT A READ, and this is the one place the two come
+            # apart on purpose.
+            #
+            # [sensitive] in policy.toml decided that a credential file is served
+            # and marked rather than hidden: opening ~/stacks/.env in the
+            # explorer is a deliberate act by the person who owns it. Putting the
+            # same file into a zip is not - it is a side effect of downloading
+            # the folder above it, and the result is a file that travels. The
+            # bulk path has no moment where anyone looks at what is inside.
+            #
+            # So the mark that is advisory everywhere else is a REFUSAL here, and
+            # it is reported in `skipped` rather than applied silently: an archive
+            # that quietly omits things is worse than one that says what it left
+            # out, because the omission is discovered by the person restoring it.
+            #
+            # OFF BY DEFAULT, and that is not timidity. This walk is shared with
+            # SEARCH, which is a read: searching the box for a string and being
+            # told it does not appear - when it appears in .env - is the walk
+            # lying about the filesystem. Only the archive endpoints pass True.
+            if for_archive and is_sensitive_name(os.path.basename(res.abspath)):
+                skip(shown, "looks like a credential store - excluded from archives")
                 continue
             try:
                 fd, st = safe_open(res.abspath)

--- a/apps/portal-next/web/src/lib/files.ts
+++ b/apps/portal-next/web/src/lib/files.ts
@@ -126,6 +126,20 @@ export interface FileRead {
    * credential" is worth saying once, loudly, and not worth blocking on.
    */
   sensitive?: string | null;
+  /**
+   * What editing THIS path costs, decided server-side from the path alone
+   * (safepath.caution_for, declared in policy.toml's [[write.caution]]).
+   *
+   * It replaced a refusal. The editor used to decline to write anything that
+   * was not prose, which did not stop the edit - it moved it to `vim`, where
+   * there is no snapshot, no conflict check and no audit line. So the service
+   * permits the write and states the consequence, and this is that statement.
+   *
+   * `critical` is confirmed before saving; `caution` is shown and not confirmed.
+   * Absent means an ordinary file, and most files are ordinary - a warning on
+   * everything is a warning on nothing.
+   */
+  caution?: { level: 'caution' | 'critical'; note: string } | null;
 }
 
 export interface WriteResult {

--- a/apps/portal-next/web/src/pages/files/Files.tsx
+++ b/apps/portal-next/web/src/pages/files/Files.tsx
@@ -904,6 +904,28 @@ export function Files() {
     const f = d.file;
     const draft = d.draft;
     const lang = langFor(f.path, f.lang);
+
+    // THE CONFIRMATION THAT REPLACED THE REFUSAL.
+    //
+    // The service used to decline to write anything that was not prose. It does
+    // not any more - see [write] in policy.toml - so the last thing standing
+    // between a typo and a stack that will not come up is this sentence, and it
+    // has to name the consequence rather than ask "are you sure?".
+    //
+    // Only `critical`. A confirm on every YAML file is a dialog people dismiss
+    // without reading, which would cost the warning its meaning on exactly the
+    // files it exists for.
+    if (f.caution?.level === 'critical' && !confirm(
+      `${f.path}\n\n${f.caution.note}\n\n`
+      + 'The previous contents are kept in the undo snapshot, and the file is in '
+      + 'git, so this is recoverable.\n\nSave anyway?')) {
+      patchDoc(id, (c) => ({
+        ...c,
+        notice: { tone: 'info', text: 'Not saved - you cancelled.' },
+      }));
+      return;
+    }
+
     patchDoc(id, (c) => ({ ...c, saving: true, notice: null }));
     // file.mtime is what this TAB read. Sending it is the whole conflict
     // guarantee - see docs/kb/editor-drafts.md.

--- a/apps/portal-next/web/src/pages/files/Inspector.tsx
+++ b/apps/portal-next/web/src/pages/files/Inspector.tsx
@@ -30,7 +30,7 @@
 
 import { useCallback, useState } from 'react';
 import {
-  Check, Copy, GitCommitVertical, Lock, ShieldAlert,
+  Check, Copy, GitCommitVertical, Lock, ShieldAlert, TriangleAlert,
 } from 'lucide-react';
 import { fmtBytes, relDate, type Commit, type FileRead } from '../../lib/files';
 import { Tooltip } from '../../components/Tooltip';
@@ -116,7 +116,28 @@ export function Inspector({
                 {file.sensitive && (
                   <div className="fx-sensitive" role="note">
                     <ShieldAlert size={15} aria-hidden="true" />
-                    <span><b>Looks sensitive.</b> {file.sensitive}</span>
+                    <span>
+                      <b>Looks sensitive.</b> {file.sensitive}
+                      {' '}It is shown because this is your box, and it is left out
+                      of folder downloads because those travel.
+                    </span>
+                  </div>
+                )}
+
+                {/* WHAT AN EDIT COSTS, said before the edit rather than after.
+                    This is the half that replaced the extension allowlist: the
+                    service will write the file now, so the interface owes the
+                    reader the consequence. `critical` is also confirmed at save
+                    time; this is the standing statement, not the dialog. */}
+                {file.caution && (
+                  <div className={`fx-caution is-${file.caution.level}`} role="note">
+                    <TriangleAlert size={15} aria-hidden="true" />
+                    <span>
+                      <b>{file.caution.level === 'critical'
+                        ? 'Editing this is load-bearing.'
+                        : 'This configures something that is running.'}</b>
+                      {' '}{file.caution.note}
+                    </span>
                   </div>
                 )}
 

--- a/apps/portal-next/web/src/pages/files/inspector.css
+++ b/apps/portal-next/web/src/pages/files/inspector.css
@@ -119,3 +119,26 @@
 }
 .bothy-files .fx-sha:hover { color: var(--fg); border-color: var(--line-strong); }
 .bothy-files .fx-sha .mono { font-size: 10.5px; }
+
+/* WHAT AN EDIT COSTS. Same shape as .fx-sensitive next to it, two tones.
+   `caution` borrows the warn tokens; `critical` borrows the down ones - and that
+   is the one place in the app where a status colour is used for something other
+   than a service's state.
+
+   It is legal for the same reason the reader's callouts are: this rail describes
+   a FILE, and there is no service status anywhere on it, so there is nothing for
+   an amber panel to be confused with. If a service's state ever appears in the
+   inspector, this borrowing is void and these need their own tokens. */
+.bothy-files .fx-caution {
+  display: flex; gap: 8px; align-items: flex-start;
+  margin: 10px 12px 0; padding: 8px 10px; font-size: 11.5px; line-height: 1.45;
+  border-radius: var(--r-sm);
+  background: var(--st-warn-bg); border: 1px solid var(--st-warn-line);
+  color: var(--st-warn-fg);
+}
+.bothy-files .fx-caution.is-critical {
+  background: var(--st-down-bg); border-color: var(--st-down-line);
+  color: var(--st-down-fg);
+}
+.bothy-files .fx-caution svg { flex: none; margin-top: 1px; }
+.bothy-files .fx-caution b { font-weight: 700; }


### PR DESCRIPTION
Your call, implemented: Bothy is dev-box tooling for the person who owns the box, so a dangerous edit gets explained rather than declined.

## Two rules removed

**The extension allowlist is gone.** `[write].suffixes` permitted `.md .txt .rst .svg .html .xml`, so a compose file could be read and not written. It never stopped the risky edit — it moved it to `vim`, where there is no snapshot, no conflict check and no audit line. The allowlist did not stop the dangerous edit; it stopped the dangerous edit from being *safe and attributed*.

**Secrets are served and marked.** The name patterns that refused `.env`, `*.pem`, `realm-*.json` now label instead. Every pattern is unchanged and still tested — what changed is that a miss now costs a missing warning rather than a leak, which is the failure a name list is actually suited to.

Recorded in `policy.toml` rather than implied: `~/stacks/.env` carries `OAUTH2_COOKIE_SECRET`, so reading it is equivalent to holding every role. Fine while one person holds all four; the fix that day is a role gate on the marked list, not a return to hiding.

## An archive is not a read

Opening `.env` is a deliberate act. A zip of the folder above it is a side effect, and the result travels somewhere nobody re-reads it. So the mark that is advisory everywhere else is a **refusal** in `collect(for_archive=True)`, reported in `skipped` rather than applied silently.

Verified live: `.env` reads at 1770 chars; a zip of the whole `stacks` root has **341 members, 7 skipped, none credential-shaped**.

The flag defaults to `False` on purpose — that walk is shared with **search**, and a search that cannot see `.env` is a search that lies about the filesystem. The check caught that within a minute of the first version.

## In place of refusing

`[[write.caution]]` says what an edit costs, most-specific-first:

| | |
|---|---|
| `edge/dynamic/*.yml` | critical — Traefik renders it as a Go template, and a doubled brace *inside a comment* voids the whole file silently |
| `**/compose.yml` | critical — editing is not applying; a label is fixed at container creation |
| `.env` | critical — nothing is live until restart; `BOX_IP` breaks every login without `just up-auth` |
| `**/policy.toml` | critical — fails closed, so a bad edit means a service that will not start |
| `monitoring/**`, `**/*.yml` | caution — config for something running |
| prose | nothing at all |

The ordering is the only thing making the table correct, so it is asserted. `critical` is confirmed at save time with the consequence named — not "are you sure?" — plus the two facts that make it recoverable. Only critical: a confirm on every YAML file is a dialog people dismiss without reading.

## Still missing, named rather than implied

If an edit does break something, the repair paths are the snapshot and git — both file-level. A change that stops a container starting is repaired from a real shell on the box. **That is the gap a terminal closes**, and it is written into `policy.toml` as the reason to build one.

## Verified

- `just files-check` **all pass** (every suite), `just verify` **23/23**, portal checks 0 FAIL.
- Every test that encoded the old refusals now asserts the new behaviour instead of being deleted — they are what notices if writes are ever re-narrowed by extension.
- `served-secrets.baseline` regenerated: **54 accepted, 0 new**. The exposure stays visible rather than becoming folklore.
- Live: `edge/dynamic/portal-api.yml` reports `Writable: yes` with the critical banner — it was not writable at all before; `.env` opens with the sensitive banner.

## Also fixed

`bytes_e2e.py` pointed at `docs/assets/portal-overview.png`, renamed to `overview.png` some commits ago — so its PNG assertions had been failing for reasons unrelated to anything they test. A check that cannot pass is as useless as one that cannot fail.