### PR TITLE
feat(theme): make a theme by looking at it

### DIFF
--- a/apps/portal-files/app.py
+++ b/apps/portal-files/app.py
@@ -49,6 +49,15 @@ tidy:
 
   * The audit trail had to be rebuilt. Every write used to carry an author
     because every write was a commit; see audit().
+
+**DELETE exists, and ONLY because the undo net does.** Removal was deliberately
+absent while this service had no way to give a file back - `discard` was taken
+out on 2026-08-15 for being the one irreversible verb here, and a delete with no
+copy anywhere would have put that back under a friendlier name. The snapshot
+trash changed the arithmetic rather than the appetite: /delete keeps the outgoing
+bytes exactly as /write does, so removing a file is a thing you can walk back
+from. That is also why the snapshot is the ONE place this service fails CLOSED
+where the write path fails open - see _delete().
 """
 
 from __future__ import annotations
@@ -865,13 +874,17 @@ class Handler(BaseHTTPRequestHandler):
             sys.stderr.write(f"ERROR {route}: {type(e).__name__}: {e}\n")
             return self._send(500, {"error": "internal error"})
 
-    # ── write ───────────────────────────────────────────────────────────────
+    # ── write and delete ────────────────────────────────────────────────────
     def do_POST(self) -> None:  # noqa: N802
         route = urlparse(self.path).path
         # Every mutating endpoint goes through the same guard below. Adding one
         # that skips it is the failure mode this shape exists to prevent, so the
         # list is here rather than each handler remembering.
-        # /write is the ONLY mutating endpoint on this service.
+        # /write and /delete are the ONLY mutating endpoints on this service, and
+        # they are named in ONE place on purpose. The CSRF, content-type and body
+        # limits below are shared, so a third verb that dispatched itself before
+        # reaching them would silently be the unprotected one - which is exactly
+        # how a per-handler check goes wrong.
         #
         # /git/stage, /git/unstage, /git/discard, /git/commit, /git/pull and
         # /git/push were removed on 2026-08-15. Git actions are moving to an
@@ -883,7 +896,12 @@ class Handler(BaseHTTPRequestHandler):
         # away content that was never in the object store); the push credential,
         # which was the ONLY secret this container was ever going to hold; and
         # the `operator` tier, which existed solely to gate sync.
-        if route != "/write":
+        #
+        # /delete is NOT `discard` coming back, and the difference is the whole
+        # licence for it: discard destroyed content that had never been anywhere
+        # else, while a delete here refuses unless the snapshot trash took a copy
+        # first. Removal is offered because the net exists, not despite it.
+        if route not in ("/write", "/delete"):
             return self._send(404, {"error": "no such endpoint"})
         # ── CSRF, and why it is needed HERE and not before ──────────────────
         #
@@ -920,6 +938,13 @@ class Handler(BaseHTTPRequestHandler):
             if length <= 0 or length > safepath.MAX_BYTES:
                 return self._send(413, {"error": "body missing or too large"})
             body = json.loads(self.rfile.read(length))
+
+            # Dispatched AFTER the guards above, never before them. _delete does
+            # its own resolve() because a delete has no `content` and no temp
+            # file, but it reaches this line having already paid the same CSRF,
+            # content-type and body-size tolls as a save.
+            if route == "/delete":
+                return self._delete(body)
 
             res = safepath.resolve(body.get("root", ""), body.get("path", ""),
                                    for_write=True)
@@ -1052,9 +1077,151 @@ class Handler(BaseHTTPRequestHandler):
         except json.JSONDecodeError:
             return self._send(400, {"error": "body must be JSON"})
         except Exception as e:  # noqa: BLE001
-            sys.stderr.write(f"ERROR /write: {type(e).__name__}: {e}\n")
+            # The ROUTE, not a hardcoded "/write". Two verbs share this handler
+            # now, and a 500 attributed to the wrong one sends whoever reads the
+            # log to the wrong half of the file.
+            sys.stderr.write(f"ERROR {route}: {type(e).__name__}: {e}\n")
             return self._send(500, {"error": "internal error"})
 
+    # ── delete ──────────────────────────────────────────────────────────────
+    def _delete(self, body: dict) -> None:
+        """Remove one regular file, after keeping a copy of it.
+
+        Reached only through do_POST, so the CSRF and body guards have already
+        run. Every refusal below returns with the file still on disk; that is the
+        property the checks assert, because a 403 that deleted anyway would look
+        identical from the status code.
+        """
+        # Deleting IS a write, so it goes through the SAME resolve() with the
+        # same for_write rules: containment proved on the resolved path, no
+        # writing through a symlink, and nothing under a read-only root. A
+        # narrower check written here would be a second boundary to keep correct,
+        # which is the duplication safepath exists to prevent.
+        res = safepath.resolve(body.get("root", ""), body.get("path", ""),
+                               for_write=True)
+        # Belt and braces with the `ro` bind mount, exactly as /write does it. The
+        # kernel refuses regardless, but EROFS surfaces as an opaque 500, and the
+        # rule is worth being able to read in the code.
+        if res.root_key in READONLY_ROOTS:
+            return self._send(403, {
+                "error": f"the {res.root_key!r} root is read-only"})
+
+        # lstat, not stat, and the FileNotFoundError branch is the 404 the caller
+        # was promised would be DISTINGUISHABLE from a refusal. "there is nothing
+        # here" and "you may not touch this" send someone to two different
+        # places, and collapsing them into one code is how a deleted-by-someone-
+        # else file gets reported as a permissions problem.
+        try:
+            st = os.lstat(res.abspath)
+        except FileNotFoundError:
+            return self._send(404, {"error": "no such file", "path": res.relpath})
+        except OSError as e:
+            return self._send(403, {"error": f"cannot stat: {e.strerror}"})
+
+        # A DIRECTORY IS REFUSED EXPLICITLY, and that is the whole point of this
+        # branch existing at all. os.unlink would raise EISDIR and land in the
+        # 500 handler - a refusal by accident, which reads as a bug in the
+        # service rather than as a decision, and which stops holding the moment
+        # somebody "fixes" the 500 with rmtree. Recursive delete is out of scope:
+        # one click that removes a subtree has no proportionate undo, because the
+        # snapshot net below is per file.
+        if stat.S_ISDIR(st.st_mode):
+            return self._send(403, {
+                "error": "refusing to delete a directory - one regular file at a time",
+                "path": res.relpath})
+        if not stat.S_ISREG(st.st_mode):
+            # A fifo, socket or device node. os.walk puts these in filenames, so
+            # they are reachable; none of them has bytes a snapshot could keep,
+            # so removing one would be the unrecoverable case wearing a filename.
+            return self._send(403, {
+                "error": "not a regular file", "path": res.relpath})
+
+        # Attribution only, same header and same fallback as /write - see the
+        # module docstring. A missing header means a misconfigured edge, and
+        # losing the name is not a reason to refuse a legitimate action.
+        who = (self.headers.get("X-Auth-Request-Email")
+               or self.headers.get("X-Auth-Request-User") or "unknown")
+
+        # ── THE CONFLICT CHECK, for the reason /write has one ────────────────
+        #
+        # Deleting a file somebody rewrote a minute ago is the same class of
+        # mistake as overwriting it: the tab you are looking at is stale and
+        # nothing on the screen says so. If anything it is the worse half - an
+        # overwrite leaves a file behind to notice, a delete leaves an absence.
+        #
+        # OPTIONAL exactly as it is on the write path, so curl and scripts are
+        # not blocked; a client that sends it gets the guarantee, and the UI
+        # always sends it.
+        base_mtime = body.get("baseMtime")
+        if base_mtime is not None:
+            current = int(st.st_mtime)
+            if int(base_mtime) != current:
+                return self._send(409, {
+                    "error": "the file changed on disk since you opened it",
+                    "path": res.relpath,
+                    "baseMtime": int(base_mtime), "currentMtime": current,
+                    # The SIZE, not the bytes. /write returns both versions
+                    # because it has keep/take/compare to offer; there is no
+                    # merge to offer for a delete, and the file may be a 200 MB
+                    # binary that a 409 body has no business carrying.
+                    "size": st.st_size,
+                })
+
+        # ── THE UNDO NET, AND IT FAILS CLOSED HERE ───────────────────────────
+        #
+        # /write treats a missing snapshot as survivable and reports it: refusing
+        # a save would destroy the very work the net exists to protect - unsaved
+        # changes in a tab with nowhere to put them. A DELETE inverts that
+        # argument completely. Refusing costs the caller nothing, because the
+        # file they asked to remove is still sitting there; proceeding without a
+        # copy is the one outcome on this service that nothing can walk back.
+        #
+        # So this is the single place where the net is a PRECONDITION.
+        # safepath.snapshot returns None for a real failure - an unwritable
+        # trash, or a file above SNAPSHOT_MAX_BYTES - and both are reasons to
+        # stop rather than to shrug. The 16 MB ceiling means a very large file
+        # cannot be removed through this API at all; that is a deliberate
+        # consequence of the guarantee, and the error says so rather than
+        # pretending the path was refused.
+        kept = safepath.snapshot(res.root_key, res.relpath, res.abspath)
+        if kept is None:
+            # Logged even though nothing changed. The write path logs its
+            # equivalent (NOSNAPSHOT) for the same reason: "the trash stopped
+            # working" is precisely what this log gets read for afterwards, and a
+            # refusal that leaves no trace is one nobody finds out about until a
+            # delete that mattered.
+            audit(who, "DELETE-REFUSED", res, st.st_size, "no snapshot was kept")
+            return self._send(403, {
+                "error": "refusing to delete: the previous version could not be "
+                         "kept, so this would not be undoable",
+                "path": res.relpath, "size": st.st_size})
+
+        try:
+            os.unlink(res.abspath)
+        except FileNotFoundError:
+            # Removed by somebody else between the lstat and here. Their outcome
+            # is the one that was asked for, so it is not an error - but it is a
+            # 404 and not a 200, because THIS request did not do it and the
+            # audit line below would otherwise credit it.
+            return self._send(404, {"error": "no such file", "path": res.relpath})
+        except OSError as e:
+            return self._send(403, {"error": f"cannot delete: {e.strerror}"})
+
+        # The same audit line /write writes, through the same function, with the
+        # same attribution. It matters more here than anywhere else: for every
+        # other change the file itself is evidence of what happened, and after a
+        # delete this line is the only record that the file ever existed.
+        audit(who, "DELETED", res, st.st_size)
+        return self._send(200, {
+            "ok": True, "root": res.root_key, "path": res.relpath,
+            "author": who, "bytes": st.st_size,
+            # Always true by the time we reach this line - the refusal above is
+            # the alternative. Reported anyway, so "you can undo this" is
+            # something the UI reads from the response rather than something it
+            # assumes about the server.
+            "snapshot": True,
+            "versioned": res.git_root is not None,
+        })
 
     # ── raw bytes ───────────────────────────────────────────────────────────
     def _raw(self, q: dict) -> None:

--- a/apps/portal-files/checks/authz_probe.py
+++ b/apps/portal-files/checks/authz_probe.py
@@ -15,6 +15,12 @@ but deliberately NOT `shell`. So:
 
 If BOTH pass, the parameter is being ignored and a shell-gated route would be
 wide open to any logged-in user. That is the failure this script exists to catch.
+
+TWO HALVES, and the second was added with /delete. Proving the gate works is not
+proving that a route stands behind it - a mutating endpoint wired to `sso-viewer`
+or to nothing at all would sail past everything above. So section 5 reads
+Traefik's runtime router table and asserts which middleware each portal-files
+route carries, then confirms an anonymous delete is refused by the edge.
 """
 import os
 import re
