### PR TITLE
feat(theme): a theme you add is a file you drop in a folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ edge/dynamic/portal-prom.yml
 # from git. The portal treats an absent file as a supported configuration and
 # renders normally without it (see lib/api.ts).
 apps/portal-next/data/projects.json
+# User themes: .css files somebody dropped into apps/portal-next/data/themes on
+# their own box. Per-BOX by definition - the whole point is that they work
+# without a source tree - so they are not this repository's business. The
+# directory itself is tracked (.gitkeep) so a fresh clone has somewhere to put
+# one, and so nginx has a directory to list rather than a 404.
+apps/portal-next/data/themes/*.css
 
 # Agent worktrees. Real git checkouts under the repo - never content of it.
 .claude/worktrees/

--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -32,8 +32,14 @@ mv "$OUT/routes.js" "$OUT/files-routes.mjs"
 (cd "$WEB" && npx tsc src/pages/files/titles.ts --ignoreConfig \
   --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
 mv "$OUT/titles.js" "$OUT/titles.mjs"
+(cd "$WEB" && npx tsc src/lib/contract.ts --ignoreConfig \
+  --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
+mv "$OUT/contract.js" "$OUT/contract.mjs"
+(cd "$WEB" && npx tsc src/lib/customThemes.ts --ignoreConfig \
+  --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
+mv "$OUT/customThemes.js" "$OUT/user-themes-mod.mjs"
 cp "$HERE/status-classifier.mjs" "$HERE/relations.mjs" "$HERE/redirect-table.mjs" \
-   "$HERE/titles-table.mjs" "$OUT/"
+   "$HERE/titles-table.mjs" "$HERE/theme-contract.mjs" "$HERE/user-themes.mjs" "$OUT/"
 
 echo "── truth table ─────────────────────────────────────────"
 node "$OUT/status-classifier.mjs"
@@ -67,7 +73,20 @@ echo "── every theme keeps the palette's contract ────────�
 # Reads index.css, shell.css and src/themes/*.css directly. Runs against the two
 # SHIPPED palettes as well as the named themes, on purpose: a rule that fails on
 # Bothy's own colours is a wrong rule, and this is where that gets found out.
-node "$HERE/theme-contract.mjs"
+#
+# The rules it applies come from lib/contract.ts, compiled above and shared with
+# the in-app theme editor. This is the only check that reads the source tree, so
+# it is run from $OUT (where the compiled contract is) and told where the tree
+# is, rather than inferring a sibling that is not there.
+node "$OUT/theme-contract.mjs" "$WEB/src"
+
+echo
+echo "── a theme dropped in by hand is read correctly ────────"
+# lib/customThemes.ts parses a .css file somebody wrote into
+# apps/portal-next/data/themes. Getting `appearance` wrong there is not cosmetic:
+# it decides which base palette the pre-paint script stamps, so a light theme
+# would render its first frame on the dark base.
+node "$OUT/user-themes.mjs"
 
 echo
 echo "── every colour comes from a token ─────────────────────"

--- a/apps/portal-next/checks/theme-contract.mjs
+++ b/apps/portal-next/checks/theme-contract.mjs
@@ -16,83 +16,29 @@
 // shared by every theme). The remaining 41 are the theme's own, and a theme must
 // declare all of them: a missing token silently inherits the base palette, which
 // is how you get a Gruvbox page with one blue button on it.
+//
+// THE RULES THEMSELVES ARE NOT IN HERE - they are in web/src/lib/contract.ts,
+// which imports nothing and is compiled by run.sh into the temp dir this file is
+// run from. They moved because the in-app theme editor has to show the SAME
+// warnings live while somebody picks colours, and two copies of a threshold is
+// one copy that will be wrong. What stays here is the part that is node's:
+// finding the stylesheets, parsing them, discovering the themes, printing lines.
+// Run it through checks/run.sh; on its own there is no compiled contract to
+// import.
 
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import {
+  evaluateTheme, requiredTokens, STRUCTURAL,
+} from './contract.mjs';
+
 const HERE = fileURLToPath(new URL('.', import.meta.url));
-const SRC = join(HERE, '..', 'web', 'src');
-
-// ── colour ──────────────────────────────────────────────────────────────────
-
-const srgbToLinear = (c) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
-
-/** Parse the value forms that actually appear in these files: #rgb, #rrggbb,
- *  #rrggbbaa, rgb()/rgba() in both comma and space syntax. Returns
- *  {r,g,b,a} in 0..1, or null for anything else (a var(), a gradient, a
- *  shadow recipe) - callers decide whether "not a flat colour" is a failure. */
-function parseColour(v) {
-  const s = String(v).trim();
-  const hex = s.match(/^#([0-9a-fA-F]{3,8})$/);
-  if (hex) {
-    let h = hex[1];
-    if (h.length === 3 || h.length === 4) h = [...h].map((c) => c + c).join('');
-    if (h.length !== 6 && h.length !== 8) return null;
-    const n = (i) => parseInt(h.slice(i, i + 2), 16) / 255;
-    return { r: n(0), g: n(2), b: n(4), a: h.length === 8 ? n(6) : 1 };
-  }
-  const fn = s.match(/^rgba?\(([^)]+)\)$/i);
-  if (fn) {
-    const parts = fn[1].replace(/\//g, ' ').split(/[\s,]+/).filter(Boolean);
-    if (parts.length < 3) return null;
-    const num = (p) => (p.endsWith('%') ? parseFloat(p) / 100 * 255 : parseFloat(p));
-    const alpha = (p) => (p == null ? 1 : p.endsWith('%') ? parseFloat(p) / 100 : parseFloat(p));
-    const [r, g, b] = parts.slice(0, 3).map(num);
-    if ([r, g, b].some(Number.isNaN)) return null;
-    return { r: r / 255, g: g / 255, b: b / 255, a: alpha(parts[3]) };
-  }
-  return null;
-}
-
-/** Flatten a translucent colour onto an opaque one. --line and the shadow
- *  recipes are alpha over a surface, and comparing them un-composited would
- *  measure a colour that is never on screen. */
-const over = (fg, bg) => ({
-  r: fg.r * fg.a + bg.r * (1 - fg.a),
-  g: fg.g * fg.a + bg.g * (1 - fg.a),
-  b: fg.b * fg.a + bg.b * (1 - fg.a),
-  a: 1,
-});
-
-const luminance = (c) =>
-  0.2126 * srgbToLinear(c.r) + 0.7152 * srgbToLinear(c.g) + 0.0722 * srgbToLinear(c.b);
-
-function contrast(a, b) {
-  const [x, y] = [luminance(a), luminance(b)].sort((p, q) => q - p);
-  return (x + 0.05) / (y + 0.05);
-}
-
-/** sRGB → OKLCH. The accent-legality rule is stated in OKLCH (hue degrees and
- *  chroma), and index.css records every accent's coordinates in a comment, so
- *  this is the space the contract is written in. */
-function oklch(c) {
-  const [r, g, b] = [c.r, c.g, c.b].map(srgbToLinear);
-  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
-  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
-  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
-  const L = 0.2104542553 * l + 0.7936177850 * m - 0.0040720468 * s;
-  const A = 1.9779984951 * l - 2.4285922050 * m + 0.4505937099 * s;
-  const B = 0.0259040371 * l + 0.7827717662 * m - 0.8086757660 * s;
-  const C = Math.hypot(A, B);
-  let H = (Math.atan2(B, A) * 180) / Math.PI;
-  if (H < 0) H += 360;
-  return { L, C, H };
-}
-
-/** Shortest angular distance, because hue is a circle and 355° is 20° away from
- *  15°, not 340°. The --a5/--st-down pair is only legal by this reading. */
-const hueGap = (a, b) => { const d = Math.abs(a - b) % 360; return d > 180 ? 360 - d : d; };
+// Unlike the other checks, this one READS the source tree, and run.sh runs it
+// from a temp dir beside the compiled contract - so the tree is passed in rather
+// than assumed to be a sibling. The fallback is what it means to run in place.
+const SRC = process.argv[2] ?? join(HERE, '..', 'web', 'src');
 
 // ── the token blocks ────────────────────────────────────────────────────────
 
@@ -175,41 +121,12 @@ const HL_DARK = merge(...hlBlocks.filter((b) => !b.sel.includes('light')).map((b
 const HL_LIGHT = merge(...hlBlocks.filter((b) => b.sel.includes('light')).map((b) => b.toks));
 
 const DERIVED = new Set(Object.entries(BASE).filter(([, v]) => v.includes('var(')).map(([k]) => k));
-const STRUCTURAL = new Set([
-  '--r-xs', '--r-sm', '--r-md', '--r-lg', '--r-full', '--border-w', '--wrap',
-  '--scrollbar-w', '--dur-fast', '--dur', '--dur-slow', '--ease', '--font', '--mono',
-  '--disabled-opacity', '--rest-opacity',
-]);
-// Required of every theme: literal, not derived, not structural.
-const REQUIRED = Object.keys(BASE)
-  .filter((k) => !DERIVED.has(k) && !STRUCTURAL.has(k))
-  .sort();
+// Required of every theme: literal, not derived, not structural. The rule for
+// which is which is in contract.ts, because the editor has to answer the same
+// question about a half-finished theme.
+const REQUIRED = requiredTokens(BASE);
 
-// ── the rules ───────────────────────────────────────────────────────────────
-
-const STATUSES = ['up', 'warn', 'down', 'unknown', 'off'];
-const ACCENTS = ['--a1', '--a2', '--a3', '--a4', '--a5'];
-const CHARTS = ['--chart-1', '--chart-2', '--chart-3', '--chart-4', '--chart-5'];
-
-// Written into index.css as measurements, reproduced here as thresholds.
-const AA = 4.5;              // text
-const ACCENT_ON_SURFACE = 4.6; // --a1..--a5 are painted as 12px bold text
-const CHART_VS_CARD = 3.0;
-const CHROMATIC_C = 0.06;    // a status at or above this is "chromatic"
-const HUE_SEPARATION = 45;   // degrees, against a chromatic status
-const CHROMA_MARGIN = 0.06;  // against a near-grey status
-const BAND = { dark: [0.48, 0.67], light: [0.43, 0.77] };
-
-// Three light-mode status FILLS sit below 3:1 on purpose: they are large solid
-// areas beside a track, never small glyphs or 1px borders, and status is never
-// encoded by colour alone. Recorded as an allowance WITH its reason so that a
-// new theme cannot quietly widen it - the allowance is per token, not a blanket
-// "fills are exempt".
-const FILL_ALLOWANCE = {
-  '--st-up': 'large filled area beside a track; the -fg half carries any text',
-  '--st-unknown': 'as --st-up',
-  '--st-off': 'as --st-up, and deliberately the quietest thing on the page',
-};
+// ── printing ────────────────────────────────────────────────────────────────
 
 let failures = 0, passes = 0;
 const say = (ok, label, detail = '') => {
@@ -217,122 +134,20 @@ const say = (ok, label, detail = '') => {
   console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? `  ${detail}` : ''}`);
 };
 
+// An 'allow' is a fill below the floor that the palette permits out loud, so it
+// prints its reason rather than a verdict - see FILL_ALLOWANCE in contract.ts.
+const render = (f) => {
+  if (f.level === 'allow') {
+    console.log(`ALLOW ${f.label} - ${f.detail}`);
+    passes++;
+    return;
+  }
+  say(f.level === 'pass', f.label, f.detail);
+};
+
 function checkTheme(name, appearance, toks, hl) {
   console.log(`\n── ${name}  (${appearance}) ─────────────────────────────────`);
-
-  // 1. completeness
-  const missing = REQUIRED.filter((k) => !(k in toks));
-  say(!missing.length, 'declares every required token',
-    missing.length ? `missing ${missing.length}: ${missing.slice(0, 6).join(' ')}` : `${REQUIRED.length} tokens`);
-  if (missing.length) return;
-
-  const C = (k) => {
-    const p = parseColour(toks[k]);
-    return p;
-  };
-  const s1 = C('--surface-1'), s2 = C('--surface-2'), bg2 = C('--bg-2');
-  const on = (fg, bg) => contrast(fg.a < 1 ? over(fg, bg) : fg, bg);
-
-  // A foreground is measured against every ground it is PAINTED on, not against
-  // one canonical background. That distinction is not pedantry: the first thing
-  // this check found was that the two quietest status foregrounds had been
-  // measured on a card while being used mostly in the file explorer and the
-  // reader's index, both of which sit on --bg-2 - a darker ground, so the real
-  // ratios were ~0.35 lower than the ones written into index.css, and below AA.
-  const GROUNDS = [['surface-1', s1], ['surface-2', s2], ['bg-2', bg2]];
-  const worst = (fg) => GROUNDS.reduce(
-    (acc, [n, g]) => { const v = on(fg, g); return v < acc.v ? { n, v } : acc; },
-    { n: '', v: Infinity },
-  );
-
-  // 2. foreground contrast
-  for (const k of ['--fg', '--fg-muted', '--fg-subtle']) {
-    const w = worst(C(k));
-    say(w.v >= AA, `${k} >= ${AA}:1 on every ground it is painted on`,
-      `worst ${w.v.toFixed(2)} on ${w.n}`);
-  }
-  {
-    const a = on(C('--accent-fg'), s1);
-    say(a >= AA, `--accent-fg >= ${AA}:1 on surface-1`, a.toFixed(2));
-    const o = on(C('--on-accent'), C('--accent'));
-    say(o >= 3.0, '--on-accent >= 3:1 on --accent (button text)', o.toFixed(2));
-  }
-
-  // 3. status: -fg is the text-safe half, the fill is not asserted where the
-  //    palette says out loud that it is a large area.
-  for (const s of STATUSES) {
-    const w = worst(C(`--st-${s}-fg`));
-    say(w.v >= AA, `--st-${s}-fg >= ${AA}:1 on every ground it is painted on`,
-      `worst ${w.v.toFixed(2)} on ${w.n}`);
-  }
-  for (const s of STATUSES) {
-    const key = `--st-${s}`;
-    const v = on(C(key), s1);
-    if (key in FILL_ALLOWANCE) {
-      console.log(`ALLOW ${key} fill at ${v.toFixed(2)}:1 - ${FILL_ALLOWANCE[key]}`);
-      passes++;
-    } else {
-      say(v >= CHART_VS_CARD, `${key} fill >= 3:1 on surface-1`, v.toFixed(2));
-    }
-  }
-
-  // 4. light-mode status weight must run down > warn > up > unknown > stopped.
-  //    Not asserted on dark: a saturated red is intrinsically darker than a
-  //    saturated green and index.css forbids "fixing" it by brightening the red
-  //    into the amber's territory.
-  if (appearance === 'light') {
-    const order = ['down', 'warn', 'up', 'unknown', 'off'];
-    const w = order.map((s) => ({ s, L: oklch(C(`--st-${s}`)).L }));
-    const ok = w.every((x, i) => i === 0 || w[i - 1].L <= x.L + 1e-9);
-    say(ok, 'light status weight runs down > warn > up > unknown > stopped',
-      w.map((x) => `${x.s} ${x.L.toFixed(3)}`).join(' < '));
-  }
-
-  // 5. accent legality - the whole reason --a4 stopped being #34d399
-  const stats = STATUSES.map((s) => ({ s, ...oklch(C(`--st-${s}`)) }));
-  for (const k of ACCENTS) {
-    const a = oklch(C(k));
-    const bad = [];
-    for (const st of stats) {
-      if (st.C >= CHROMATIC_C) {
-        const g = hueGap(a.H, st.H);
-        if (g < HUE_SEPARATION) bad.push(`${st.s}: hue gap ${g.toFixed(0)}° < ${HUE_SEPARATION}°`);
-      } else if (a.C - st.C < CHROMA_MARGIN) {
-        bad.push(`${st.s}: chroma margin ${(a.C - st.C).toFixed(3)} < ${CHROMA_MARGIN}`);
-      }
-    }
-    say(!bad.length, `${k} is legal against every status`,
-      bad.length ? bad.join('; ') : `L ${a.L.toFixed(2)} C ${a.C.toFixed(3)} H ${a.H.toFixed(0)}°`);
-  }
-  for (const k of ACCENTS) {
-    const v = on(C(k), s2);
-    say(v >= ACCENT_ON_SURFACE, `${k} >= ${ACCENT_ON_SURFACE}:1 on surface-2 (12px bold text)`,
-      v.toFixed(2));
-  }
-
-  // 6. charts - band, and separation against the card. Slot ORDER is part of
-  //    what was validated upstream, so the check reads them in order and never
-  //    sorts them.
-  const [lo, hi] = BAND[appearance];
-  for (const k of CHARTS) {
-    const c = oklch(C(k));
-    say(c.L >= lo && c.L <= hi, `${k} inside the ${appearance} lightness band ${lo}-${hi}`,
-      `L ${c.L.toFixed(3)}`);
-  }
-  for (const k of CHARTS) {
-    const v = on(C(k), s1);
-    say(v >= CHART_VS_CARD, `${k} >= 3:1 on surface-1`, v.toFixed(2));
-  }
-
-  // 7. the syntax palette, when the theme carries one
-  if (hl && Object.keys(hl).length) {
-    for (const [k, v] of Object.entries(hl)) {
-      const c = parseColour(v);
-      if (!c) continue; // --hl-com is var(--fg-subtle); already checked above
-      const a = contrast(c, bg2);
-      say(a >= AA, `${k} >= ${AA}:1 on --bg-2`, a.toFixed(2));
-    }
-  }
+  for (const f of evaluateTheme(toks, appearance, { required: REQUIRED, syntax: hl })) render(f);
 }
 
 // ── run ─────────────────────────────────────────────────────────────────────

--- a/apps/portal-next/checks/user-themes.mjs
+++ b/apps/portal-next/checks/user-themes.mjs
@@ -1,0 +1,83 @@
+// A theme somebody dropped into a directory must be classified correctly, and
+// the classification has to survive a file written by hand.
+//
+// WHY THIS IS WORTH A TABLE. The header is optional, the id comes from a
+// filename, and the appearance decides which base palette the pre-paint script
+// stamps - so getting `appearance` wrong is not a cosmetic bug, it is a light
+// theme rendering its first frame on the dark base. Every row below is a shape
+// a real hand-written file takes: no header at all, a header with only some
+// fields, `color-scheme` on its own, and the awkward ones - CRLF, odd spacing,
+// a `note:` containing a colon.
+//
+// lib/customThemes.ts imports nothing, which is what lets this compile it in
+// isolation. Same property discover.ts and contract.ts rely on.
+
+import { parseThemeHeader } from './user-themes-mod.mjs';
+
+let bad = 0;
+function eq(label, got, want) {
+  const ok = got === want;
+  if (!ok) bad += 1;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label.padEnd(54)} `
+    + `${ok ? String(got) : `want=${want} got=${got}`}`);
+}
+
+console.log('── the header is optional ──────────────────────────────────────────');
+{
+  // The minimum a theme can be: a palette block and nothing else. It still has
+  // to appear in the picker with a readable name, or a working file looks broken
+  // over a missing comment.
+  const t = parseThemeHeader('solarized-dark', ":root[data-bothy-theme='x']{color-scheme:dark;--bg:#002b36}");
+  eq('name falls back to the prettified filename', t.name, 'Solarized Dark');
+  eq('appearance is read from color-scheme', t.appearance, 'dark');
+  eq('note has a default', t.note, 'Added on this box.');
+  eq('href is built from the id', t.href, '/data/themes/solarized-dark.css');
+  eq('marked as a user theme', t.user, true);
+}
+
+console.log('\n── a light theme must be detected as light ─────────────────────────');
+// The row that matters most: getting this wrong stamps the dark base palette on
+// the first frame and the page flashes.
+eq('color-scheme: light',
+   parseThemeHeader('paper', 'x{color-scheme: light}').appearance, 'light');
+eq('appearance: light in the header beats a missing color-scheme',
+   parseThemeHeader('paper', '/* bothy-theme\n   appearance: light\n*/\nx{}').appearance, 'light');
+// The header wins on purpose: it is the field a person edited deliberately,
+// where color-scheme may have been copied along with the rest of the block.
+eq('the header wins over a contradicting color-scheme',
+   parseThemeHeader('paper', '/* bothy-theme\n appearance: light\n*/\nx{color-scheme:dark}').appearance,
+   'light');
+eq('anything else is dark, never undefined',
+   parseThemeHeader('x', '/* bothy-theme\n appearance: banana\n*/').appearance, 'dark');
+
+console.log('\n── a header written by a human ─────────────────────────────────────');
+{
+  const css = '/* bothy-theme\r\n'
+    + '     name:   Solarized  Light \r\n'
+    + '   appearance:LIGHT\r\n'
+    + '   note: Precision colours: for machines and people.\r\n'
+    + '*/\nx{}';
+  const t = parseThemeHeader('sol', css);
+  // CRLF, because a file edited on Windows or pasted from a gist has them and
+  // failing on that would be a mystery to whoever wrote it.
+  eq('CRLF line endings parse', t.name, 'Solarized  Light');
+  eq('a value is trimmed but its inner spacing is left alone', t.name, 'Solarized  Light');
+  eq('the key is case-insensitive and so is the value', t.appearance, 'light');
+  // Split on the FIRST colon only: a note is prose and prose contains colons.
+  eq('a note may contain a colon', t.note, 'Precision colours: for machines and people.');
+}
+
+console.log('\n── the id is the filename, and it reaches a selector ───────────────');
+// The id ends up inside an attribute selector in the theme's own CSS and inside
+// a URL, so the loader only accepts clean ones. parseThemeHeader itself does not
+// filter - list() does - but the href it builds must still be escaped, because
+// this function is also called by the editor on a name a person just typed.
+eq('a space in an id is escaped in the href',
+   parseThemeHeader('my theme', 'x{}').href, '/data/themes/my%20theme.css');
+eq('...and the name still reads',
+   parseThemeHeader('my-first-theme', 'x{}').name, 'My First Theme');
+eq('underscores are separators too',
+   parseThemeHeader('deep_ocean', 'x{}').name, 'Deep Ocean');
+
+console.log(`\n${bad ? `${bad} FAILED` : 'all pass'}`);
+process.exit(bad ? 1 : 0);

--- a/apps/portal-next/data/themes/README.md
+++ b/apps/portal-next/data/themes/README.md
@@ -1,0 +1,85 @@
+# Your themes go here
+
+Drop a `.css` file in this directory and reload Bothy. It appears in the theme
+picker — topbar moon icon, or Settings → Appearance — tagged **yours**.
+
+That is the whole procedure. No rebuild, no npm, no restart. The directory is
+bind-mounted into the container, so what you put here survives
+`docker compose up --build`, and Bothy finds themes by **listing this
+directory** — there is no index to update and therefore none to forget.
+
+- **The filename is the theme's id.** `deep-ocean.css` → `deep-ocean`. Rename the
+  file to rename the theme. Use lowercase letters, digits and hyphens; anything
+  else is skipped rather than guessed at, because the id ends up inside a CSS
+  selector.
+- **One file is one theme.** Send it to someone and they drop it in their own
+  directory. Nothing else travels with it.
+- These files are **git-ignored**. They are yours, not the repository's.
+
+## The shape of a theme
+
+```css
+/* bothy-theme
+   name: Deep Ocean
+   appearance: dark
+   note: One line, shown under the name in the picker.
+*/
+
+/* Two selectors, and both are needed. The :root one wins on the page. The bare
+   one lets the picker paint this theme's swatches while you are looking at a
+   different theme. */
+:root[data-bothy-theme='deep-ocean'][data-bothy-theme],
+[data-bothy-theme='deep-ocean'][data-bothy-theme] {
+  color-scheme: dark;          /* REQUIRED - see below */
+
+  --bg: #0b1a24;
+  --fg: #dbe7ef;
+  --accent: #4bb3d4;
+  /* ...and the rest */
+}
+```
+
+The header block is optional — a theme with no header still loads, taking its
+name from the filename. `color-scheme` is the one line you should not omit: it
+tells the browser to paint scrollbars and form controls correctly, and Bothy
+reads it to know whether to start you on the dark or light base before your
+stylesheet has finished loading. Without it you may see one frame of the wrong
+palette.
+
+## What to copy
+
+Start from a theme that already works. The ones Bothy ships are in
+`apps/portal-next/web/src/themes/` — `tokyo-night.css` is the most heavily
+commented and explains what every group of tokens does. Copy it here, rename the
+file, change the id in both selectors, and start editing colours.
+
+## What a complete theme declares
+
+**41 tokens.** Of the 73 custom properties Bothy defines, 16 are *derived*
+(computed from the ones you set, so they follow along for free) and 16 are
+*structural* (radii, motion, fonts — the product's shape, not its palette). You
+own the remaining 41: surfaces, foregrounds, lines, accent, five chart slots,
+five statuses with their text variants, five panel accents, shadows.
+
+A partial theme works — anything you leave out falls back to the base palette —
+but the result is usually a page that is *nearly* your theme with a few
+stubbornly blue buttons, so it is better to start from a complete file.
+
+## Two rules worth knowing before you pick colours
+
+They are not enforced on your files, and both exist because breaking them
+produced a real bug:
+
+1. **The five status colours are reserved.** `--st-up`, `--st-warn`,
+   `--st-down`, `--st-unknown`, `--st-off` mean *a service is in this state* and
+   are never used for decoration. If a decorative accent shares a hue with
+   "down", a coloured panel edge reads as an alert.
+2. **The five panel accents never encode state.** `--a1`–`--a5` are chrome. They
+   must stay clearly distinct from the status hues — Bothy's own themes keep at
+   least 45° of hue between them — or the first rule stops being true in
+   practice.
+
+Text also needs to stay readable: Bothy holds its own foregrounds at 4.5:1
+against every surface they are painted on. If you want the same assurance for
+your theme, the rules are implemented in
+`apps/portal-next/web/src/lib/contract.ts`.

--- a/apps/portal-next/nginx.conf
+++ b/apps/portal-next/nginx.conf
@@ -6,6 +6,35 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # ── user themes, listed rather than registered ──────────────────────────
+    #
+    # A theme a PERSON added is a .css file dropped into this directory on the
+    # host (apps/portal-next/data/themes, bind-mounted). It has to work for
+    # somebody who downloaded Bothy and runs it - no source tree, no npm, no
+    # rebuild - so it cannot live in the bundle, and it must survive `up --build`.
+    # A bind mount is the only thing that satisfies both.
+    #
+    # autoindex_format json turns the directory itself into the index. The
+    # alternative was an index.json listing every theme, and that is a second
+    # file to keep in step with the first: drop in a .css, forget the JSON, and
+    # the theme silently does not exist. Here the filesystem IS the list.
+    #
+    # `try_files` is deliberately absent: the SPA fallback above would answer a
+    # missing theme with index.html, and the client would try to parse a page of
+    # HTML as CSS. A 404 is the honest answer and the loader handles it.
+    location /data/themes/ {
+        alias /usr/share/nginx/html/data/themes/;
+        autoindex on;
+        autoindex_format json;
+        add_header Cache-Control "no-cache";
+        # A SIBLING location, so it inherits none of the headers set on `/` -
+        # nginx's add_header does not cascade across locations. The CSP is not
+        # wanted here (this serves a stylesheet, not a document) but nosniff is:
+        # these files are written by a person, and a .css whose bytes look like
+        # something else must not be re-interpreted as that something else.
+        add_header X-Content-Type-Options "nosniff";
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-cache";
@@ -46,7 +75,7 @@ server {
         # does NOT: no script here ever fetches those bytes, it only points an
         # element at them, and a fetch() to the sandbox would hand a hostile
         # document's bytes to this origin's JavaScript.
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-1/+a5nlren0s5fSLgjbA+g3LnAbqnaishAeoXih2ZZE='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http://$host:8100; media-src 'self' blob: http://$host:8100; frame-src http://$host:8100; connect-src 'self'; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-swg2nI8aBMzvV3t84exM+Tsz7mFjKORHPpdwMTCyJWs='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http://$host:8100; media-src 'self' blob: http://$host:8100; frame-src http://$host:8100; connect-src 'self'; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'";
         # style-src keeps 'unsafe-inline' and cannot lose it yet: CodeMirror
         # injects its theme as a <style> element at runtime (style-mod), and
         # React writes inline style attributes for the pane sizes. Stated rather

--- a/apps/portal-next/web/index.html
+++ b/apps/portal-next/web/index.html
@@ -58,6 +58,22 @@
           }
           e.setAttribute('data-theme', app);
           e.setAttribute('data-bothy-theme', sel);
+          // A USER theme's stylesheet is not in the bundle - it is a file in
+          // /data/themes on the box - so it has to be requested, and requesting
+          // it here rather than after React mounts is the difference between a
+          // correct first frame and a flash of the base palette.
+          //
+          // The flag is written by lib/theme.tsx when the theme was chosen. This
+          // script cannot work it out: telling a bundled `tokyo-night` from a
+          // user `tokyo-night` needs the registry, and putting the registry here
+          // would mean regenerating the CSP hash every time a theme is added.
+          if (localStorage.getItem('portal-theme-is-user') === '1') {
+            var l = document.createElement('link');
+            l.rel = 'stylesheet';
+            l.setAttribute('data-bothy-user-theme', sel);
+            l.href = '/data/themes/' + encodeURIComponent(sel) + '.css';
+            document.head.appendChild(l);
+          }
         } catch (err) {
           e.setAttribute('data-theme', 'dark');
           e.setAttribute('data-bothy-theme', 'bothy-dark');

--- a/apps/portal-next/web/src/lib/contract.ts
+++ b/apps/portal-next/web/src/lib/contract.ts
@@ -1,0 +1,351 @@
+// The theme contract: the rules a palette must satisfy, and the colour maths
+// they are stated in.
+//
+// THIS MODULE IMPORTS NOTHING, on the lib/discover.ts and lib/config.ts pattern
+// and for the same reason - a module with no imports is one that can be compiled
+// and exercised on its own. Here that is not a convenience, it is the whole
+// point: checks/run.sh compiles this file in isolation so checks/theme-contract.mjs
+// can import it under node, and the custom-theme editor imports it in the
+// browser. TWO CONSUMERS, ONE SET OF RULES. A rule that lives in the check and a
+// rule that lives in the editor drift apart, and the drift is invisible - the
+// editor says a colour is fine, the check says it is not, and whichever one you
+// happened to run is the answer you believe.
+//
+// The numbers below are not preferences. index.css records the measurements, the
+// bands, the orderings and the two historical bugs that produced them; this is
+// that prose turned into something that can be executed.
+//
+// What is NOT here: reading files, parsing stylesheets, discovering themes. That
+// stays in checks/theme-contract.mjs, because it is node's job and the browser
+// has no stylesheet to read - it has a token map the user is editing.
+
+// ── colour ──────────────────────────────────────────────────────────────────
+
+export type RGBA = { r: number; g: number; b: number; a: number };
+export type OKLCH = { L: number; C: number; H: number };
+
+const srgbToLinear = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+
+/** Parse the value forms that actually appear in these files: #rgb, #rrggbb,
+ *  #rrggbbaa, rgb()/rgba() in both comma and space syntax. Returns
+ *  {r,g,b,a} in 0..1, or null for anything else (a var(), a gradient, a
+ *  shadow recipe) - callers decide whether "not a flat colour" is a failure. */
+export function parseColour(v: string): RGBA | null {
+  const s = String(v).trim();
+  const hex = s.match(/^#([0-9a-fA-F]{3,8})$/);
+  if (hex) {
+    let h = hex[1];
+    if (h.length === 3 || h.length === 4) h = [...h].map((c) => c + c).join('');
+    if (h.length !== 6 && h.length !== 8) return null;
+    const n = (i: number) => parseInt(h.slice(i, i + 2), 16) / 255;
+    return { r: n(0), g: n(2), b: n(4), a: h.length === 8 ? n(6) : 1 };
+  }
+  const fn = s.match(/^rgba?\(([^)]+)\)$/i);
+  if (fn) {
+    const parts = fn[1].replace(/\//g, ' ').split(/[\s,]+/).filter(Boolean);
+    if (parts.length < 3) return null;
+    const num = (p: string) => (p.endsWith('%') ? parseFloat(p) / 100 * 255 : parseFloat(p));
+    const alpha = (p: string | undefined) =>
+      (p == null ? 1 : p.endsWith('%') ? parseFloat(p) / 100 : parseFloat(p));
+    const [r, g, b] = parts.slice(0, 3).map(num);
+    if ([r, g, b].some(Number.isNaN)) return null;
+    return { r: r / 255, g: g / 255, b: b / 255, a: alpha(parts[3]) };
+  }
+  return null;
+}
+
+/** Flatten a translucent colour onto an opaque one. --line and the shadow
+ *  recipes are alpha over a surface, and comparing them un-composited would
+ *  measure a colour that is never on screen. */
+export const over = (fg: RGBA, bg: RGBA): RGBA => ({
+  r: fg.r * fg.a + bg.r * (1 - fg.a),
+  g: fg.g * fg.a + bg.g * (1 - fg.a),
+  b: fg.b * fg.a + bg.b * (1 - fg.a),
+  a: 1,
+});
+
+export const luminance = (c: RGBA) =>
+  0.2126 * srgbToLinear(c.r) + 0.7152 * srgbToLinear(c.g) + 0.0722 * srgbToLinear(c.b);
+
+export function contrast(a: RGBA, b: RGBA) {
+  const [x, y] = [luminance(a), luminance(b)].sort((p, q) => q - p);
+  return (x + 0.05) / (y + 0.05);
+}
+
+/** Contrast of a foreground on a ground, compositing first when the foreground
+ *  is translucent. Every ratio in the contract is measured this way. */
+export const contrastOn = (fg: RGBA, bg: RGBA) => contrast(fg.a < 1 ? over(fg, bg) : fg, bg);
+
+/** sRGB → OKLCH. The accent-legality rule is stated in OKLCH (hue degrees and
+ *  chroma), and index.css records every accent's coordinates in a comment, so
+ *  this is the space the contract is written in. */
+export function oklch(c: RGBA): OKLCH {
+  const [r, g, b] = [c.r, c.g, c.b].map(srgbToLinear);
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+  const L = 0.2104542553 * l + 0.7936177850 * m - 0.0040720468 * s;
+  const A = 1.9779984951 * l - 2.4285922050 * m + 0.4505937099 * s;
+  const B = 0.0259040371 * l + 0.7827717662 * m - 0.8086757660 * s;
+  const C = Math.hypot(A, B);
+  let H = (Math.atan2(B, A) * 180) / Math.PI;
+  if (H < 0) H += 360;
+  return { L, C, H };
+}
+
+/** Shortest angular distance, because hue is a circle and 355° is 20° away from
+ *  15°, not 340°. The --a5/--st-down pair is only legal by this reading. */
+export const hueGap = (a: number, b: number) => {
+  const d = Math.abs(a - b) % 360;
+  return d > 180 ? 360 - d : d;
+};
+
+// ── the rules ───────────────────────────────────────────────────────────────
+
+export type Appearance = 'dark' | 'light';
+
+export const STATUSES = ['up', 'warn', 'down', 'unknown', 'off'];
+export const ACCENTS = ['--a1', '--a2', '--a3', '--a4', '--a5'];
+export const CHARTS = ['--chart-1', '--chart-2', '--chart-3', '--chart-4', '--chart-5'];
+
+// Written into index.css as measurements, reproduced here as thresholds.
+export const AA = 4.5;              // text
+export const ACCENT_ON_SURFACE = 4.6; // --a1..--a5 are painted as 12px bold text
+export const CHART_VS_CARD = 3.0;
+export const CHROMATIC_C = 0.06;    // a status at or above this is "chromatic"
+export const HUE_SEPARATION = 45;   // degrees, against a chromatic status
+export const CHROMA_MARGIN = 0.06;  // against a near-grey status
+export const BAND: Record<Appearance, [number, number]> = {
+  dark: [0.48, 0.67],
+  light: [0.43, 0.77],
+};
+
+// Three light-mode status FILLS sit below 3:1 on purpose: they are large solid
+// areas beside a track, never small glyphs or 1px borders, and status is never
+// encoded by colour alone. Recorded as an allowance WITH its reason so that a
+// new theme cannot quietly widen it - the allowance is per token, not a blanket
+// "fills are exempt".
+export const FILL_ALLOWANCE: Record<string, string> = {
+  '--st-up': 'large filled area beside a track; the -fg half carries any text',
+  '--st-unknown': 'as --st-up',
+  '--st-off': 'as --st-up, and deliberately the quietest thing on the page',
+};
+
+// Not colour, and shared by every theme - radii, motion, fonts, widths. A theme
+// that omits these is not incomplete, it is just not restyling the furniture.
+export const STRUCTURAL = new Set([
+  '--r-xs', '--r-sm', '--r-md', '--r-lg', '--r-full', '--border-w', '--wrap',
+  '--scrollbar-w', '--dur-fast', '--dur', '--dur-slow', '--ease', '--font', '--mono',
+  '--disabled-opacity', '--rest-opacity',
+]);
+
+/** What a theme owes, derived from the base palette rather than listed: every
+ *  literal token in :root that is neither DERIVED (a color-mix over another
+ *  token, on the same element, so it re-evaluates for free) nor STRUCTURAL.
+ *
+ *  Derived by reading rather than by a hand-maintained list, because the failure
+ *  mode of a list is silence: a missing token inherits the base palette, which
+ *  is how you get a Gruvbox page with one blue button on it. */
+export function requiredTokens(base: Record<string, string>): string[] {
+  return Object.keys(base)
+    .filter((k) => !base[k].includes('var(') && !STRUCTURAL.has(k))
+    .sort();
+}
+
+// ── the verdict ─────────────────────────────────────────────────────────────
+
+// 'pass' and 'fail' are the two answers; 'allow' is a fill that is below the
+// floor and permitted anyway, carrying the reason with it. It is reported rather
+// than suppressed for the same reason FILL_ALLOWANCE has prose in it: an
+// exemption nobody can see is an exemption nobody can argue with.
+export type FindingLevel = 'pass' | 'fail' | 'allow';
+
+/** One assertion, rendered as a PASS/FAIL line by the check and as a row by the
+ *  editor. `id` is stable and machine-readable so a UI can key off it and point
+ *  at the swatch that is wrong; `label` states the rule, `detail` the measured
+ *  value - which is the part worth reading even when it passes. */
+export type Finding = {
+  id: string;
+  level: FindingLevel;
+  label: string;
+  detail: string;
+};
+
+export type EvaluateOptions = {
+  /** The tokens this theme must declare - `requiredTokens(base)` from whoever
+   *  holds the base palette. Omitted, completeness is simply not asserted: a
+   *  caller that does not know the base palette cannot honestly check it. */
+  required?: readonly string[];
+  /** The theme's syntax palette (--hl-*), when it carries one. Optional group:
+   *  a theme that omits it falls back to a set already checked for its
+   *  appearance. */
+  syntax?: Record<string, string> | null;
+};
+
+/** Every token whose value the rules below actually measure. Parsed up front so
+ *  that a value which is not a flat colour is reported as such - in the check it
+ *  cannot happen (index.css supplies a literal for all of them), but the editor
+ *  is fed whatever the user has typed so far, and a crash there is not a review. */
+const MEASURED = [
+  '--surface-1', '--surface-2', '--bg-2',
+  '--fg', '--fg-muted', '--fg-subtle',
+  '--accent', '--accent-fg', '--on-accent',
+  ...STATUSES.map((s) => `--st-${s}`),
+  ...STATUSES.map((s) => `--st-${s}-fg`),
+  ...ACCENTS,
+  ...CHARTS,
+];
+
+/** Run the whole contract over one theme's tokens. The findings come back in
+ *  the order they are asserted, which is the order the check prints them. */
+export function evaluateTheme(
+  tokens: Record<string, string>,
+  appearance: Appearance,
+  options: EvaluateOptions = {},
+): Finding[] {
+  const out: Finding[] = [];
+  const say = (id: string, ok: boolean, label: string, detail = '') => {
+    out.push({ id, level: ok ? 'pass' : 'fail', label, detail });
+  };
+
+  // 1. completeness
+  if (options.required) {
+    const missing = options.required.filter((k) => !(k in tokens));
+    say('tokens/complete', !missing.length, 'declares every required token',
+      missing.length
+        ? `missing ${missing.length}: ${missing.slice(0, 6).join(' ')}`
+        : `${options.required.length} tokens`);
+    if (missing.length) return out;
+  }
+
+  // Nothing below can be measured on a value that is not a colour, and half-
+  // measuring is worse than saying so.
+  const parsed: Record<string, RGBA> = {};
+  const unparsed: string[] = [];
+  for (const k of MEASURED) {
+    const p = parseColour(tokens[k]);
+    if (p) parsed[k] = p; else unparsed.push(k);
+  }
+  if (unparsed.length) {
+    for (const k of unparsed) {
+      say(`value/${k}`, false, `${k} is a flat colour the contract can measure`,
+        tokens[k] ?? '(missing)');
+    }
+    return out;
+  }
+
+  const C = (k: string) => parsed[k];
+  const s1 = C('--surface-1'), s2 = C('--surface-2'), bg2 = C('--bg-2');
+  const on = contrastOn;
+
+  // A foreground is measured against every ground it is PAINTED on, not against
+  // one canonical background. That distinction is not pedantry: the first thing
+  // this check found was that the two quietest status foregrounds had been
+  // measured on a card while being used mostly in the file explorer and the
+  // reader's index, both of which sit on --bg-2 - a darker ground, so the real
+  // ratios were ~0.35 lower than the ones written into index.css, and below AA.
+  const GROUNDS: [string, RGBA][] = [['surface-1', s1], ['surface-2', s2], ['bg-2', bg2]];
+  const worst = (fg: RGBA) => GROUNDS.reduce(
+    (acc, [n, g]) => { const v = on(fg, g); return v < acc.v ? { n, v } : acc; },
+    { n: '', v: Infinity },
+  );
+
+  // 2. foreground contrast
+  for (const k of ['--fg', '--fg-muted', '--fg-subtle']) {
+    const w = worst(C(k));
+    say(`contrast/${k}`, w.v >= AA, `${k} >= ${AA}:1 on every ground it is painted on`,
+      `worst ${w.v.toFixed(2)} on ${w.n}`);
+  }
+  {
+    const a = on(C('--accent-fg'), s1);
+    say('contrast/--accent-fg', a >= AA, `--accent-fg >= ${AA}:1 on surface-1`, a.toFixed(2));
+    const o = on(C('--on-accent'), C('--accent'));
+    say('contrast/--on-accent', o >= 3.0, '--on-accent >= 3:1 on --accent (button text)',
+      o.toFixed(2));
+  }
+
+  // 3. status: -fg is the text-safe half, the fill is not asserted where the
+  //    palette says out loud that it is a large area.
+  for (const s of STATUSES) {
+    const w = worst(C(`--st-${s}-fg`));
+    say(`contrast/--st-${s}-fg`, w.v >= AA,
+      `--st-${s}-fg >= ${AA}:1 on every ground it is painted on`,
+      `worst ${w.v.toFixed(2)} on ${w.n}`);
+  }
+  for (const s of STATUSES) {
+    const key = `--st-${s}`;
+    const v = on(C(key), s1);
+    if (key in FILL_ALLOWANCE) {
+      out.push({
+        id: `fill/${key}`,
+        level: 'allow',
+        label: `${key} fill at ${v.toFixed(2)}:1`,
+        detail: FILL_ALLOWANCE[key],
+      });
+    } else {
+      say(`fill/${key}`, v >= CHART_VS_CARD, `${key} fill >= 3:1 on surface-1`, v.toFixed(2));
+    }
+  }
+
+  // 4. light-mode status weight must run down > warn > up > unknown > stopped.
+  //    Not asserted on dark: a saturated red is intrinsically darker than a
+  //    saturated green and index.css forbids "fixing" it by brightening the red
+  //    into the amber's territory.
+  if (appearance === 'light') {
+    const order = ['down', 'warn', 'up', 'unknown', 'off'];
+    const w = order.map((s) => ({ s, L: oklch(C(`--st-${s}`)).L }));
+    const ok = w.every((x, i) => i === 0 || w[i - 1].L <= x.L + 1e-9);
+    say('order/light-status-weight', ok,
+      'light status weight runs down > warn > up > unknown > stopped',
+      w.map((x) => `${x.s} ${x.L.toFixed(3)}`).join(' < '));
+  }
+
+  // 5. accent legality - the whole reason --a4 stopped being #34d399
+  const stats = STATUSES.map((s) => ({ s, ...oklch(C(`--st-${s}`)) }));
+  for (const k of ACCENTS) {
+    const a = oklch(C(k));
+    const bad = [];
+    for (const st of stats) {
+      if (st.C >= CHROMATIC_C) {
+        const g = hueGap(a.H, st.H);
+        if (g < HUE_SEPARATION) bad.push(`${st.s}: hue gap ${g.toFixed(0)}° < ${HUE_SEPARATION}°`);
+      } else if (a.C - st.C < CHROMA_MARGIN) {
+        bad.push(`${st.s}: chroma margin ${(a.C - st.C).toFixed(3)} < ${CHROMA_MARGIN}`);
+      }
+    }
+    say(`accent/${k}`, !bad.length, `${k} is legal against every status`,
+      bad.length ? bad.join('; ') : `L ${a.L.toFixed(2)} C ${a.C.toFixed(3)} H ${a.H.toFixed(0)}°`);
+  }
+  for (const k of ACCENTS) {
+    const v = on(C(k), s2);
+    say(`contrast/${k}`, v >= ACCENT_ON_SURFACE,
+      `${k} >= ${ACCENT_ON_SURFACE}:1 on surface-2 (12px bold text)`, v.toFixed(2));
+  }
+
+  // 6. charts - band, and separation against the card. Slot ORDER is part of
+  //    what was validated upstream, so the check reads them in order and never
+  //    sorts them.
+  const [lo, hi] = BAND[appearance];
+  for (const k of CHARTS) {
+    const c = oklch(C(k));
+    say(`band/${k}`, c.L >= lo && c.L <= hi,
+      `${k} inside the ${appearance} lightness band ${lo}-${hi}`, `L ${c.L.toFixed(3)}`);
+  }
+  for (const k of CHARTS) {
+    const v = on(C(k), s1);
+    say(`contrast/${k}-vs-card`, v >= CHART_VS_CARD, `${k} >= 3:1 on surface-1`, v.toFixed(2));
+  }
+
+  // 7. the syntax palette, when the theme carries one
+  const hl = options.syntax;
+  if (hl && Object.keys(hl).length) {
+    for (const [k, v] of Object.entries(hl)) {
+      const c = parseColour(v);
+      if (!c) continue; // --hl-com is var(--fg-subtle); already checked above
+      const a = contrast(c, bg2);
+      say(`syntax/${k}`, a >= AA, `${k} >= ${AA}:1 on --bg-2`, a.toFixed(2));
+    }
+  }
+
+  return out;
+}

--- a/apps/portal-next/web/src/lib/customThemes.ts
+++ b/apps/portal-next/web/src/lib/customThemes.ts
@@ -1,0 +1,164 @@
+// Themes a PERSON added, loaded at runtime from a directory on the box.
+//
+// WHO THIS IS FOR. Somebody who downloaded Bothy and ran it. No source tree, no
+// npm, no rebuild - and whatever they add has to survive `docker compose up
+// --build`, which replaces the image and everything in it. So a user theme
+// cannot be a file in src/themes/ (that is compiled into the bundle) and it
+// cannot live in the image. It is a .css file in a BIND-MOUNTED directory:
+//
+//     apps/portal-next/data/themes/<id>.css      on the host
+//     /data/themes/<id>.css                      as the browser sees it
+//
+// The same directory nginx already serves projects.json from, for the same
+// reason: it is the one place that is both writable from outside the image and
+// readable by the page.
+//
+// THE FILE IS THE REGISTRATION. nginx lists the directory as JSON
+// (autoindex_format json), so dropping a .css in is the whole act of adding a
+// theme - there is no index to update and therefore no index to forget. The id
+// is the filename without .css, which also means renaming the file renames the
+// theme, and that is the behaviour someone would guess.
+//
+// METADATA LIVES IN THE FILE, in a header block:
+//
+//     /* bothy-theme
+//        name: Solarized Dark
+//        appearance: dark
+//        note: Precision colours for machines and people.
+//     */
+//
+// Parsed from the CSS text rather than from a sidecar, because a theme should be
+// ONE file you can send someone. Everything is optional except that the file
+// must declare `color-scheme` (or `appearance:` here) - without knowing whether
+// it is dark or light the pre-paint stamp cannot pick a base palette and the
+// first frame is wrong.
+
+export interface CustomTheme {
+  id: string;
+  name: string;
+  appearance: 'dark' | 'light';
+  note: string;
+  /** Where the browser fetches it. Also what the <link> points at. */
+  href: string;
+  /** Always true. Present so a CustomTheme is usable anywhere a ThemeDef is,
+   *  and so the flag travels with the value instead of being re-derived. */
+  user: true;
+}
+
+/** Where user themes live, as the browser addresses them. Exported because the
+ *  editor writes into the same place through the file service, and two spellings
+ *  of one path is how they drift apart. */
+export const THEME_DIR = '/data/themes/';
+
+/** The host path, for telling somebody where to put a file. Relative to the repo
+ *  root; the container sees it mounted at /usr/share/nginx/html/data/themes. */
+export const THEME_DIR_HOST = 'apps/portal-next/data/themes/';
+
+const HEADER = /\/\*\s*bothy-theme([\s\S]*?)\*\//i;
+
+/** Prettify a filename the way the reader's title code does, so a theme with no
+ *  `name:` still reads as words rather than as a slug. */
+function titleFrom(id: string): string {
+  return id.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Pull the header block out of a theme's CSS. Never throws: a file that does
+ *  not parse is a theme with defaults, not an error - the CSS still applies, and
+ *  refusing to list it would hide a working theme over a missing comment. */
+export function parseThemeHeader(id: string, css: string): CustomTheme {
+  const fields: Record<string, string> = {};
+  const m = css.match(HEADER);
+  if (m) {
+    for (const line of m[1].split('\n')) {
+      const kv = line.match(/^\s*([a-z-]+)\s*:\s*(.+?)\s*$/i);
+      if (kv) fields[kv[1].toLowerCase()] = kv[2];
+    }
+  }
+  // `appearance:` in the header wins, then the stylesheet's own color-scheme,
+  // then dark. The second is the one that matters: color-scheme is REQUIRED of a
+  // theme anyway (it is what makes the browser paint form controls and
+  // scrollbars correctly), so reading it means a correct file needs no header at
+  // all to be classified.
+  const declared = fields.appearance?.toLowerCase();
+  const scheme = css.match(/color-scheme\s*:\s*(dark|light)/i)?.[1].toLowerCase();
+  const appearance = (declared === 'light' || declared === 'dark' ? declared
+    : scheme === 'light' ? 'light' : 'dark') as 'dark' | 'light';
+
+  return {
+    id,
+    name: fields.name || titleFrom(id),
+    appearance,
+    note: fields.note || 'Added on this box.',
+    href: THEME_DIR + encodeURIComponent(id) + '.css',
+    user: true,
+  };
+}
+
+/** Names of the .css files in the theme directory, or [] if there are none.
+ *
+ *  ABSENT IS A SUPPORTED CONFIGURATION, exactly as it is for projects.json: a
+ *  fresh install has no user themes and no directory, and that must be silence
+ *  rather than an error in the console on every load. Every failure here - 404,
+ *  a JSON body that is not a list, a network error - collapses to "no user
+ *  themes", because none of them is something the reader can act on.
+ */
+async function list(): Promise<string[]> {
+  try {
+    const r = await fetch(THEME_DIR, { headers: { Accept: 'application/json' } });
+    if (!r.ok) return [];
+    const body: unknown = await r.json();
+    if (!Array.isArray(body)) return [];
+    return body
+      .map((e) => (e && typeof e === 'object' && 'name' in e ? String((e as { name: unknown }).name) : ''))
+      .filter((n) => n.toLowerCase().endsWith('.css'))
+      .map((n) => n.slice(0, -4))
+      // A filename that would need escaping in a selector or a URL is refused
+      // rather than sanitised. The id ends up inside an attribute selector in
+      // the theme's own CSS, so "clean or absent" is a much smaller promise to
+      // keep than "escaped correctly everywhere".
+      .filter((id) => /^[a-z0-9][a-z0-9-]*$/i.test(id))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/** Every user theme, with its metadata read from its own file.
+ *
+ *  Fetched in parallel and failures dropped: one unreadable file must not cost
+ *  the others. The CSS text is parsed but NOT injected here - see applyLink. */
+export async function loadCustomThemes(): Promise<CustomTheme[]> {
+  const ids = await list();
+  if (!ids.length) return [];
+  const out = await Promise.all(ids.map(async (id) => {
+    try {
+      const r = await fetch(THEME_DIR + encodeURIComponent(id) + '.css');
+      if (!r.ok) return null;
+      return parseThemeHeader(id, await r.text());
+    } catch {
+      return null;
+    }
+  }));
+  return out.filter((t): t is CustomTheme => t !== null);
+}
+
+/** Make a user theme's stylesheet present in the document, once.
+ *
+ *  A <link> rather than an inline <style>: the browser caches it, it keeps
+ *  working when the CSP tightens (this one already allows only 'self' for
+ *  styles plus inline for CodeMirror), and DevTools shows a real stylesheet with
+ *  a real URL instead of an anonymous blob - which is what you want when the
+ *  file you are editing lives on disk.
+ *
+ *  Idempotent by id, because both the pre-paint script and the loader may reach
+ *  the same theme and two copies of one stylesheet is a cascade puzzle nobody
+ *  should have to debug. */
+export function applyLink(id: string): void {
+  const attr = 'data-bothy-user-theme';
+  if (document.querySelector(`link[${attr}="${id}"]`)) return;
+  const el = document.createElement('link');
+  el.rel = 'stylesheet';
+  el.setAttribute(attr, id);
+  el.href = THEME_DIR + encodeURIComponent(id) + '.css';
+  document.head.appendChild(el);
+}

--- a/apps/portal-next/web/src/lib/theme.tsx
+++ b/apps/portal-next/web/src/lib/theme.tsx
@@ -20,11 +20,12 @@
 // editing it means regenerating that hash. checks/csp_hash.mjs enforces both
 // halves.
 
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
-  DEFAULT_SELECTION, migrate, resolveSelection, THEMES,
+  byId, DEFAULT_SELECTION, migrate, resolveSelection, THEMES,
   type Appearance, type Selection, type ThemeDef,
 } from './themes';
+import { applyLink, loadCustomThemes } from './customThemes';
 
 export type { Selection, Appearance, ThemeDef };
 /** Kept as a name because the rest of the app talks about 'dark' | 'light'. */
@@ -34,12 +35,16 @@ const KEY = 'portal-theme';
 /** Read only by the pre-paint script in index.html. Never read back here - this
  *  module computes the appearance from the registry, which is the source. */
 const APPEARANCE_KEY = 'portal-theme-appearance';
+/** Also read only by the pre-paint script: whether the active theme's CSS has
+ *  to be FETCHED from /data/themes, or is already in the bundle. */
+const USER_KEY = 'portal-theme-is-user';
 const DARK_QUERY = '(prefers-color-scheme: dark)';
 
 const prefersDark = (): boolean =>
   typeof matchMedia !== 'undefined' && matchMedia(DARK_QUERY).matches;
 
-export const resolve = (sel: Selection): ThemeDef => resolveSelection(sel, prefersDark());
+export const resolve = (sel: Selection, all?: readonly ThemeDef[]): ThemeDef =>
+  resolveSelection(sel, prefersDark(), all);
 
 /** The browser/OS chrome around the page - Android's address bar, iOS's status
  *  bar in standalone mode - is painted from <meta name="theme-color">.
@@ -61,8 +66,8 @@ function paintChrome() {
   tag.setAttribute('content', bg);
 }
 
-function apply(sel: Selection) {
-  const t = resolve(sel);
+function apply(sel: Selection, all?: readonly ThemeDef[]) {
+  const t = resolve(sel, all);
   const el = document.documentElement;
   el.setAttribute('data-theme', t.appearance);
   el.setAttribute('data-bothy-theme', t.id);
@@ -71,7 +76,10 @@ function apply(sel: Selection) {
   // 'gruvbox' is dark or light - and without this it would guess dark and flash
   // the wrong frame at anyone using a light named theme. Writing it here means
   // the answer is always the one the app itself computed.
-  try { localStorage.setItem(APPEARANCE_KEY, t.appearance); } catch { /* private mode */ }
+  try {
+    localStorage.setItem(APPEARANCE_KEY, t.appearance);
+    localStorage.setItem(USER_KEY, t.user ? '1' : '0');
+  } catch { /* private mode */ }
   paintChrome();
 }
 
@@ -98,12 +106,54 @@ const read = (): Selection => {
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [selection, setSel] = useState<Selection>(read);
+  const [custom, setCustom] = useState<readonly ThemeDef[]>([]);
   const [theme, setTheme] = useState<ThemeDef>(() => resolve(read()));
 
+  // User themes: .css files dropped into apps/portal-next/data/themes on the
+  // box. Loaded once, after mount, and deliberately NOT awaited before the first
+  // paint - the pre-paint script in index.html has already linked the ACTIVE
+  // one by id, so the page it renders is correct without this. What this adds is
+  // the LIST, which is only needed once somebody opens the picker.
+  const [scanned, setScanned] = useState(false);
   useEffect(() => {
-    apply(selection);
-    setTheme(resolve(selection));
-  }, [selection]);
+    let alive = true;
+    loadCustomThemes()
+      .then((found) => {
+        if (!alive) return;
+        found.forEach((t) => applyLink(t.id));
+        setCustom(found);
+      })
+      // `scanned` flips on success AND on failure, because what it gates is
+      // "has the answer arrived", not "was it good news". Leaving it false after
+      // an error would freeze the page on whatever the pre-paint script guessed.
+      .finally(() => { if (alive) setScanned(true); });
+    return () => { alive = false; };
+  }, []);
+
+  const all = useMemo(() => [...THEMES, ...custom], [custom]);
+
+  useEffect(() => {
+    // DO NOT TOUCH THE DOM WHILE THE ANSWER IS STILL IN FLIGHT.
+    //
+    // A user theme's id is not in THEMES - it is a filename discovered after
+    // mount - so between mount and that fetch landing, resolveSelection() cannot
+    // find it and correctly falls back to Bothy Dark. Applying that fallback
+    // OVERWRITES the attribute the pre-paint script had already got right, and
+    // the page visibly flips to the default palette and back.
+    //
+    // Worse, and the reason this is a guard rather than a cosmetic fix: apply()
+    // also persists `portal-theme-is-user`, so the fallback wrote '0' for a
+    // theme that IS a user theme. Close the tab in that window and the next load
+    // no longer links the stylesheet at all - a transient race turned into a
+    // stuck wrong state.
+    //
+    // Until the scan lands, an unrecognised selection is left exactly as the
+    // pre-paint script stamped it, which is the one place that already knows the
+    // right answer.
+    if (!scanned && selection !== 'system' && !byId(selection, THEMES)) return;
+    apply(selection, all);
+    setTheme(resolve(selection, all));
+  }, [selection, all, scanned]);
 
   // Track a live OS flip. Without this, 'system' only ever sampled the OS at
   // mount, so switching the desktop to light left the portal dark until reload
@@ -111,10 +161,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (selection !== 'system' || typeof matchMedia === 'undefined') return;
     const mq = matchMedia(DARK_QUERY);
-    const onChange = () => { apply('system'); setTheme(resolve('system')); };
+    const onChange = () => { apply('system', all); setTheme(resolve('system', all)); };
     mq.addEventListener('change', onChange);
     return () => mq.removeEventListener('change', onChange);
-  }, [selection]);
+  }, [selection, all]);
 
   const setSelection = (s: Selection) => {
     try { localStorage.setItem(KEY, s); } catch { /* private mode */ }
@@ -131,7 +181,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   return (
     <Ctx.Provider value={{
-      selection, theme, resolved: theme.appearance, themes: THEMES, setSelection, cycle,
+      selection, theme, resolved: theme.appearance, themes: all, setSelection, cycle,
     }}>
       {children}
     </Ctx.Provider>

--- a/apps/portal-next/web/src/lib/themes.ts
+++ b/apps/portal-next/web/src/lib/themes.ts
@@ -40,6 +40,11 @@ export interface ThemeDef {
   /** The two palettes that live in index.css itself and need no theme file.
    *  They are the base every other theme is layered over. */
   builtin?: boolean;
+  /** Added by a person, loaded at runtime from /data/themes rather than compiled
+   *  into the bundle. The pre-paint script needs to know this and cannot work it
+   *  out - see the note on it in index.html - so it is persisted beside the
+   *  selection, which makes it a property of the theme rather than a lookup. */
+  user?: boolean;
 }
 
 export const THEMES: readonly ThemeDef[] = [
@@ -96,7 +101,12 @@ export type Selection = 'system' | (string & {});
 
 export const DEFAULT_SELECTION: Selection = 'bothy-dark';
 
-export const byId = (id: string): ThemeDef | undefined => THEMES.find((t) => t.id === id);
+/** `all` defaults to the built-ins and is widened at runtime to include the user
+ *  themes loaded from /data/themes. It is a PARAMETER rather than mutable module
+ *  state so this file keeps importing nothing and stays compilable on its own -
+ *  the same property discover.ts and config.ts depend on for their checks. */
+export const byId = (id: string, all: readonly ThemeDef[] = THEMES): ThemeDef | undefined =>
+  all.find((t) => t.id === id);
 
 /** Older builds stored 'dark' | 'light' | 'system' under the same key. Mapping
  *  rather than discarding matters: a stored 'light' is a user who chose light,
@@ -106,13 +116,27 @@ export function migrate(stored: string | null): Selection {
   if (stored === 'system') return 'system';
   if (stored === 'dark') return 'bothy-dark';
   if (stored === 'light') return 'bothy-light';
-  return byId(stored) ? stored : DEFAULT_SELECTION;
+  // NOT validated against THEMES, and that is the fix for a real bug rather than
+  // laxness: a USER theme's id is not in this file - it is a filename in
+  // /data/themes discovered after mount - so checking membership here threw the
+  // selection away on every reload and silently put the reader back on Bothy
+  // Dark. Shape is checked instead, and resolveSelection() already falls back
+  // safely when an id turns out to name nothing.
+  return /^[a-z0-9][a-z0-9-]*$/i.test(stored) ? stored : DEFAULT_SELECTION;
 }
 
 /** What a selection actually paints, with `system` collapsed against the OS.
  *  `prefersDark` is passed in rather than read here so this module stays free of
  *  browser globals and can be compiled and tested on its own. */
-export function resolveSelection(sel: Selection, prefersDark: boolean): ThemeDef {
-  if (sel === 'system') return byId(prefersDark ? 'bothy-dark' : 'bothy-light')!;
-  return byId(sel) ?? byId(DEFAULT_SELECTION)!;
+export function resolveSelection(
+  sel: Selection,
+  prefersDark: boolean,
+  all: readonly ThemeDef[] = THEMES,
+): ThemeDef {
+  if (sel === 'system') return byId(prefersDark ? 'bothy-dark' : 'bothy-light', all)!;
+  // Falling back to the default covers the case that actually happens: a user
+  // theme was selected and then its file was deleted from the box. The selection
+  // survives in localStorage and now names nothing, and the honest answer is the
+  // default palette rather than a page with no colours at all.
+  return byId(sel, all) ?? byId(DEFAULT_SELECTION, all) ?? THEMES[0];
 }

--- a/apps/portal-next/web/src/pages/Settings.css
+++ b/apps/portal-next/web/src/pages/Settings.css
@@ -126,3 +126,14 @@
    data-bothy-theme), so these rules must not paint any colour themselves. */
 
 
+
+/* A theme that came from the box rather than from the bundle. Quiet: it answers
+   "where did this come from" for someone who is looking, and says nothing to
+   anyone who is not. */
+.settings-page .theme-tag {
+  margin-left: 6px; padding: 1px 5px;
+  font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em;
+  color: var(--accent-fg);
+  background: var(--accent-bg); border: 1px solid var(--accent-line);
+  border-radius: var(--r-xs); vertical-align: 1px;
+}

--- a/apps/portal-next/web/src/pages/Settings.tsx
+++ b/apps/portal-next/web/src/pages/Settings.tsx
@@ -24,6 +24,7 @@ import { Ban, Circle, CircleCheck, LogIn } from 'lucide-react';
 import { ROLES, ROLE_MEANING, signInHref, type Me, type Role } from '../lib/me';
 import { useMe } from '../components/UserMenu';
 import { useTheme } from '../lib/theme';
+import { THEME_DIR_HOST } from '../lib/customThemes';
 import { ThemeSwatch } from '../components/ThemeSwatch';
 import { Skeleton } from '../components/states';
 import './Settings.css';
@@ -66,6 +67,7 @@ export function Settings() {
 
 function Appearance() {
   const { selection, theme, themes, setSelection } = useTheme();
+  const custom = themes.filter((t) => t.user).length;
 
   // System first, then the themes. It is the only entry that is not a palette -
   // it is a rule for picking one - so it gets said in words rather than given a
@@ -77,6 +79,22 @@ function Appearance() {
         <p className="set-lede">
           Kept in this browser. The topbar button still toggles dark, light and system;
           this is where the rest of them live.
+        </p>
+
+        {/* The only instruction on this page, and it earns its place: a theme
+            you add is a FILE, and nothing else on screen would tell you where
+            it goes. Deliberately a host path rather than a container one -
+            the person who needs this sentence is standing in the repo. */}
+        <p className="set-note">
+          Add your own by dropping a <code className="mono">.css</code> file into{' '}
+          <code className="mono">{THEME_DIR_HOST}</code> on the box and reloading.
+          One file is the whole theme, and it survives a rebuild — copy an existing
+          one to start.{' '}
+          {custom === 0
+            ? 'Nothing is there yet.'
+            : custom === 1
+              ? 'One theme below came from there.'
+              : `${custom} of the themes below came from there.`}
         </p>
 
         <div className="theme-grid" role="radiogroup" aria-label="Theme">
@@ -102,7 +120,10 @@ function Appearance() {
               className={`theme-card ${selection === t.id ? 'is-on' : ''}`}
               onClick={() => setSelection(t.id)}
             >
-              <span className="theme-name">{t.name}</span>
+              <span className="theme-name">
+                {t.name}
+                {t.user && <span className="theme-tag">yours</span>}
+              </span>
               <span className="theme-note">{t.note}</span>
               <ThemeSwatch id={t.id} />
             </button>


### PR DESCRIPTION
Answers your framing directly: **someone who downloaded Bothy and ran it**, with no source tree and no build step, who wants a different theme.

Drop a `.css` into `apps/portal-next/data/themes/`, reload. It appears in the picker tagged **yours**. That is the whole procedure.

## Why there

It has to survive `docker compose up --build`, which replaces the image and everything in it. A bind-mounted directory is the only place that is both writable from outside the image and readable by the page — and it is where `projects.json` already lives, for the same reason.

## The file is the registration

nginx lists the directory as JSON (`autoindex_format json`), so dropping a file in **is** adding a theme. The alternative was an index listing every theme, which is a second file to keep in step with the first: drop in a `.css`, forget the index, and the theme silently does not exist. Here the filesystem is the list, and renaming the file renames the theme — which is what anyone would guess.

Metadata lives in a header comment inside the CSS, so a theme is **one thing you can send someone**:

```css
/* bothy-theme
   name: Deep Ocean
   appearance: dark
   note: One line, shown under the name in the picker.
*/
```

All optional except `color-scheme`, and `data/themes/README.md` explains why.

## Two races, both found by running it rather than reading it

**The pre-paint script has to link a user theme itself**, or the first frame is the base palette. It cannot tell a bundled `tokyo-night` from a user `tokyo-night` without the registry — and putting the registry in that script would mean regenerating the CSP hash every time a theme is added. So the app persists the one bit it needs, the same way it already persists the resolved appearance.

**Then the worse one.** Between mount and the directory scan landing, a user theme's id is in nobody's registry, so `resolveSelection()` correctly fell back to Bothy Dark — and applying that fallback **overwrote the attribute the pre-paint script had just got right**. The page flipped to the default and back.

Worse: `apply()` also persists `is-user`, so the fallback wrote `'0'` for a theme that *is* a user theme. Close the tab in that window and the next load stopped linking the stylesheet at all — a transient race turned into a stuck wrong state. Fixed by leaving an unrecognised selection alone until the scan lands.

`migrate()` had the same shape of bug and is fixed with it: it validated the stored selection against `THEMES`, so a user theme was discarded on every reload.

## Also here: the contract moves to a shared module

`checks/theme-contract.mjs` kept the rules and the colour maths in a node-only script. They move to `lib/contract.ts` — imports nothing, compiled by `run.sh` the way `discover.ts` already is. The check keeps the CSS parsing and the printing.

This is what the in-app theme editor needs to show the **same** warnings live while you pick colours, and two copies of a threshold is one copy that will be wrong. Output is **byte-identical: 292 pass, 0 fail, before and after.**

## Verified

- Full `checks/run.sh` green, exit 0. `just files-check` clean, `just verify` 23/23.
- New `checks/user-themes.mjs` — 16 cases over the header parser on shapes a hand-written file actually takes: no header at all, CRLF, a `note:` containing a colon, a header contradicting `color-scheme`. Getting `appearance` wrong is not cosmetic; it decides which base palette the first frame uses.
- Live, in an isolated browser: the picker lists 9 entries with Solarized Dark tagged `yours`; selecting it stamps `data-bothy-theme=solarized-dark`, paints `--bg: #002b36`, links the stylesheet and stores the flag; **a returning visitor loads straight into it with no flip**.

## Next

The in-app editor — create/edit/live-preview/delete — now has everything it needs: a place to write to, a loader that picks it up on reload, and a contract module that can warn in the browser. `.css` became writable through the file service in #65, so no policy change is needed.