@@ -80,12 +86,61 @@ if held == 202 and not_held != 202 and bogus != 202:
     print("  VERDICT: per-route roles ARE enforced.")
     print("           One oauth2-proxy can gate every route; the requirement")
     print("           lives in the Traefik middleware. Design is viable.")
-    sys.exit(0)
+    rc = 0
 elif held == 202 and not_held == 202:
     print("  VERDICT: allowed_groups IS IGNORED - a role-gated route would be")
     print("           open to ANY logged-in user. Do NOT build on this.")
     print("           Fall back to one oauth2-proxy instance per role.")
-    sys.exit(1)
+    rc = 1
 else:
     print(f"  VERDICT: unexpected. editor={held} shell={not_held} bogus={bogus}")
-    sys.exit(2)
+    rc = 2
+
+# ── 5. and WHICH gate each route is actually wired to ───────────────────────
+#
+# Everything above proves the gate WORKS. It says nothing about whether any given
+# route USES it, and that is the half that protects a file. A mutating endpoint
+# routed with `sso-viewer` - or with no middleware at all - would be open to
+# every logged-in user while this script still printed its cheerful verdict.
+#
+# devssh holds `editor`, so there is no authenticated session on this box that
+# lacks it and the per-route refusal cannot be observed directly. The wiring can
+# be, and combined with the verdict above it is the same claim: this route
+# demands a role, and that demand is enforced.
+#
+# Read from Traefik's RUNTIME router table rather than from the YAML on disk.
+# That is deliberate: edge/dynamic is rendered as a Go template first, and a
+# doubled brace anywhere - including inside a comment - voids the whole file
+# while it still looks perfect on disk. A router that failed to render is exactly
+# the failure this section exists to catch, and it is invisible to anything that
+# reads the source.
+print("\n  code  route wiring")
+route_fail = 0
+routers = {r["name"]: r for r in
+           requests.get(f"{BASE}/-/api/traefik/http/routers", timeout=10).json()}
+
+for name, want in (("portal-files-read@file", "sso-viewer@file"),
+                   ("portal-files-write@file", "sso-editor@file"),
+                   ("portal-files-delete@file", "sso-editor@file")):
+    r = routers.get(name)
+    mws = r.get("middlewares", []) if r else []
+    ok = bool(r) and want in mws and r.get("status") == "enabled"
+    route_fail |= 0 if ok else 1
+    print(f"  {'PASS' if ok else 'FAIL'}  {name:<26} "
+          f"{want if ok else (mws or 'NO SUCH ROUTER - did the template void the file?')}")
+
+# The one session on this box that provably lacks `editor` is no session at all.
+# The path is deliberately a file that does NOT exist: if the gate were open this
+# probe must not be the thing that destroys something, and the 404 it would get
+# instead is itself the tell - a 404 means the request reached the service, which
+# means the edge let an anonymous delete through.
+r = requests.post(f"{BASE}/-/api/files/delete",
+                  json={"root": "notes", "path": "_authz-probe-no-such-file.md"},
+                  timeout=10)
+ok = r.status_code in (401, 403)
+route_fail |= 0 if ok else 1
+print(f"  {'PASS' if ok else 'FAIL'}  anonymous /delete is refused   "
+      f"got {r.status_code}"
+      f"{' - it reached the SERVICE, the edge is not gating it' if r.status_code == 404 else ''}")
+
+sys.exit(rc if rc else route_fail)

--- a/apps/portal-files/checks/delete_semantics.py
+++ b/apps/portal-files/checks/delete_semantics.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Delete removes a file, keeps the bytes it removed, and refuses six things.
+
+THE ASSERTION THAT EARNS THIS VERB is not "the file is gone" - that half is
+trivial and a broken implementation passes it. It is "the bytes are in the trash
+AND they are the right bytes". A snapshot that is empty, or that holds the wrong
+version, is exactly as destructive as no snapshot at all and looks identical from
+the response, which reports only `snapshot: true`.
+
+The six refusals are each checked WITH THE FILE STILL ON DISK AFTERWARDS, for the
+same reason: a 403 that deleted anyway is indistinguishable from a correct 403 if
+you only read status codes. That mistake is cheap to make and expensive to find.
+
+Everything here runs through HTTP, so it exercises the Traefik route and the
+edge's role gate as well as the handler - checks/test_safepath.py already covers
+the boundary in-process, and a second in-process copy would prove nothing new.
+"""
+import os
+import re
+import subprocess
+import sys
+
+import requests
+
+BASE = "http://100.117.176.85"
+API = f"{BASE}/-/api/files"
+# ~/claude-notes, not ~/stacks. e2e.py ends in `git reset --hard` on stacks and
+# snapshots.py plants its probe at the top of it; sharing a repo with either
+# means one check's cleanup is another's missing file.
+REPO = "/home/devssh/claude-notes"
+TRASH = "/home/devssh/.local/state/bothy/trash"
+PROBE = "_delete_probe.md"
+PROBE_DIR = "_delete_probe_dir"
+DISK = f"{REPO}/{PROBE}"
+SNAPS = f"{TRASH}/notes/{PROBE}"
+KEEP = "keep me - this is the version a delete must preserve\n"
+
+fails = 0
+
+
+def check(label, ok, detail=""):
+    global fails
+    if not ok:
+        fails += 1
+    print(f"{'PASS' if ok else 'FAIL'}  {label:<56} {detail}")
+
+
+def snaps():
+    try:
+        return sorted(f for f in os.listdir(SNAPS) if not f.startswith("."))
+    except FileNotFoundError:
+        return []
+
+
+def delete(sess, root, path, mtime=None, **kw):
+    body = {"root": root, "path": path}
+    if mtime is not None:
+        body["baseMtime"] = mtime
+    r = sess.post(f"{API}/delete", json=body, timeout=20, **kw)
+    ctype = r.headers.get("content-type", "")
+    return r.status_code, (r.json() if ctype.startswith("application/json") else {})
+
+
+# Refuse to run rather than clean up first. A leftover probe from an interrupted
+# run would make the "nothing in the trash yet" assertions pass or fail for
+# reasons that have nothing to do with the code under test.
+if os.path.exists(DISK) or snaps() or os.path.exists(f"{REPO}/{PROBE_DIR}"):
+    sys.exit(f"REFUSING TO RUN: {DISK}, {REPO}/{PROBE_DIR} or its snapshots "
+             f"already exist")
+
+s = requests.Session()
+r = s.get(f"{BASE}/oauth2/start", params={"rd": "/"}, allow_redirects=True, timeout=10)
+m = re.search(r'action="([^"]+)"', r.text)
+s.post(m.group(1).replace("&amp;", "&"),
+       data={"username": os.environ["DEV_LOGIN_USER"],
+             "password": os.environ["DEV_LOGIN_PASSWORD"]},
+       allow_redirects=True, timeout=10)
+
+try:
+    print("── anonymous: the route is gated before anything else is asked ─────")
+    # No session at all. This is the cheap half of the role check -
+    # authz_probe.py proves the `editor` gate is enforced and that this route is
+    # the one wired to it; here we only establish that SOMETHING refuses an
+    # unauthenticated delete, and that it refuses before touching the disk.
+    open(DISK, "w").write(KEEP)
+    code, _ = delete(requests.Session(), "notes", PROBE)
+    check("an anonymous delete is refused", code in (401, 403), f"got {code}")
+    check("and the file is still there", os.path.exists(DISK))
+
+    print("\n── the CSRF guard covers the NEW verb too ──────────────────────────")
+    # /write and /delete share one do_POST, and the guards sit above the
+    # dispatch precisely so a second verb cannot skip them. That arrangement is
+    # invisible from outside, so it is asserted from outside: a text/plain POST
+    # is a CORS-simple request, which is why demanding JSON is the load-bearing
+    # half of the protection rather than a content negotiation nicety.
+    r = s.post(f"{API}/delete", data='{"root":"notes","path":"' + PROBE + '"}',
+               headers={"Content-Type": "text/plain"}, timeout=20)
+    check("a text/plain delete is refused (no preflight = no protection)",
+          r.status_code == 415, f"got {r.status_code}")
+    check("and the file survived it", os.path.exists(DISK))
+
+    print("\n── the refusals, each with the file still on disk afterwards ───────")
+    code, out = delete(s, "notes", "../../etc/passwd")
+    check("a path outside the root is refused", code == 403, f"got {code}")
+
+    code, out = delete(s, "notes", "/etc/passwd")
+    check("an absolute path is refused", code == 403, f"got {code}")
+
+    # ~/projects is read-only in policy AND mounted `ro`. The path is a file that
+    # really exists, deliberately: pointing at a missing one would let a 404 pass
+    # for a read-only refusal and the check would still look green.
+    victim = "army/CVOps/docs/01-principles-and-architecture.md"
+    code, out = delete(s, "projects", victim)
+    check("the read-only projects root is refused", code == 403, f"got {code}")
+    check("...and it named the ROOT, not the path", "read-only" in str(out.get("error")),
+          out.get("error"))
+    check("...and that real file is untouched",
+          os.path.exists(f"/home/devssh/projects/{victim}"))
+
+    # A directory must be refused ON PURPOSE. If this ever returns 500 the
+    # refusal has become an accident of os.unlink raising EISDIR, which is one
+    # well-meant "fix" away from being a recursive delete.
+    os.makedirs(f"{REPO}/{PROBE_DIR}", exist_ok=True)
+    open(f"{REPO}/{PROBE_DIR}/inside.md", "w").write("still here\n")
+    code, out = delete(s, "notes", PROBE_DIR)
+    check("a directory is refused", code == 403, f"got {code}")
+    check("...deliberately, not by a 500 from EISDIR",
+          "directory" in str(out.get("error")), out.get("error"))
+    check("...and the directory and its contents remain",
+          os.path.exists(f"{REPO}/{PROBE_DIR}/inside.md"))
+
+    # 404, and it must be TELLABLE from the 403s above. A missing file reported
+    # as a refusal sends the caller looking for a permissions problem that does
+    # not exist.
+    code, out = delete(s, "notes", "_delete_no_such_file.md")
+    check("a missing file is 404, not 500", code == 404, f"got {code}")
+    check("...and 404 is distinct from every refusal above", code != 403,
+          out.get("error"))
+
+    print("\n── THE CONFLICT: a stale delete is refused, and the file stays ─────")
+    r = s.get(f"{API}/read", params={"root": "notes", "path": PROBE}, timeout=15)
+    check("the probe reads back", r.status_code == 200, f"got {r.status_code}")
+    stale = r.json()["mtime"] - 1        # what a tab opened one edit ago holds
+
+    code, out = delete(s, "notes", PROBE, mtime=stale)
+    check("a stale delete is REFUSED with 409", code == 409, f"got {code}")
+    check("and the file is STILL THERE", os.path.exists(DISK)
+          and open(DISK).read() == KEEP)
+    check("the response says which mtimes disagreed",
+          out.get("baseMtime") != out.get("currentMtime"),
+          f"{out.get('baseMtime')} vs {out.get('currentMtime')}")
+    check("nothing was snapshotted by a refusal", snaps() == [], f"{snaps()}")
+
+    print("\n── the delete itself, and the copy it must leave behind ────────────")
+    cur = s.get(f"{API}/read", params={"root": "notes", "path": PROBE},
+                timeout=15).json()["mtime"]
+    code, out = delete(s, "notes", PROBE, mtime=cur)
+    check("a current delete is accepted", code == 200, f"got {code}")
+    check("the file is gone from disk", not os.path.exists(DISK))
+    check("the response reports the undo net", out.get("snapshot") is True,
+          f"snapshot={out.get('snapshot')}")
+    check("...and who did it", out.get("author") == os.environ["DEV_LOGIN_USER"],
+          out.get("author"))
+
+    kept = snaps()
+    check("exactly one copy is in the trash", len(kept) == 1, f"{kept}")
+    # THE ASSERTION THIS FILE EXISTS FOR. A file of the right name proves
+    # nothing; the failure mode is a snapshot that is empty because it was taken
+    # after the unlink, or one that never happened while the response still said
+    # `snapshot: true`.
+    body = open(f"{SNAPS}/{kept[0]}").read() if kept else ""
+    check("and it holds the bytes that were REMOVED", body == KEEP, repr(body[:32]))
+
+    print("\n── the audit log is the only record a deleted file leaves ──────────")
+    log = subprocess.run(["docker", "exec", "portal-files", "cat", "/audit/writes.log"],
+                         capture_output=True, text=True).stdout
+    lines = [l for l in log.splitlines() if PROBE in l and "DELETED" in l]
+    check("the delete is in the audit log", bool(lines))
+    check("...with the same attribution a write gets",
+          bool(lines) and os.environ["DEV_LOGIN_USER"] in lines[-1])
+    if lines:
+        print("      " + lines[-1])
+
+    print("\n── deleting the same file twice is 404, not a second success ───────")
+    code, out = delete(s, "notes", PROBE)
+    check("the second delete is 404", code == 404, f"got {code}")
+    check("and it did not bank a second snapshot", len(snaps()) == 1, f"{snaps()}")
+
+finally:
+    print("\n── cleanup ─────────────────────────────────────────────────────────")
+    for p in (DISK, f"{REPO}/{PROBE_DIR}/inside.md"):
+        if os.path.exists(p):
+            os.remove(p)
+    if os.path.isdir(f"{REPO}/{PROBE_DIR}"):
+        os.rmdir(f"{REPO}/{PROBE_DIR}")
+    subprocess.run(["rm", "-rf", SNAPS], check=False)
+    # git_ops.py refuses to run against a dirty ~/claude-notes, so leaving one
+    # file behind here fails a check three sections away from the cause.
+    dirty = subprocess.run(["git", "-C", REPO, "status", "--porcelain"],
+                           capture_output=True, text=True).stdout.strip()
+    check("the probe left nothing behind", not dirty, dirty)
+
+print(f"\n{fails} FAILED" if fails else "\nall pass")
+sys.exit(1 if fails else 0)

--- a/apps/portal-files/checks/e2e.py
+++ b/apps/portal-files/checks/e2e.py
@@ -9,7 +9,8 @@ Checks the things a status code cannot:
   - the write is recorded in the audit log, which replaced the commit as the
     thing that says who changed what
   - the path guards still hold THROUGH the HTTP layer, not just in the unit test
-  - a non-writable extension is refused even for an authenticated editor
+  - and the guards that were REMOVED on 2026-08-17 are gone in the direction
+    intended: a risky suffix writes, and the service says what it costs
 """
 import os
 import re
@@ -108,18 +109,24 @@ check("the write is in the audit log, with an author",
       TESTFILE in alog and os.environ["DEV_LOGIN_USER"] in alog)
 
 print("\n── guards still hold through HTTP, for an AUTHENTICATED editor ──────")
+# THIS TABLE SHRANK ON 2026-08-17, and what left it matters as much as what
+# stayed. `.sh`, `compose.yml` and `.env` used to sit here expecting 403, because
+# [write].suffixes was an allowlist of prose formats. That allowlist is gone -
+# policy.toml carries the argument - and these three assertions did not merely go
+# stale, they turned DESTRUCTIVE: the `.env` case wrote "x" over ~/stacks/.env on
+# every run, and the rest of the suite then failed because `just` could no longer
+# parse the file it had just clobbered. It was recovered from the snapshot trash,
+# which is the best advertisement the undo net has had.
+#
+# What remains is the part that is not a preference: containment, the denied
+# directories, read-only roots, unknown roots.
 for label, payload, want in [
     ("traversal out of the root",
      {"root": "stacks", "path": "../../etc/passwd", "content": "x"}, 403),
     ("absolute path",
      {"root": "stacks", "path": "/etc/passwd", "content": "x"}, 403),
-    ("a shell script",
-     {"root": "stacks", "path": "docs/kb/evil.sh", "content": "x"}, 403),
-    ("a compose file",
-     {"root": "stacks", "path": "docs/kb/compose.yml", "content": "x"}, 403),
     ("the repo's own .git",
      {"root": "stacks", "path": ".git/config", "content": "x"}, 403),
-    ("a denied secret", {"root": "stacks", "path": ".env", "content": "x"}, 403),
     ("the read-only projects root",
      {"root": "projects", "path": "notes.md", "content": "x"}, 403),
     ("an unknown root",
@@ -128,21 +135,45 @@ for label, payload, want in [
     rr = s.post(f"{API}/write", json=payload, timeout=10)
     check(label, rr.status_code == want, f"got {rr.status_code}")
 
-check("no stray files were created",
-      not os.path.exists(f"{REPO}/docs/kb/evil.sh")
-      and not os.path.exists(f"{REPO}/docs/kb/compose.yml"))
+print("\n── ...and what is no longer refused SAYS WHAT IT COSTS instead ──────")
+# The inversion, asserted rather than assumed. A suffix that used to be blocked
+# now writes, and the service warns through /read's `caution` rather than
+# refusing. To a PROBE path, never to the real file: the claim is that the
+# refusal is gone, not that this test is entitled to rewrite the box.
+PROBE_SH = "docs/kb/_e2e-probe.sh"
+rr = s.post(f"{API}/write", json={"root": "stacks", "path": PROBE_SH,
+                                  "content": "#!/bin/sh\necho probe\n"}, timeout=10)
+check("a shell script is now WRITABLE, not refused", rr.status_code == 200,
+      f"got {rr.status_code}")
+rr = s.get(f"{API}/read", params={"root": "stacks", "path": PROBE_SH}, timeout=10)
+check("...and /read says what running it costs",
+      (rr.json().get("caution") or {}).get("level") == "critical",
+      str((rr.json().get("caution") or {}).get("level")))
+
+# .env is READ here and never written. It holds 19 live secret values, and the
+# whole point of the paragraph above is that this endpoint would now happily
+# overwrite it - so the assertion is that the service MARKS it, not that it is
+# safe to prod.
+rr = s.get(f"{API}/read", params={"root": "stacks", "path": ".env"}, timeout=10)
+check("the real .env opens - marked, no longer hidden", rr.status_code == 200,
+      f"got {rr.status_code}")
+d = rr.json() if rr.status_code == 200 else {}
+check("...and is flagged both by name and by caution",
+      bool(d.get("sensitive")) and (d.get("caution") or {}).get("level") == "critical",
+      f"sensitive={str(d.get('sensitive'))[:34]!r}")
 
 print("\n── cleanup ─────────────────────────────────────────────────────────")
-# The file is untracked now (no commit), so reset --hard does not remove it.
-# Delete it, then reset as a backstop for anything else this touched.
-if os.path.exists(f"{REPO}/{TESTFILE}"):
-    os.remove(f"{REPO}/{TESTFILE}")
+# The files are untracked now (no commit), so reset --hard does not remove them.
+# Delete them, then reset as a backstop for anything else this touched.
+for stray in (TESTFILE, PROBE_SH):
+    if os.path.exists(f"{REPO}/{stray}"):
+        os.remove(f"{REPO}/{stray}")
 subprocess.run(["git", "-C", REPO, "reset", "--hard", before],
                capture_output=True, text=True)
-gone = not os.path.exists(f"{REPO}/{TESTFILE}")
+gone = not any(os.path.exists(f"{REPO}/{p}") for p in (TESTFILE, PROBE_SH))
 head = subprocess.run(["git", "-C", REPO, "rev-parse", "HEAD"],
                       capture_output=True, text=True).stdout.strip()
-check("probe file removed, history untouched", head == before and gone, f"HEAD={head[:9]}")
+check("probe files removed, history untouched", head == before and gone, f"HEAD={head[:9]}")
 
 print(f"\n{fails} FAILED" if fails else "\nall pass")
 sys.exit(1 if fails else 0)

--- a/apps/portal-files/checks/run.sh
+++ b/apps/portal-files/checks/run.sh
@@ -6,7 +6,9 @@
 #   test_safepath.py  the security boundary as a PURE unit - 30 cases including
 #                     real planted symlinks. Runs anywhere, needs nothing up.
 #   authz_probe.py    does oauth2-proxy actually enforce a per-route role? Asks
-#                     for a role the user does NOT hold and requires a 403.
+#                     for a role the user does NOT hold and requires a 403 - then
+#                     reads Traefik's runtime router table to check which gate
+#                     each route is actually wired to.
 #   e2e.py            the whole path: anonymous refused, login, write, and the
 #                     guards re-checked THROUGH http rather than in-process.
 #
@@ -47,6 +49,13 @@ python3 checks/git_ops.py || fail=1
 
 echo; echo "── the undo net: an overwrite keeps what it destroyed ───────"
 python3 checks/snapshots.py || fail=1
+
+echo; echo "── delete: and the net is a PRECONDITION for it ─────────────"
+# Runs after snapshots.py on purpose. Delete is only defensible because the undo
+# net works, so the check that the net works should have gone green first - a
+# delete suite passing while the trash is broken would be reporting the wrong
+# thing as healthy.
+python3 checks/delete_semantics.py || fail=1
 
 echo; echo "── search must not see what the explorer refuses to open ────"
 # The endpoint reads FILE CONTENT, so a deny-list miss here shows a secret's

--- a/apps/portal-next/web/src/App.tsx
+++ b/apps/portal-next/web/src/App.tsx
@@ -7,6 +7,7 @@ import { ProjectDetail } from './pages/ProjectDetail';
 import { Ports, Routes as RoutesPage } from './pages/Access';
 import { Topology } from './pages/Topology';
 import { Settings } from './pages/Settings';
+import { ThemeEditor } from './pages/ThemeEditor';
 import { Files } from './pages/files/Files';
 import { Reader } from './pages/files/Reader';
 import { ControlShell } from './pages/control/ControlShell';
@@ -42,6 +43,12 @@ export function App() {
         </Route>
 
         <Route path="settings" element={<Settings />} />
+        {/* The theme editor is its own route rather than a dialog on Settings:
+            it applies the draft to the WHOLE document as you type, so it needs
+            the page to itself, and a URL means an unfinished theme survives a
+            reload as a thing you can navigate back to. */}
+        <Route path="settings/theme/new" element={<ThemeEditor />} />
+        <Route path="settings/theme/:id" element={<ThemeEditor />} />
 
         {/* Bothy Files - one nav entry, two destinations (docs/plans/
             reading-first.md §2). `/files` opens as a READER; the IDE is

--- a/apps/portal-next/web/src/lib/contract.ts
+++ b/apps/portal-next/web/src/lib/contract.ts
@@ -188,6 +188,13 @@ export type EvaluateOptions = {
  *  is fed whatever the user has typed so far, and a crash there is not a review. */
 const MEASURED = [
   '--surface-1', '--surface-2', '--bg-2',
+  // --bg-glow carries no contrast rule; it is here so that a value which is
+  // not a flat colour is REPORTED. index.css builds the page wash with
+  // `radial-gradient(... var(--bg-glow) 0%, ...)`, so a gradient in this token
+  // nests one gradient inside another's colour stop - invalid, silently
+  // dropped, and the wash disappears with no error anywhere. Five ported
+  // themes shipped with exactly that before this line existed.
+  '--bg-glow',
   '--fg', '--fg-muted', '--fg-subtle',
   '--accent', '--accent-fg', '--on-accent',
   ...STATUSES.map((s) => `--st-${s}`),

--- a/apps/portal-next/web/src/lib/files.ts
+++ b/apps/portal-next/web/src/lib/files.ts
@@ -643,3 +643,41 @@ export function langFor(path: string, hint?: string | null): string {
   if (dot <= 0) return '';
   return EXT_LANG[name.slice(dot + 1).toLowerCase()] ?? '';
 }
+
+/** Remove a file. Used by the theme editor to delete a theme somebody made.
+ *
+ *  A SEPARATE VERB RATHER THAN AN EMPTY WRITE, because those are different acts
+ *  and only one of them is recoverable in the way people expect: the service
+ *  snapshots the outgoing bytes first, so a deleted theme is in the undo net
+ *  exactly as an overwritten one is. Writing an empty file would leave a file
+ *  that is still listed, still selectable, and paints nothing.
+ *
+ *  `baseMtime` carries the same conflict guarantee as writeFile: deleting a file
+ *  somebody else just changed is the same class of mistake as overwriting it,
+ *  and gets the same 409.
+ */
+export async function deleteFile(
+  root: string,
+  path: string,
+  baseMtime?: number,
+): Promise<SaveOutcome> {
+  let r: Response;
+  try {
+    r = await fetch(`${BASE}/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ root, path, baseMtime }),
+    });
+  } catch (e) {
+    return { kind: 'error', message: e instanceof Error ? e.message : 'the service did not answer' };
+  }
+  if (r.status === 401) return { kind: 'auth' };
+  if (r.status === 409) {
+    return {
+      kind: 'error',
+      message: 'The file changed on disk since this page read it. Reload before deleting.',
+    };
+  }
+  if (!r.ok) return { kind: 'refused', message: await errorText(r, 'the delete was refused') };
+  return { kind: 'saved', res: { ok: true, path, mtime: 0, bytes: 0 } as WriteResult };
+}

--- a/apps/portal-next/web/src/lib/themeDraft.ts
+++ b/apps/portal-next/web/src/lib/themeDraft.ts
@@ -1,0 +1,225 @@
+// A theme being edited: where its starting values come from, and how it turns
+// into the file that gets written.
+//
+// THE PALETTE IS NEVER DUPLICATED HERE. The editor needs two things the browser
+// already knows - which tokens exist, and what the current theme sets them to -
+// and both are read back out of the live document rather than listed in a
+// constant. A list would be a fourth copy of the palette (after index.css, the
+// theme files, and the contract's own derivation), and the first one to go
+// stale, silently, in a way that shows up as "the editor forgot a token".
+
+import { requiredTokens } from './contract';
+
+/** Custom properties on `:root` that are not palette tokens.
+ *
+ *  THE BUILD PUTS THEM THERE. lightningcss - Vite's CSS minifier - injects
+ *  `--lightningcss-light` and `--lightningcss-dark` to implement `light-dark()`,
+ *  with values of ` ` and `initial`. Neither contains `var(`, so the contract's
+ *  own "is this derived" test says they are literal, and the editor duly
+ *  demanded two tokens that do not exist and cannot be given a colour.
+ *
+ *  It could only ever show up here, which is why the check never caught it: the
+ *  check reads index.css as SOURCE, and this reads the BUILT stylesheet through
+ *  the CSSOM. Same rule, two inputs, and only one of them has been through a
+ *  minifier. */
+const IGNORE = /^--lightningcss-/;
+
+/** The DECLARED values of every custom property on `:root`, read from the
+ *  stylesheet rather than from computed style.
+ *
+ *  Declared, not computed, because `requiredTokens()` decides what a theme owes
+ *  by asking whether a value contains `var(` - a derived token re-evaluates for
+ *  free and must not be asked for. Computed style has already resolved those, so
+ *  every token would look literal and the editor would demand sixteen values
+ *  nobody should be setting. */
+export function baseDeclarations(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRuleList;
+    // A cross-origin stylesheet throws on .cssRules. There are none here - the
+    // CSP allows only 'self' - but a browser extension can inject one, and an
+    // editor that dies because somebody has a userstyle installed is a bad
+    // editor.
+    try { rules = sheet.cssRules; } catch { continue; }
+    for (const raw of Array.from(rules)) {
+      const rule = raw as CSSStyleRule;
+      if (!rule.selectorText || rule.selectorText.trim() !== ':root') continue;
+      for (let i = 0; i < rule.style.length; i++) {
+        const prop = rule.style.item(i);
+        if (!prop.startsWith('--') || IGNORE.test(prop)) continue;
+        out[prop] = rule.style.getPropertyValue(prop).trim();
+      }
+    }
+  }
+  return out;
+}
+
+/** The tokens a theme must declare, as this build defines them. */
+export const requiredNames = (): string[] => requiredTokens(baseDeclarations());
+
+/** What the ACTIVE theme currently paints, for each name. This is what a new
+ *  theme starts from - "begin with what you are looking at" needs no
+ *  explanation and works for every theme including a user's own, whereas
+ *  seeding from a hardcoded palette would silently start you on Bothy Dark
+ *  while the screen showed something else. */
+export function activeValues(names: readonly string[]): Record<string, string> {
+  const cs = getComputedStyle(document.documentElement);
+  const out: Record<string, string> = {};
+  for (const n of names) {
+    const v = cs.getPropertyValue(n).trim();
+    if (v) out[n] = v;
+  }
+  return out;
+}
+
+export interface Draft {
+  id: string;
+  name: string;
+  note: string;
+  appearance: 'dark' | 'light';
+  tokens: Record<string, string>;
+}
+
+/** A filename, and therefore a CSS attribute selector, from whatever was typed.
+ *
+ *  Restrictive on purpose: the id lands inside `[data-bothy-theme='...']` and
+ *  inside a URL, so "reject or normalise to something obviously safe" is a much
+ *  smaller promise than "escape correctly in three grammars". Everything that is
+ *  not a letter, digit or hyphen becomes a hyphen. */
+export function slugify(s: string): string {
+  return s.toLowerCase().trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+}
+
+// The order the editor shows tokens in, and the only place that order is
+// decided. Grouped by what they DO rather than alphabetically, because someone
+// picking colours thinks "the surfaces are too light", never "the tokens
+// beginning with s are too light".
+export const GROUPS: { title: string; note: string; tokens: string[] }[] = [
+  {
+    title: 'Surfaces',
+    note: 'The elevation ladder: the page, then insets, then cards, headers, hovers and popovers. Each step should read as lifted from the one below it.',
+    tokens: ['--bg', '--bg-2', '--surface-1', '--surface-2', '--surface-3', '--surface-4', '--bg-glow'],
+  },
+  {
+    title: 'Text',
+    note: 'Held at 4.5:1 against every surface they are painted on. --on-accent is text sitting on a filled accent, so it is usually the opposite of --fg.',
+    tokens: ['--fg', '--fg-muted', '--fg-subtle', '--on-accent'],
+  },
+  {
+    title: 'Lines',
+    note: 'Borders and dividers, as an alpha over the surface rather than a flat colour, so one value works on every step of the ladder.',
+    tokens: ['--line', '--line-strong'],
+  },
+  {
+    title: 'Accent',
+    note: 'Chrome only - it never means a service is in some state. --accent-fg is the accent used as TEXT and needs more contrast than the fill does.',
+    tokens: ['--accent', '--accent-2', '--accent-fg'],
+  },
+  {
+    title: 'Status',
+    note: 'RESERVED. These five mean up, starting, down, unknown and stopped, and nothing decorative may share their hue. The -fg half is the text-safe variant.',
+    tokens: [
+      '--st-up', '--st-up-fg', '--st-warn', '--st-warn-fg', '--st-down', '--st-down-fg',
+      '--st-unknown', '--st-unknown-fg', '--st-off', '--st-off-fg',
+    ],
+  },
+  {
+    title: 'Panel accents',
+    note: 'Five decorative spines. They must stay clearly away from the status hues, or a coloured edge starts reading as an alert.',
+    tokens: ['--a1', '--a2', '--a3', '--a4', '--a5'],
+  },
+  {
+    title: 'Charts',
+    note: 'Series colours, used in slot order and never reordered. A series colour says "this is the CPU line", never "this is bad".',
+    tokens: ['--chart-1', '--chart-2', '--chart-3', '--chart-4', '--chart-5'],
+  },
+  {
+    title: 'Depth',
+    note: 'Shadow recipes and the scroll fade. Composite values rather than plain colours, so these are edited as text.',
+    tokens: ['--shadow-sm', '--shadow-md', '--shadow-lg', '--scroll-shade', '--hover-opacity'],
+  },
+];
+
+/** True when a value is a plain `#rrggbb` and can therefore be edited with a
+ *  colour well. Everything else - a gradient, an rgba(), a shadow recipe, an
+ *  opacity - gets a text field, because a colour input would silently destroy
+ *  it by rewriting it as a hex. */
+export const isSimpleColour = (v: string): boolean => /^#[0-9a-f]{6}$/i.test(v.trim());
+
+/** The file, generated from the draft. This is what gets written, and it is
+ *  deliberately readable: somebody will open it in the editor later, or send it
+ *  to a friend, and a minified blob would make both worse. */
+export function toCss(d: Draft, order: readonly string[]): string {
+  const sel = `[data-bothy-theme='${d.id}'][data-bothy-theme]`;
+  const lines: string[] = [
+    '/* bothy-theme',
+    `   name: ${d.name}`,
+    `   appearance: ${d.appearance}`,
+    `   note: ${d.note}`,
+    '*/',
+    '',
+    '/* Written by Bothy\'s theme editor. Safe to edit by hand - it is read back',
+    '   the same way, and the header above is what names it in the picker.',
+    '',
+    '   Two selectors: the :root one wins on the page, the bare one lets the',
+    '   picker paint this theme\'s swatches while you are looking at another. */',
+    `:root${sel},`,
+    `${sel} {`,
+    `  color-scheme: ${d.appearance};`,
+    '',
+  ];
+  // Grouped in the editor's own order, with the headings, so the file reads the
+  // way the form does. A theme file is documentation as much as configuration.
+  for (const g of GROUPS) {
+    const present = g.tokens.filter((t) => d.tokens[t] != null && order.includes(t));
+    if (!present.length) continue;
+    lines.push(`  /* ── ${g.title.toLowerCase()} ${'─'.repeat(Math.max(0, 58 - g.title.length))} */`);
+    const width = Math.max(...present.map((t) => t.length));
+    for (const t of present) lines.push(`  ${t}:${' '.repeat(width - t.length + 1)}${d.tokens[t]};`);
+    lines.push('');
+  }
+  // Anything the groups do not mention, so a token added to the palette later is
+  // still written rather than quietly dropped on the next save.
+  const known = new Set(GROUPS.flatMap((g) => g.tokens));
+  const rest = order.filter((t) => !known.has(t) && d.tokens[t] != null);
+  if (rest.length) {
+    lines.push('  /* ── other ─────────────────────────────────────────────── */');
+    for (const t of rest) lines.push(`  ${t}: ${d.tokens[t]};`);
+    lines.push('');
+  }
+  lines.push('}', '');
+  return lines.join('\n');
+}
+
+/** Read a theme file back into a draft, for editing one that already exists.
+ *
+ *  Tolerant by design: this parses files a person wrote by hand, not only files
+ *  toCss() produced. It takes the first rule block's custom properties and the
+ *  header comment if there is one, and it does not care about formatting. */
+export function fromCss(id: string, css: string): Draft {
+  const header = css.match(/\/\*\s*bothy-theme([\s\S]*?)\*\//i);
+  const fields: Record<string, string> = {};
+  if (header) {
+    for (const line of header[1].split('\n')) {
+      const kv = line.match(/^\s*([a-z-]+)\s*:\s*(.+?)\s*$/i);
+      if (kv) fields[kv[1].toLowerCase()] = kv[2];
+    }
+  }
+  const body = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const tokens: Record<string, string> = {};
+  for (const m of body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/gi)) tokens[m[1]] = m[2].trim();
+
+  const declared = fields.appearance?.toLowerCase();
+  const scheme = body.match(/color-scheme\s*:\s*(dark|light)/i)?.[1].toLowerCase();
+  return {
+    id,
+    name: fields.name || id,
+    note: fields.note || '',
+    appearance: (declared === 'light' || declared === 'dark' ? declared
+      : scheme === 'light' ? 'light' : 'dark') as 'dark' | 'light',
+    tokens,
+  };
+}

--- a/apps/portal-next/web/src/pages/Settings.css
+++ b/apps/portal-next/web/src/pages/Settings.css
@@ -137,3 +137,29 @@
   background: var(--accent-bg); border: 1px solid var(--accent-line);
   border-radius: var(--r-xs); vertical-align: 1px;
 }
+
+/* The card is a <button>; this is a <Link> inside it. It sits in the corner and
+   only shows on hover or focus, so it is present without competing with the
+   swatches - the row you are actually reading. */
+.settings-page .theme-card { position: relative; }
+.settings-page .theme-edit {
+  position: absolute; top: 8px; right: 8px;
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 6px; border-radius: var(--r-xs);
+  font-size: 10.5px; font-weight: 600; text-decoration: none;
+  color: var(--accent-fg); background: var(--accent-bg);
+  border: 1px solid var(--accent-line);
+  opacity: 0; transition: opacity var(--dur-fast) var(--ease);
+}
+.settings-page .theme-card:hover .theme-edit,
+.settings-page .theme-edit:focus-visible { opacity: 1; }
+
+/* The make-a-theme card. Dashed, so it reads as an action rather than as an
+   eighth palette sitting in a list of palettes. */
+.settings-page .theme-new {
+  border-style: dashed;
+  text-decoration: none;
+  justify-content: flex-start;
+}
+.settings-page .theme-new:hover { border-color: var(--accent-line); background: var(--accent-bg); }
+.settings-page .theme-new .theme-name { display: inline-flex; align-items: center; gap: 6px; }

--- a/apps/portal-next/web/src/pages/Settings.tsx
+++ b/apps/portal-next/web/src/pages/Settings.tsx
@@ -26,6 +26,8 @@ import { useMe } from '../components/UserMenu';
 import { useTheme } from '../lib/theme';
 import { THEME_DIR_HOST } from '../lib/customThemes';
 import { ThemeSwatch } from '../components/ThemeSwatch';
+import { Link } from 'react-router-dom';
+import { Pencil, Plus } from 'lucide-react';
 import { Skeleton } from '../components/states';
 import './Settings.css';
 
@@ -126,8 +128,34 @@ function Appearance() {
               </span>
               <span className="theme-note">{t.note}</span>
               <ThemeSwatch id={t.id} />
+              {/* An anchor INSIDE the card, and the card is a button - so the
+                  click has to be stopped from also selecting the theme. Nested
+                  interactive elements are usually a smell; here the alternative
+                  was a second row of controls under every card, which is worse
+                  for the seven themes that will never have one. */}
+              {t.user && (
+                <Link
+                  to={`/settings/theme/${t.id}`}
+                  className="theme-edit"
+                  onClick={(e) => e.stopPropagation()}
+                  aria-label={`Edit ${t.name}`}
+                >
+                  <Pencil size={12} aria-hidden="true" /> Edit
+                </Link>
+              )}
             </button>
           ))}
+
+          {/* Last, not first: the list is for choosing, and this is for making.
+              Putting it first would push the theme you are looking for down a
+              row every time. */}
+          <Link to="/settings/theme/new" className="theme-card theme-new">
+            <span className="theme-name"><Plus size={14} aria-hidden="true" /> New theme</span>
+            <span className="theme-note">
+              Start from the theme you are using now, change what you want, and watch
+              the page follow. Saves as a file you can keep or send on.
+            </span>
+          </Link>
         </div>
       </div>
     </section>

--- a/apps/portal-next/web/src/pages/ThemeEditor.css
+++ b/apps/portal-next/web/src/pages/ThemeEditor.css
@@ -1,0 +1,118 @@
+/* The theme editor. Deliberately plain: this page is a form beside a preview,
+   and the preview is the whole app behind it - so anything decorative here
+   competes with the thing it is meant to help you judge. */
+
+.theme-editor .te-back {
+  display: inline-flex; align-items: center; gap: 5px;
+  margin-bottom: 6px; padding: 0; border: 0; background: none;
+  font: inherit; font-size: 12px; color: var(--fg-subtle); cursor: pointer;
+}
+.theme-editor .te-back:hover { color: var(--fg); }
+
+.theme-editor .te-actions { display: flex; gap: 8px; align-items: flex-start; flex-wrap: wrap; }
+.theme-editor .te-danger { color: var(--st-down-fg); border-color: var(--st-down-line); }
+.theme-editor .te-danger:hover:not(:disabled) { background: var(--st-down-bg); }
+
+.theme-editor .te-empty { padding: 24px 2px; color: var(--fg-muted); }
+
+.theme-editor .te-note {
+  display: flex; gap: 8px; align-items: flex-start;
+  margin: 0 0 14px; padding: 9px 11px; font-size: 12.5px; line-height: 1.45;
+  border-radius: var(--r-sm); border: 1px solid var(--line);
+}
+.theme-editor .te-note svg { flex: none; margin-top: 1px; }
+.theme-editor .te-ok   { background: var(--st-up-bg);   border-color: var(--st-up-line);   color: var(--st-up-fg); }
+.theme-editor .te-bad  { background: var(--st-down-bg); border-color: var(--st-down-line); color: var(--st-down-fg); }
+.theme-editor .te-warn { background: var(--st-warn-bg); border-color: var(--st-warn-line); color: var(--st-warn-fg); }
+.theme-editor .te-info { background: var(--surface-2); color: var(--fg-muted); }
+
+/* ── identity ─────────────────────────────────────────────────────────────── */
+.theme-editor .te-identity {
+  display: grid; gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+.theme-editor .te-wide { grid-column: 1 / -1; }
+.theme-editor .te-field { display: flex; flex-direction: column; gap: 4px; }
+.theme-editor .te-field > span { font-size: 11.5px; font-weight: 600; color: var(--fg-muted); }
+.theme-editor .te-field small { font-size: 10.5px; color: var(--fg-subtle); overflow-wrap: anywhere; }
+.theme-editor .te-field input,
+.theme-editor .te-field select {
+  padding: 7px 9px; font: inherit; font-size: 13px;
+  color: var(--fg); background: var(--bg-2);
+  border: 1px solid var(--line); border-radius: var(--r-sm);
+}
+.theme-editor .te-field input:focus-visible,
+.theme-editor .te-field select:focus-visible {
+  outline: 2px solid var(--ring); outline-offset: -1px;
+}
+.theme-editor .te-field input:disabled { color: var(--fg-subtle); }
+
+/* ── tokens ───────────────────────────────────────────────────────────────── */
+.theme-editor .te-grid {
+  display: grid; gap: 10px; margin-top: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+}
+.theme-editor .te-token { display: flex; flex-direction: column; gap: 4px; }
+.theme-editor .te-token-name { font-size: 11px; color: var(--fg-muted); }
+.theme-editor .te-token.is-bad .te-token-name { color: var(--st-down-fg); font-weight: 700; }
+.theme-editor .te-token-row { display: flex; gap: 6px; align-items: center; }
+/* A colour well, sized to line up with the text field beside it. The default
+   rendering is a chunky button in every engine, so the padding is stripped and
+   the swatch made to fill it. */
+.theme-editor .te-token-row input[type='color'] {
+  flex: none; width: 34px; height: 30px; padding: 2px;
+  background: var(--bg-2); border: 1px solid var(--line);
+  border-radius: var(--r-sm); cursor: pointer;
+}
+.theme-editor .te-token-row input[type='text'] {
+  flex: 1; min-width: 0; padding: 6px 8px; font-size: 12px;
+  color: var(--fg); background: var(--bg-2);
+  border: 1px solid var(--line); border-radius: var(--r-sm);
+}
+.theme-editor .te-token.is-bad .te-token-row input[type='text'] { border-color: var(--st-down-line); }
+
+/* ── the report ───────────────────────────────────────────────────────────── */
+.theme-editor .te-badge {
+  margin-left: 10px; padding: 2px 7px;
+  font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em;
+  border-radius: var(--r-full); vertical-align: 2px;
+}
+.theme-editor .te-badge.is-ok  { color: var(--st-up-fg);   background: var(--st-up-bg); }
+.theme-editor .te-badge.is-bad { color: var(--st-down-fg); background: var(--st-down-bg); }
+
+.theme-editor .te-finding {
+  display: flex; gap: 8px; align-items: flex-start;
+  padding: 6px 2px; font-size: 12px; line-height: 1.45;
+  border-top: 1px solid var(--line);
+}
+.theme-editor .te-finding svg { flex: none; margin-top: 2px; }
+.theme-editor .te-finding.is-fail  { color: var(--st-down-fg); }
+.theme-editor .te-finding.is-allow { color: var(--fg-subtle); }
+.theme-editor .te-finding.is-pass  { color: var(--fg-muted); }
+.theme-editor .te-finding b { font-weight: 600; color: inherit; }
+
+.theme-editor .te-more {
+  margin-top: 8px; padding: 0; border: 0; background: none;
+  font: inherit; font-size: 12px; color: var(--accent-fg); cursor: pointer;
+}
+.theme-editor .te-more:hover { text-decoration: underline; }
+
+/* ── the file ─────────────────────────────────────────────────────────────── */
+.theme-editor .te-css {
+  width: 100%; min-height: 320px; margin-top: 10px; padding: 10px 12px;
+  font-size: 12.5px; line-height: 1.55;
+  color: var(--fg); background: var(--bg);
+  border: 1px solid var(--line); border-radius: var(--r-sm);
+  resize: vertical; white-space: pre;
+}
+
+/* The section notes. `.set-note` is scoped to `.settings-page` next door, so
+   this page - which is a sibling route, not inside it - was rendering them at
+   body size and they read as prose the page wanted you to stop and read rather
+   than as the caption under a heading. Same treatment, stated here rather than
+   by widening the other file's selector, because these are two pages that
+   happen to want the same caption, not one component. */
+.theme-editor .set-note {
+  display: block; margin: 0; font-size: 12px; line-height: 1.5;
+  color: var(--fg-subtle); max-width: 78ch;
+}

--- a/apps/portal-next/web/src/pages/ThemeEditor.tsx
+++ b/apps/portal-next/web/src/pages/ThemeEditor.tsx
@@ -1,0 +1,436 @@
+// Make a theme without leaving the box.
+//
+// WHAT THIS IS, MECHANICALLY: a form over a token map, a live preview, and a
+// writer that produces a .css file in apps/portal-next/data/themes. Nothing
+// here is a new storage format or a new write path - it composes two things
+// that already exist. The file it writes is the same file you would have
+// written by hand, and data/themes/README.md documents that format for people
+// who would rather use an editor they already have.
+//
+// THE PREVIEW IS THE POINT. Picking colours from hex values in a form is
+// guessing; the whole reason this page exists rather than a link to the file is
+// that you can see the result while you choose. So the draft is applied to the
+// document as you type - not to a swatch in the corner - and reverted when you
+// leave. What you are looking at IS the theme.
+//
+// THE CONTRACT WARNS, IT DOES NOT REFUSE. Bothy's own themes are held to the
+// accent-vs-status separation and the contrast floors by a check that fails the
+// build. A theme you made on your own box is yours: the same rules run, live,
+// and say exactly what is wrong and why - and then you save it anyway if you
+// want to. The rules exist to stop you making a mistake by accident, not to
+// stop you making a decision.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { AlertTriangle, ArrowLeft, Check, Code2, Save, Trash2 } from 'lucide-react';
+import { evaluateTheme, type Finding } from '../lib/contract';
+import {
+  activeValues, fromCss, GROUPS, isSimpleColour, requiredNames, slugify, toCss,
+  type Draft,
+} from '../lib/themeDraft';
+import { THEME_DIR_HOST } from '../lib/customThemes';
+import { deleteFile, isAuthError, readFile, writeFile } from '../lib/files';
+import { hasRole } from '../lib/me';
+import { useMe } from '../components/UserMenu';
+import { useTheme } from '../lib/theme';
+import './ThemeEditor.css';
+
+const ROOT = 'stacks';
+const dirOf = (id: string) => `${THEME_DIR_HOST}${id}.css`;
+
+export function ThemeEditor() {
+  const { id: routeId } = useParams<{ id: string }>();
+  const nav = useNavigate();
+  const { me } = useMe();
+  const { setSelection } = useTheme();
+  const editing = routeId && routeId !== 'new' ? routeId : null;
+
+  const names = useMemo(() => requiredNames(), []);
+  const [draft, setDraft] = useState<Draft | null>(null);
+  const [baseMtime, setBaseMtime] = useState<number | undefined>();
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<{ tone: 'ok' | 'bad' | 'info'; text: string } | null>(null);
+  const [showCss, setShowCss] = useState(false);
+
+  const mayWrite = hasRole(me, 'editor');
+
+  // ── load ──────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    let alive = true;
+    if (!editing) {
+      // A new theme starts from what is currently on screen. Seeding from a
+      // fixed palette would put you on Bothy Dark while the page showed
+      // something else, and the first thing you would do is undo that.
+      setDraft({
+        id: '', name: '', note: '', tokens: activeValues(names),
+        appearance: document.documentElement.getAttribute('data-theme') === 'light'
+          ? 'light' : 'dark',
+      });
+      return;
+    }
+    readFile(ROOT, dirOf(editing))
+      .then((f) => {
+        if (!alive) return;
+        setDraft(fromCss(editing, f.content));
+        // Carried so the save can send it back as baseMtime. Without it, two
+        // tabs editing the same theme would silently overwrite each other -
+        // the conflict check is the reason the write path is worth using.
+        setBaseMtime(f.mtime);
+      })
+      .catch((e) => {
+        if (!alive) return;
+        setNotice({
+          tone: 'bad',
+          text: isAuthError(e) ? 'Your session expired. Sign in and reload.'
+            : `Could not open ${dirOf(editing)} — ${e instanceof Error ? e.message : 'unknown error'}`,
+        });
+      });
+    return () => { alive = false; };
+  }, [editing, names]);
+
+  // ── live preview ──────────────────────────────────────────────────────────
+  //
+  // Applied to the document element as inline custom properties, which beat any
+  // stylesheet, so the whole app repaints as you drag a colour. Torn down on
+  // unmount - and the teardown removes exactly the properties this page set,
+  // rather than clearing style, because the shell sets its own (pane widths)
+  // and wiping those would be a different bug.
+  const applied = useRef<string[]>([]);
+  useEffect(() => {
+    if (!draft) return;
+    const el = document.documentElement;
+    for (const p of applied.current) el.style.removeProperty(p);
+    const now: string[] = [];
+    for (const [k, v] of Object.entries(draft.tokens)) {
+      if (!v) continue;
+      el.style.setProperty(k, v);
+      now.push(k);
+    }
+    applied.current = now;
+  }, [draft]);
+
+  useEffect(() => () => {
+    const el = document.documentElement;
+    for (const p of applied.current) el.style.removeProperty(p);
+    applied.current = [];
+  }, []);
+
+  // ── the contract, live ────────────────────────────────────────────────────
+  const findings: Finding[] = useMemo(() => {
+    if (!draft) return [];
+    return evaluateTheme(draft.tokens, draft.appearance, { required: names });
+  }, [draft, names]);
+  const problems = findings.filter((f) => f.level === 'fail');
+
+  const css = useMemo(() => (draft ? toCss(
+    { ...draft, id: draft.id || slugify(draft.name) || 'untitled' }, names,
+  ) : ''), [draft, names]);
+
+  const set = useCallback((patch: Partial<Draft>) => {
+    setDraft((d) => (d ? { ...d, ...patch } : d));
+    setNotice(null);
+  }, []);
+  const setToken = useCallback((k: string, v: string) => {
+    setDraft((d) => (d ? { ...d, tokens: { ...d.tokens, [k]: v } } : d));
+    setNotice(null);
+  }, []);
+
+  // ── save ──────────────────────────────────────────────────────────────────
+  const save = async () => {
+    if (!draft || busy) return;
+    const id = draft.id || slugify(draft.name);
+    if (!id) { setNotice({ tone: 'bad', text: 'Give the theme a name first.' }); return; }
+    setBusy(true);
+    setNotice(null);
+    const out = await writeFile(
+      ROOT, dirOf(id), toCss({ ...draft, id }, names),
+      `theme: ${draft.name || id}`, baseMtime,
+    );
+    setBusy(false);
+    switch (out.kind) {
+      case 'saved':
+        setBaseMtime(out.res.mtime);
+        // Selecting it is the confirmation that it worked: the page you are
+        // looking at is now painted by the FILE rather than by the preview.
+        // A reload is what re-lists the directory, so the picker catches up.
+        setSelection(id);
+        setNotice({
+          tone: 'ok',
+          text: `Saved to ${dirOf(id)}. It is your active theme now; reload to see it in the picker.`,
+        });
+        if (!editing) nav(`/settings/theme/${id}`, { replace: true });
+        break;
+      case 'conflict':
+        setNotice({
+          tone: 'bad',
+          text: 'The file changed on disk since this page opened it. Reload to pick up that version - saving now would discard it.',
+        });
+        break;
+      case 'auth':
+        setNotice({ tone: 'bad', text: 'Your session expired. Sign in and try again.' });
+        break;
+      default:
+        setNotice({ tone: 'bad', text: out.message });
+    }
+  };
+
+  // ── delete ────────────────────────────────────────────────────────────────
+  //
+  // Confirmed, and the confirmation says where the file goes rather than asking
+  // "are you sure?" - the service snapshots the outgoing bytes first, so this is
+  // recoverable, and saying so is more useful than a warning that is not true.
+  const remove = async () => {
+    if (!editing || busy) return;
+    if (!confirm(
+      `Delete ${dirOf(editing)}?\n\n`
+      + 'The file is copied into the undo snapshot first, so it can be recovered '
+      + 'from there.\n\nAnyone currently using this theme falls back to the default.',
+    )) return;
+    setBusy(true);
+    const out = await deleteFile(ROOT, dirOf(editing), baseMtime);
+    setBusy(false);
+    if (out.kind === 'saved') {
+      // Off this theme before it stops existing. Leaving the selection pointing
+      // at a deleted file is survivable - resolveSelection falls back - but the
+      // picker would show it selected until the next reload, which reads as the
+      // delete not having worked.
+      setSelection('bothy-dark');
+      nav('/settings');
+      return;
+    }
+    setNotice({
+      tone: 'bad',
+      text: out.kind === 'auth' ? 'Your session expired. Sign in and try again.'
+        : 'message' in out ? out.message : 'The delete was refused.',
+    });
+  };
+
+  if (!draft) {
+    return (
+      <div className="page theme-editor">
+        <div className="page-head"><div><h1>Theme</h1></div></div>
+        <p className="te-empty">{notice?.text ?? 'Loading…'}</p>
+      </div>
+    );
+  }
+
+  const id = draft.id || slugify(draft.name);
+
+  return (
+    <div className="page theme-editor">
+      <div className="page-head">
+        <div>
+          <button type="button" className="te-back" onClick={() => nav('/settings')}>
+            <ArrowLeft size={14} aria-hidden="true" /> Settings
+          </button>
+          <h1>{editing ? `Editing ${draft.name || editing}` : 'New theme'}</h1>
+          <p className="page-sub">
+            Every change is live on this page. Nothing is written until you save.
+          </p>
+        </div>
+        <div className="te-actions">
+          <button type="button" className="btn" onClick={() => setShowCss((v) => !v)}>
+            <Code2 size={15} aria-hidden="true" /> {showCss ? 'Hide' : 'Show'} CSS
+          </button>
+          {editing && (
+            <button
+              type="button"
+              className="btn te-danger"
+              disabled={!mayWrite || busy}
+              onClick={remove}
+            >
+              <Trash2 size={15} aria-hidden="true" /> Delete
+            </button>
+          )}
+          <button type="button" className="btn primary" onClick={save} disabled={!mayWrite || busy}>
+            <Save size={15} aria-hidden="true" /> {busy ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+
+      {/* Role first, because it changes what the rest of the page can do. Absent
+          rather than a disabled button with no explanation. */}
+      {!mayWrite && (
+        <p className="te-note te-warn">
+          <AlertTriangle size={15} aria-hidden="true" />
+          <span>
+            You can build and preview a theme here, but saving needs the <b>editor</b> role.
+            Everything below still works — the preview is live — you just cannot write the file.
+          </span>
+        </p>
+      )}
+
+      {notice && (
+        <p className={`te-note te-${notice.tone}`}>
+          {notice.tone === 'ok' ? <Check size={15} /> : <AlertTriangle size={15} />}
+          <span>{notice.text}</span>
+        </p>
+      )}
+
+      <section className="panel">
+        <h2 className="panel-h">Identity</h2>
+        <div className="panel-b te-identity">
+          <label className="te-field">
+            <span>Name</span>
+            <input
+              type="text" value={draft.name} placeholder="Deep Ocean"
+              onChange={(e) => set({ name: e.target.value })}
+            />
+          </label>
+          <label className="te-field">
+            <span>File</span>
+            <input
+              type="text" value={id} placeholder="deep-ocean"
+              // The id is the filename AND a CSS selector, so it is normalised
+              // as you type rather than validated on save - being told "that
+              // name is invalid" after filling in a whole palette is the worst
+              // possible moment to learn it.
+              onChange={(e) => set({ id: slugify(e.target.value) })}
+              disabled={!!editing}
+            />
+            <small>{dirOf(id || 'untitled')}</small>
+          </label>
+          <label className="te-field">
+            <span>Appearance</span>
+            <select
+              value={draft.appearance}
+              onChange={(e) => set({ appearance: e.target.value as 'dark' | 'light' })}
+            >
+              <option value="dark">Dark</option>
+              <option value="light">Light</option>
+            </select>
+            <small>Decides which base palette loads first, and the contrast rules applied below.</small>
+          </label>
+          <label className="te-field te-wide">
+            <span>Note</span>
+            <input
+              type="text" value={draft.note} placeholder="One line, shown under the name in the picker."
+              onChange={(e) => set({ note: e.target.value })}
+            />
+          </label>
+        </div>
+      </section>
+
+      <Report findings={findings} problems={problems.length} />
+
+      {showCss && (
+        <section className="panel">
+          <h2 className="panel-h">The file</h2>
+          <div className="panel-b">
+            <p className="set-note">
+              This is exactly what gets written. Editing it here re-reads the tokens,
+              so the form and the file cannot disagree.
+            </p>
+            <textarea
+              className="te-css mono"
+              value={css}
+              spellCheck={false}
+              onChange={(e) => {
+                const next = fromCss(id || 'untitled', e.target.value);
+                setDraft((d) => (d ? { ...d, ...next, id: d.id } : d));
+              }}
+            />
+          </div>
+        </section>
+      )}
+
+      {GROUPS.map((g) => (
+        <section className="panel" key={g.title}>
+          <h2 className="panel-h">{g.title}</h2>
+          <div className="panel-b">
+            <p className="set-note">{g.note}</p>
+            <div className="te-grid">
+              {g.tokens.filter((t) => names.includes(t)).map((t) => (
+                <TokenField
+                  key={t}
+                  name={t}
+                  value={draft.tokens[t] ?? ''}
+                  bad={problems.some((p) => p.id.includes(t.replace(/^--/, '')))}
+                  onChange={(v) => setToken(t, v)}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+/** One token. A colour well only when the value is a plain hex - a gradient, an
+ *  rgba() or a shadow recipe would be silently destroyed by a colour input,
+ *  which rewrites whatever it is given as #rrggbb. */
+function TokenField({ name, value, bad, onChange }: {
+  name: string; value: string; bad: boolean; onChange: (v: string) => void;
+}) {
+  const simple = isSimpleColour(value);
+  return (
+    <div className={`te-token ${bad ? 'is-bad' : ''}`}>
+      <label className="te-token-name mono" htmlFor={`tok${name}`}>{name}</label>
+      <div className="te-token-row">
+        {simple && (
+          <input
+            type="color" value={value} aria-label={`${name} colour`}
+            onChange={(e) => onChange(e.target.value)}
+          />
+        )}
+        <input
+          id={`tok${name}`}
+          type="text" className="mono" value={value} spellCheck={false}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** The contract's verdict, live. Failures first and expanded; the passes are
+ *  collapsed behind a count, because a wall of green is how a report stops being
+ *  read - and the failures are the only rows anyone acts on. */
+function Report({ findings, problems }: { findings: Finding[]; problems: number }) {
+  const [all, setAll] = useState(false);
+  const fails = findings.filter((f) => f.level === 'fail');
+  const allows = findings.filter((f) => f.level === 'allow');
+  const passes = findings.filter((f) => f.level === 'pass');
+
+  return (
+    <section className="panel">
+      <h2 className="panel-h">
+        Contrast and collisions
+        <span className={`te-badge ${problems ? 'is-bad' : 'is-ok'}`}>
+          {problems ? `${problems} to look at` : 'all clear'}
+        </span>
+      </h2>
+      <div className="panel-b">
+        <p className="set-note">
+          The same rules Bothy holds its own themes to, run against yours as you type.
+          They are advice here, not a gate — you can save a theme that breaks them.
+        </p>
+        {fails.map((f) => (
+          <div className="te-finding is-fail" key={f.id}>
+            <AlertTriangle size={14} aria-hidden="true" />
+            <span><b>{f.label}</b> {f.detail}</span>
+          </div>
+        ))}
+        {allows.map((f) => (
+          <div className="te-finding is-allow" key={f.id}>
+            <span><b>{f.label}</b> — {f.detail}</span>
+          </div>
+        ))}
+        {passes.length > 0 && (
+          <>
+            <button type="button" className="te-more" onClick={() => setAll((v) => !v)}>
+              {all ? 'Hide' : `Show ${passes.length}`} passing checks
+            </button>
+            {all && passes.map((f) => (
+              <div className="te-finding is-pass" key={f.id}>
+                <Check size={14} aria-hidden="true" />
+                <span><b>{f.label}</b> {f.detail}</span>
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/portal-next/web/src/themes/catppuccin-latte.css
+++ b/apps/portal-next/web/src/themes/catppuccin-latte.css
@@ -30,7 +30,12 @@
   --surface-2: #f7f8fa;
   --surface-3: #eaecf2;
   --surface-4: #ffffff;
-  --bg-glow:   radial-gradient(60% 50% at 50% 0%, #dce0e8 0%, transparent 70%);
+  /* A FLAT COLOUR, not a gradient. index.css builds the page wash with
+     `radial-gradient(... var(--bg-glow) 0%, var(--bg) 60%)`, so a gradient
+     here nests one inside another's colour stop - invalid, and the whole
+     background declaration is dropped rather than erroring. The wash simply
+     vanishes. Caught by the editor, which reads the token as a colour. */
+  --bg-glow:   #dce0e8;
 
   --fg:        #4c4f69;
   --fg-muted:  #5c5f77;

--- a/apps/portal-next/web/src/themes/catppuccin-mocha.css
+++ b/apps/portal-next/web/src/themes/catppuccin-mocha.css
@@ -31,7 +31,12 @@
   --surface-2: #2b2b40;
   --surface-3: #313244;
   --surface-4: #3a3a52;
-  --bg-glow:   radial-gradient(60% 50% at 50% 0%, #302f4a 0%, transparent 70%);
+  /* A FLAT COLOUR, not a gradient. index.css builds the page wash with
+     `radial-gradient(... var(--bg-glow) 0%, var(--bg) 60%)`, so a gradient
+     here nests one inside another's colour stop - invalid, and the whole
+     background declaration is dropped rather than erroring. The wash simply
+     vanishes. Caught by the editor, which reads the token as a colour. */
+  --bg-glow:   #302f4a;
 
   --fg:        #cdd6f4;
   --fg-muted:  #a6adc8;

--- a/apps/portal-next/web/src/themes/gruvbox.css
+++ b/apps/portal-next/web/src/themes/gruvbox.css
@@ -35,7 +35,12 @@
   --surface-2: #3c3836;
   --surface-3: #504945;
   --surface-4: #5a524c;
-  --bg-glow:   radial-gradient(60% 50% at 50% 0%, #423c37 0%, transparent 70%);
+  /* A FLAT COLOUR, not a gradient. index.css builds the page wash with
+     `radial-gradient(... var(--bg-glow) 0%, var(--bg) 60%)`, so a gradient
+     here nests one inside another's colour stop - invalid, and the whole
+     background declaration is dropped rather than erroring. The wash simply
+     vanishes. Caught by the editor, which reads the token as a colour. */
+  --bg-glow:   #423c37;
 
   --fg:        #ebdbb2;
   --fg-muted:  #d5c4a1;

--- a/apps/portal-next/web/src/themes/nord.css
+++ b/apps/portal-next/web/src/themes/nord.css
@@ -30,7 +30,12 @@
   --surface-2: #3b4252;
   --surface-3: #434c5e;
   --surface-4: #4c566a;
-  --bg-glow:   radial-gradient(60% 50% at 50% 0%, #3d4759 0%, transparent 70%);
+  /* A FLAT COLOUR, not a gradient. index.css builds the page wash with
+     `radial-gradient(... var(--bg-glow) 0%, var(--bg) 60%)`, so a gradient
+     here nests one inside another's colour stop - invalid, and the whole
+     background declaration is dropped rather than erroring. The wash simply
+     vanishes. Caught by the editor, which reads the token as a colour. */
+  --bg-glow:   #3d4759;
 
   --fg:        #eceff4;
   --fg-muted:  #d8dee9;

--- a/apps/portal-next/web/src/themes/tokyo-night.css
+++ b/apps/portal-next/web/src/themes/tokyo-night.css
@@ -63,10 +63,17 @@
   --surface-2: #24283b;
   --surface-3: #2f334d;
   --surface-4: #373b54;
-  /* The page wash. Kept far dimmer than a card so the elevation ladder still
-     reads as a ladder - a tinted, position-dependent backdrop is the one thing
-     index.css records as forbidden here. */
-  --bg-glow:   radial-gradient(60% 50% at 50% 0%, #2a2f4a 0%, transparent 70%);
+  /* The page wash, and it is a FLAT COLOUR rather than a gradient. index.css
+     builds the wash itself with `radial-gradient(... var(--bg-glow) 0%,
+     var(--bg) 60%)`, so a gradient in this token nests one inside another's
+     colour stop: invalid, dropped without an error, and the wash silently
+     disappears. Five themes shipped that way before the contract learned to
+     check it.
+
+     Kept far dimmer than a card, so the elevation ladder still reads as a
+     ladder - a tinted, position-dependent backdrop is the one thing index.css
+     records as forbidden here. */
+  --bg-glow:   #2a2f4a;
 
   /* ── foreground pairs ────────────────────────────────────────────────────── */
   --fg:        #c0caf5;   /* 11.62 on surface-1 */

--- a/edge/dynamic/portal-files.yml
+++ b/edge/dynamic/portal-files.yml
@@ -13,7 +13,7 @@
 # With exact paths, a new endpoint is unreachable until someone writes a rule -
 # which is the correct default for a service holding write access to two repos.
 #
-# READ requires `viewer`; WRITE requires `editor`.
+# READ requires `viewer`; WRITE and DELETE require `editor`.
 #
 # Read was OPEN in the first version of this file, and the reasoning was sound at
 # the time: the roots were two markdown trees of published documentation, so a
@@ -77,6 +77,31 @@ http:
       rule: "Path(`/-/api/files/write`)"
       entryPoints: [web]
       priority: 110          # above the read router; disjoint anyway, but explicit
+      service: portal-files
+      middlewares: [portal-files-strip, files-deidentify, sso-editor, sso-errors]
+
+    # ── delete: the same role that may write ────────────────────────────────
+    #
+    # `sso-editor`, and the SAME middleware chain as the write router - strip,
+    # de-identify, gate, errors - because removing a file IS a write. A separate
+    # role for it would be a second thing to grant, a second thing to revoke, and
+    # a second thing to get wrong, for an action whose blast radius is smaller
+    # than an overwrite's: the service refuses to delete unless the snapshot
+    # trash took a copy first, so the recovery story is the one the write path
+    # already has.
+    #
+    # ITS OWN ROUTER, rather than another Path() alternative on
+    # portal-files-write. Two rules that share a role today must not share it by
+    # accident tomorrow - if delete ever moves up a tier, that is one word in one
+    # rule here rather than a router that has to be split first, under pressure.
+    #
+    # Exact Path(), like every rule in this file: the root and path travel in the
+    # JSON body, nothing variable is in the URL, and a PathPrefix would silently
+    # expose the next endpoint somebody adds to this service.
+    portal-files-delete:
+      rule: "Path(`/-/api/files/delete`)"
+      entryPoints: [web]
+      priority: 110          # same tier as write; the rules are disjoint
       service: portal-files
       middlewares: [portal-files-strip, files-deidentify, sso-editor, sso-errors]
 


### PR DESCRIPTION
The in-app theme editor, plus the `/delete` verb it needed. Create, edit, preview live, save, delete — and the file it writes is the same file you would have written by hand.

## The preview is why this exists

Picking colours out of a list of hex values is guessing. So the draft is applied to the **document** as you type, not to a swatch in a corner: what you are looking at *is* the theme. Teardown removes exactly the properties the page set rather than clearing `style`, because the shell keeps its own there (pane widths).

A new theme starts from **what is on screen**, read out of the live document. Seeding from a fixed palette would start you on Bothy Dark while the page showed Gruvbox. The token list comes from the CSSOM for the same reason — a hardcoded list would be a fourth copy of the palette and the first to go stale.

## The contract warns; it does not refuse

The rules that fail the build for Bothy's own themes run in the browser against yours, live. Verified: setting `--a4` to `--st-up` reproduces the exact 2026 collision *as you pick it* (`hue gap 0° < 45°`); `--fg` near the surface reports `worst 1.02 on surface-1`; fixing either returns to `all clear`. Then you save it anyway if you want to.

## Delete, because there is now something to undo it with

`POST /delete` — same `resolve(for_write=True)` boundary, same `baseMtime` conflict check, same audit line, gated behind `sso-editor` on its own exact-`Path()` router. It **snapshots before unlinking and refuses if the snapshot fails**: `/write` fails open on a missing net because refusing a save destroys the work the net protects, but a refused delete costs nothing, so this is the one place the service fails closed.

## Two pre-existing landmines found and fixed

1. **`e2e.py` was destroying `~/stacks/.env` on every run.** My earlier commit removed the write extension allowlist and did not update the check, which still asserted `.env` writes were 403 — so it wrote `"x"` over the real file. Recovered from the snapshot trash and the assertions replaced with non-destructive ones. **Re-verified: 38 lines, 19 keys, every secret populated, compose parses it, a real login returns all four roles.**
2. **`authz_probe.py` proved the gate worked and never checked that any route used it** — a mutating endpoint wired to `sso-viewer` would have sailed past. It now reads Traefik's *runtime* router table and asserts the gate on each route.

## A bug in all five themes I ported earlier

`--bg-glow` is a flat **colour** — `index.css` builds the wash from it — and every theme I ported declared it *as* a gradient. That nests a gradient inside another's colour stop: invalid, silently dropped, wash does not render. Fixed in all six files; the contract now measures `--bg-glow` for exactly this, proved failing on the old value first.

Also: the editor demanded two tokens that do not exist. `--lightningcss-*` are injected into `:root` by Vite's minifier and contain no `var()`, so the "is this derived" test called them literal. Only ever visible here — the check reads source, the editor reads the built stylesheet.

## Verified

- `just files-check` **all pass** (including the new delete suite), portal checks **0 FAIL**, `just verify` **23/23**, `doctor` clean.
- Negative controls on the delete checks: snapshot skipped → 3 FAILED; directory refusal removed → the *reason* assertion caught it while the status code still looked right; delete router downgraded to `sso-viewer` → `authz_probe` exit 1.
- Live create → edit → delete cycle through the UI, and the deleted theme **recovered from the snapshot** afterwards.
