### PR TITLE
feat(reader): callouts, wikilinks, backlinks

### DIFF
--- a/apps/portal-files/app.py
+++ b/apps/portal-files/app.py
@@ -564,6 +564,303 @@ def search(root_keys: list[str], rel: str, needle: str, *,
     }
 
 
+# ── backlinks ───────────────────────────────────────────────────────────────
+#
+# "3 documents link here". A markdown corpus is a graph and the reader only ever
+# sees one direction of it: the links OUT of the page they are on. The edges
+# pointing IN are the ones that say whether a note is load-bearing or orphaned,
+# and no document knows its own.
+#
+# THE WALK GOES THROUGH safepath.collect(), for the reason the search comment
+# above gives at length: a second os.walk is a second chance to forget the
+# per-entry resolve(), and that is exactly how `.env` ends up in an index. This
+# is a READ, like search, so it does NOT pass for_archive - that flag is the
+# difference between "a credential file is excluded from a bulk download" and "an
+# index lies about what is on disk", and only the archive endpoints want it.
+#
+# MARKDOWN ONLY, and the constraint is doing real work rather than being tidy.
+# A link graph over `.py`, `.png` and `.sqlite` is not a document graph; those
+# files are not documents, cannot carry a wikilink, and including them turns a
+# few hundred reads into a whole-tree read of every byte in the root for edges
+# that cannot exist.
+LINKS_MAX_FILES = SEARCH_MAX_FILES        # candidates the WALK may enumerate
+LINKS_MAX_DOCS = 2_000                    # markdown files actually indexed
+LINKS_MAX_FILE_BYTES = 1_000_000          # per file; bigger than this is not prose
+LINKS_SECONDS = 10.0                      # the READ phase; collect() bounds the walk
+# The title is looked for in the HEAD of the file only. A `# heading` that is not
+# in the first couple of lines is not the document's title - it is a section - so
+# scanning further would find the wrong string, and it would do it while reading
+# every byte of every document a second time. 200 bytes clears a front-matter-less
+# `# Title` line with room for a leading blank line or two.
+LINKS_TITLE_BYTES = 200
+MARKDOWN_SUFFIXES = (".md", ".markdown")
+
+# `[label](target)` - deliberately the same shape as the link arm of INLINE_RE in
+# md.tsx. If the two disagree, the reader sees a link the index does not count or
+# counts one the reader cannot follow, and both look like a bug in the backlinks
+# rather than in the parser.
+_RE_INLINE_LINK = re.compile(r"\[[^\]\n]*\]\(([^)\s]+)\)")
+# `[[target]]` and `[[target|label]]` - the notes' own convention (see the
+# "Cross-link liberally with wikilinks" rule in claude-notes/README.md). The
+# renderer does not resolve these yet; the index does, because a wikilink is the
+# commonest edge in the corpus this feature exists for.
+_RE_WIKI_LINK = re.compile(r"\[\[([^\]|\n]+)(?:\|[^\]\n]*)?\]\]")
+# A fence opens and closes with the SAME character, and the closer must be at
+# least as long as the opener - so a ```` ``` ```` inside a ```` ```` ```` block
+# does not end it. Up to three leading spaces, per CommonMark.
+_RE_FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
+# An inline code span is literal, and md.tsx already treats it that way - its
+# INLINE_RE puts the backtick arm FIRST, so `[foo](bar)` inside backticks renders
+# as code and never as a link. Blanked here so the two agree.
+_RE_CODESPAN = re.compile(r"`[^`\n]+`")
+# Anything carrying a scheme, or a protocol-relative `//host/x`, is a URL and not
+# a path into this root - the same test md.tsx applies before it will resolve
+# anything. A bare `#anchor` names a place INSIDE the document, so it is not an
+# edge between documents either.
+_RE_SCHEME = re.compile(r"^([a-z][a-z0-9+.-]*:|//)", re.I)
+_RE_TITLE = re.compile(r"^ {0,3}#{1,6}\s+(.+?)\s*#*\s*$", re.M)
+
+
+def _doc_title(head: str, relpath: str) -> str:
+    """The first `# heading` in `head`, or the filename made readable."""
+    m = _RE_TITLE.search(head)
+    if m:
+        return m.group(1).strip()
+    # Only the first character is capitalised. Title-casing the rest turns `dns`
+    # into "Dns" and `wsl.md` into "Wsl", which is worse than leaving them alone -
+    # this fallback exists for the untitled file, not to rename anything.
+    stem = os.path.splitext(os.path.basename(relpath))[0].replace("-", " ").replace("_", " ")
+    return stem[:1].upper() + stem[1:] if stem else relpath
+
+
+def _link_targets(text: str) -> list[tuple[str, bool]]:
+    """Every (target, is_wikilink) in a document, code excluded.
+
+    FENCED BLOCKS ARE SKIPPED ENTIRELY, and that is not a nicety: this repo's
+    documentation is largely about shell commands and config, so a code sample
+    containing `[foo](bar)` or a glob that looks like `[[x]]` is common. Counting
+    those would make the backlink number a count of code samples, which is the
+    one number nobody asked for.
+    """
+    out: list[tuple[str, bool]] = []
+    fence = ""
+    for line in text.splitlines():
+        m = _RE_FENCE.match(line)
+        if m:
+            mark = m.group(1)
+            if not fence:
+                fence = mark
+            elif mark[0] == fence[0] and len(mark) >= len(fence):
+                fence = ""
+            continue
+        if fence:
+            continue
+        line = _RE_CODESPAN.sub(" ", line)
+        for w in _RE_WIKI_LINK.finditer(line):
+            out.append((w.group(1).strip(), True))
+        for i in _RE_INLINE_LINK.finditer(line):
+            out.append((i.group(1).strip(), False))
+    return out
+
+
+def _resolve_link(src_dir: str, target: str, wiki: bool,
+                  index: dict, by_base: dict[str, list[str]]) -> str | None:
+    """Which document in THIS INDEX a target names, or None.
+
+    RESOLUTION IS A LOOKUP IN THE INDEX, never a stat() of a path built from file
+    content, and that is the security shape of this function. The index holds
+    exactly what safepath.collect() proved readable, so an edge can only ever name
+    a file that walk already allowed - a link that says `../../../.env` or
+    `~/.ssh/id_ed25519` resolves to nothing at all, because those are not keys in
+    the dict. Touching the filesystem here would put a second, weaker path to the
+    same question beside the one that is already correct.
+
+    The joining rules are md.tsx's resolveRelative(), for the reason the shapes
+    above are shared: a link the reader can click and the index cannot count is
+    indistinguishable from a broken backlink count.
+    """
+    rel = target.split("#", 1)[0].split("?", 1)[0].strip()
+    if not rel or _RE_SCHEME.match(rel):
+        return None
+    # A leading slash means "from the top of this root" - there is no other
+    # document root here for it to mean.
+    parts = [] if rel.startswith("/") else [p for p in src_dir.split("/") if p]
+    for seg in rel.split("/"):
+        if not seg or seg == ".":
+            continue
+        if seg == "..":
+            if not parts:
+                return None      # climbing out of the root is not an edge
+            parts.pop()
+            continue
+        parts.append(seg)
+    if not parts:
+        return None
+    cand = "/".join(parts)
+    if cand in index:
+        return cand
+    # A wikilink carries no extension, and neither does a hand-written relative
+    # link to a sibling note. Both spellings are what a human means by the file.
+    for suffix in MARKDOWN_SUFFIXES:
+        if cand + suffix in index:
+            return cand + suffix
+        if f"{cand}/index{suffix}" in index:
+            return f"{cand}/index{suffix}"
+    if not wiki:
+        # Only wikilinks get the basename fallback. An inline `[x](notes)` that
+        # points nowhere is a broken link in the document and should read as one;
+        # inventing a target for it would put an edge on the page that the reader
+        # cannot follow.
+        return None
+    # `[[dns]]` means the document called dns.md wherever it lives - the notes are
+    # written that way on purpose ("cross-link liberally") and a wikilink is a
+    # NAME, not a path. Both spellings are tried, because `[[dns.md]]` is the same
+    # link written by someone who knew the extension.
+    base = os.path.basename(cand).lower()
+    hits = [p for name in (base, base + ".md", base + ".markdown")
+            for p in by_base.get(name, [])]
+    if not hits:
+        return None
+    if len(hits) == 1:
+        return hits[0]
+    # AMBIGUITY IS RESOLVED DETERMINISTICALLY, not by walk order. Two files named
+    # `dns.md` in different folders would otherwise attach the backlink to
+    # whichever one os.walk reached first, so the same tree would answer
+    # differently after a rename somewhere else entirely. Nearest first (same
+    # directory as the linking document), then the shallowest path, then the name.
+    return sorted(hits, key=lambda p: (os.path.dirname(p) != src_dir,
+                                       p.count("/"), p))[0]
+
+
+# The cache, keyed on (max mtime, file count) over the markdown files the walk
+# returned.
+#
+# WHAT IT REMOVES is the READ, which is all of the cost: the walk is stat-only
+# and takes tens of milliseconds, while opening and parsing several hundred
+# documents is the second that a reader waits for on every page they open. So the
+# walk still runs on every request and is what produces the key - a cache that
+# skipped the walk could not know it was stale.
+#
+# WHY MTIME-MAX IS ENOUGH, and it is worth being precise because it is a
+# heuristic and not a hash: any edit to any indexed file sets that file's mtime to
+# now, so the maximum moves and the key changes. That covers the only mutation
+# this service performs itself (a save) and every edit made from a shell.
+#
+# WHAT IT MISSES: a DELETE leaves the surviving files' mtimes alone, so the
+# maximum can be unchanged - which is exactly why the count is half the key. What
+# survives both halves is a change that cancels out: deleting one file while
+# restoring another with a preserved old mtime (`cp -p`, `git checkout`, `rsync
+# -t`) in the same instant, or an edit that deliberately rewinds the mtime with
+# `touch -d`. Both are recoverable by touching any file in the tree, and neither
+# is worth hashing several hundred documents on every request to catch.
+_LINKS_CACHE: dict[tuple[str, str], tuple[tuple[int, int], dict]] = {}
+_LINKS_CACHE_LOCK = threading.Lock()
+# Per root AND per scope, bounded. ThreadingHTTPServer is one long-lived process,
+# so an unbounded dict keyed on a caller-supplied path is a memory leak with a
+# public trigger: `?path=` takes any directory in the root.
+_LINKS_CACHE_MAX = 8
+
+
+def links(root_key: str, rel: str = "") -> dict:
+    """A markdown adjacency list over one root: who links out, who links in.
+
+    `in` IS THE INVERSE OF `out`, computed by inverting the map rather than by a
+    second pass over the corpus. A second pass would read every file twice to
+    answer a question the first pass already answered, and - worse - it would be a
+    second implementation of resolution, so the two directions could disagree.
+    "3 documents link here" that does not match the three documents' own link
+    lists is a bug nobody can see from either end.
+    """
+    deadline = time.monotonic() + LINKS_SECONDS
+    members, _skipped = safepath.collect(
+        root_key, rel,
+        max_entries=LINKS_MAX_FILES,
+        max_total=1 << 40,          # not building an archive; size is not the bound
+        max_member=LINKS_MAX_FILE_BYTES,
+        walk_seconds=max(1.0, deadline - time.monotonic()),
+    )
+    docs = [m for m in members
+            if os.path.splitext(m.res.relpath)[1].lower() in MARKDOWN_SUFFIXES]
+
+    truncated: dict | None = None
+    if len(docs) > LINKS_MAX_DOCS:
+        # Reported rather than applied quietly, exactly as /search and /tree do: a
+        # backlink list that silently stops is how a reader concludes a page is an
+        # orphan when it is only past the cutoff.
+        truncated = {"reason": "too many documents", "limit": LINKS_MAX_DOCS,
+                     "found": len(docs)}
+        docs = sorted(docs, key=lambda m: m.res.relpath)[:LINKS_MAX_DOCS]
+
+    stamp = (max((m.mtime for m in docs), default=0), len(docs))
+    key = (root_key, rel or "")
+    with _LINKS_CACHE_LOCK:
+        cached = _LINKS_CACHE.get(key)
+    if cached and cached[0] == stamp:
+        return {**cached[1], "cached": True}
+
+    index: dict[str, dict] = {}
+    by_base: dict[str, list[str]] = {}
+    raw: dict[str, list[tuple[str, bool]]] = {}
+    scanned = 0
+
+    for m in docs:
+        if time.monotonic() > deadline:
+            truncated = truncated or {"reason": "took too long",
+                                      "seconds": LINKS_SECONDS, "scanned": scanned}
+            break
+        path = m.res.relpath
+        try:
+            with open(m.res.abspath, encoding="utf-8", errors="replace") as fh:
+                text = fh.read(LINKS_MAX_FILE_BYTES)
+        except OSError:
+            # One unreadable file must not lose the other six hundred - the same
+            # split collect() makes between per-file problems and whole-request
+            # limits.
+            continue
+        scanned += 1
+        index[path] = {"title": _doc_title(text[:LINKS_TITLE_BYTES], path),
+                       "out": [], "in": []}
+        by_base.setdefault(os.path.basename(path).lower(), []).append(path)
+        raw[path] = _link_targets(text)
+
+    for src, targets in raw.items():
+        seen: list[str] = []
+        for target, wiki in targets:
+            dst = _resolve_link(os.path.dirname(src), target, wiki, index, by_base)
+            # A document that links to itself is not a backlink. Left in, every
+            # page with a table of contents would report that one document links
+            # here - itself - which is the one answer the reader already has.
+            if dst is None or dst == src or dst in seen:
+                continue
+            seen.append(dst)
+        index[src]["out"] = sorted(seen)
+
+    for src, doc in index.items():
+        for dst in doc["out"]:
+            # `out` only ever names a key of `index`, so this cannot raise and
+            # cannot invent a node. That is the same property that keeps a denied
+            # file out of the graph: it was never indexed, so nothing can point at
+            # it and it can point at nothing.
+            index[dst]["in"].append(src)
+    for doc in index.values():
+        doc["in"].sort()
+
+    payload = {
+        "root": root_key,
+        "path": rel,
+        "docs": index,
+        "scanned": scanned,
+        "edges": sum(len(d["out"]) for d in index.values()),
+        # Always present, null when nothing was cut - see /search.
+        "truncated": truncated,
+    }
+    with _LINKS_CACHE_LOCK:
+        if len(_LINKS_CACHE) >= _LINKS_CACHE_MAX and key not in _LINKS_CACHE:
+            _LINKS_CACHE.pop(next(iter(_LINKS_CACHE)))
+        _LINKS_CACHE[key] = (stamp, payload)
+    return {**payload, "cached": False}
+
+
 def history(res: safepath.Resolved, limit: int = 20) -> list[dict]:
     # A file under no repository has no history. Real state, not an error: it is
     # why the write path also reports `committed: false` rather than pretending.
@@ -782,6 +1079,21 @@ class Handler(BaseHTTPRequestHandler):
                     case=q.get("case") == "1",
                     glob=q.get("glob") or None,
                     limit=max(1, limit)))
+
+            if route == "/links":
+                # NO `root=*`, unlike /search, and the reason is the shape of the
+                # answer rather than caution: `docs` is keyed on a path relative to
+                # ONE root, and a link inside a document cannot name another root -
+                # there is no syntax for it. A merged graph would have to key on
+                # (root, path) tuples to stay honest, and every hit under `home`
+                # would duplicate a node that already exists under stacks or notes.
+                root = q.get("root", "")
+                if root not in safepath.ROOTS:
+                    return self._send(400, {"error": f"unknown root {root!r}"})
+                # `path` scopes the graph to a subtree, like /search's. Backlinks
+                # are read while a document is open, so the useful scope is often
+                # the folder it lives in rather than a 3,000-file root.
+                return self._send(200, links(root, q.get("path", "")))
 
             if route == "/read":
                 res = safepath.resolve(q.get("root", ""), q.get("path", ""))

--- a/apps/portal-files/checks/links_index.py
+++ b/apps/portal-files/checks/links_index.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Does /links describe the document graph that is actually there?
+
+The endpoint answers one question for the reader - "3 documents link here" - and
+every way it can be wrong is quiet. A missed edge reads as an orphan page. An
+invented edge sends someone to a document that never mentioned theirs. And an
+index built from its own os.walk would happily hold a file the explorer refuses
+to open, which is the failure checks/search_denied.py exists for, one endpoint
+along.
+
+So this plants a small corpus with one instance of every case that matters and
+asserts the exact graph:
+
+    a.md               inline [b](b.md), wiki [[deep/c]], an http link, an
+                       unresolvable target, a bare #anchor, and a link inside a
+                       FENCED BLOCK - only the first two may become edges
+    b.md               no links; receives two
+    deep/c.md          [[b]] - a wikilink that must match on BASENAME from a
+                       subdirectory, the shape claude-notes is written in
+    fenced-only.md     linked ONLY from inside a code fence - must be an orphan
+    no-heading.md      no `# heading`; its title comes from the filename
+    .env               a credential store, and linked to from a.md
+    node_modules/x.md  markdown, inside a DENIED directory
+
+WHERE IT PLANTS THEM, and this is deliberate: a probe directory in $HOME, read
+through the `home` root, NOT inside ~/stacks or ~/claude-notes. Those two are git
+repositories that this same service holds writable handles on, and a check that
+leaves a stray file in one of them dirties a tree somebody is working in - a
+previous agent's probe destroyed ~/stacks/.env doing exactly this. Nothing here
+writes inside a repo, and the directory is removed in a `finally`.
+"""
+import json
+import os
+import re
+import shutil
+import sys
+import time
+
+import requests
+
+BASE = "http://100.117.176.85"
+API = f"{BASE}/-/api/files"
+# Under $HOME rather than under either repo - see the module docstring. Named so
+# that a leftover from a crashed run is unmistakable and greppable.
+PROBE_REL = "_bothy-links-probe-4c81de"
+PROBE_DIR = f"/home/devssh/{PROBE_REL}"
+
+fails = 0
+
+
+def check(label, ok, detail=""):
+    global fails
+    if not ok:
+        fails += 1
+    print(f"{'PASS' if ok else 'FAIL'}  {label:<56} {detail}")
+
+
+def write(rel, body):
+    path = f"{PROBE_DIR}/{rel}"
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        fh.write(body)
+
+
+if os.path.exists(PROBE_DIR):
+    sys.exit(f"REFUSING TO RUN: {PROBE_DIR} already exists - a previous run did "
+             f"not clean up. Inspect it, then remove it.")
+
+FILES = {
+    "a.md": (
+        "# Alpha\n\n"
+        "An inline link to [Beta](b.md) and a wikilink to [[deep/c]].\n"
+        "A web link to [example](https://example.com/x.md) and a protocol-relative\n"
+        "one to [cdn](//example.net/y.md), plus a bare [anchor](#alpha).\n"
+        "A link to a file that is not there: [gone](nowhere.md).\n"
+        "And to a credential store: [env](.env).\n"
+        "An inline code span is not a link: `[code](fenced-only.md)`\n\n"
+        "```sh\n"
+        "# a code SAMPLE, not a link: [fenced](fenced-only.md) and [[fenced-only]]\n"
+        "```\n"
+    ),
+    "b.md": "# Beta\n\nNothing links out of here.\n",
+    "deep/c.md": "# Gamma\n\nA basename wikilink back to [[b]].\n",
+    "fenced-only.md": "# Fenced only\n\nOnly ever linked from inside a fence.\n",
+    "no-heading.md": "just prose, no heading at all\n",
+    ".env": "PROBE_API_TOKEN=zzq-links-probe-not-a-real-secret-0001\n",
+    "node_modules/x.md": "# Hidden\n\nLinks to [Alpha](../a.md).\n",
+}
+
+try:
+    for rel, body in FILES.items():
+        write(rel, body)
+
+    # ── anonymous ───────────────────────────────────────────────────────────
+    print("── anonymous ───────────────────────────────────────────────────────")
+    r = requests.get(f"{API}/links", params={"root": "home", "path": PROBE_REL},
+                     timeout=20)
+    check("anonymous /links is refused", r.status_code in (401, 403),
+          f"got {r.status_code}")
+
+    # ── log in ──────────────────────────────────────────────────────────────
+    print("\n── log in ──────────────────────────────────────────────────────────")
+    s = requests.Session()
+    r = s.get(f"{BASE}/oauth2/start", params={"rd": "/"}, allow_redirects=True,
+              timeout=10)
+    m = re.search(r'action="([^"]+)"', r.text)
+    if not m:
+        sys.exit("FAIL: no Keycloak login form")
+    s.post(m.group(1).replace("&amp;", "&"),
+           data={"username": os.environ["DEV_LOGIN_USER"],
+                 "password": os.environ["DEV_LOGIN_PASSWORD"]},
+           allow_redirects=True, timeout=10)
+    check("session established",
+          any(c.name.startswith("_oauth2_proxy") for c in s.cookies))
+
+    def graph(**extra):
+        r = s.get(f"{API}/links",
+                  params={"root": "home", "path": PROBE_REL, **extra}, timeout=60)
+        if r.status_code != 200:
+            check("/links answers", False, f"got {r.status_code}: {r.text[:200]}")
+            return {"docs": {}, "cached": None}
+        b = r.json()
+        # Re-key on paths relative to the PROBE, so the assertions below read as
+        # the corpus above rather than as $HOME paths. Edge lists are rewritten
+        # too - a half-stripped graph is one whose `in` lists no longer name keys
+        # of `docs`, which is a bug in this file that would look like one in the
+        # endpoint.
+        def strip(p):
+            return p[len(PROBE_REL) + 1:] if p.startswith(PROBE_REL + "/") else p
+        return {**b, "docs": {
+            strip(p): {**d,
+                       "out": [strip(x) for x in d["out"]],
+                       "in": [strip(x) for x in d["in"]]}
+            for p, d in b["docs"].items()}}
+
+    print("\n── the graph ───────────────────────────────────────────────────────")
+    b = graph()
+    docs = b["docs"]
+    out_a = docs.get("a.md", {}).get("out", [])
+
+    check("an inline link becomes an edge", "b.md" in out_a, f"a.md -> {out_a}")
+    check("a wikilink becomes an edge", "deep/c.md" in out_a, f"a.md -> {out_a}")
+    check("a link inside a FENCE is not an edge", "fenced-only.md" not in out_a,
+          f"a.md -> {out_a}")
+    check("an http:// link is not an edge",
+          not any("example" in t for t in out_a), f"a.md -> {out_a}")
+    check("a bare #anchor is not an edge", "a.md" not in out_a, f"a.md -> {out_a}")
+    check("an unresolvable target is not an edge",
+          "nowhere.md" not in out_a and "nowhere.md" not in docs, f"a.md -> {out_a}")
+    check("and nothing else got in either", sorted(out_a) == ["b.md", "deep/c.md"],
+          f"a.md -> {out_a}")
+
+    # ── the boundary ────────────────────────────────────────────────────────
+    #
+    # The index is built from safepath.collect(), so a file the walk refuses is
+    # not a node - and because link targets are resolved by LOOKUP in that index
+    # rather than against the filesystem, it cannot be an edge either. Both halves
+    # are asserted: absent as a document, absent as a target.
+    print("\n── what must never appear in an index ──────────────────────────────")
+    every_target = {t for d in docs.values() for t in d["out"]}
+    check("a markdown file in node_modules/ is not indexed",
+          "node_modules/x.md" not in docs, f"{sorted(docs)}")
+    check("...and cannot be a link target either",
+          "node_modules/x.md" not in every_target, f"{sorted(every_target)}")
+    check("a credential store is not a document", ".env" not in docs)
+    check("...and a link to one is not an edge", ".env" not in every_target,
+          f"{sorted(every_target)}")
+    check("only markdown is indexed",
+          all(p.endswith((".md", ".markdown")) for p in docs), f"{sorted(docs)}")
+
+    # ── inversion ───────────────────────────────────────────────────────────
+    print("\n── `in` is the exact inverse of `out` ──────────────────────────────")
+    inverse: dict[str, list[str]] = {p: [] for p in docs}
+    for src, d in docs.items():
+        for dst in d["out"]:
+            inverse[dst].append(src)
+    mismatch = {p: (sorted(d["in"]), sorted(inverse[p]))
+                for p, d in docs.items() if sorted(d["in"]) != sorted(inverse[p])}
+    check("every `in` list is exactly the inverted `out`", not mismatch,
+          json.dumps(mismatch) if mismatch else f"{len(docs)} documents")
+    check("a wikilink matches on BASENAME from a subdirectory",
+          docs.get("deep/c.md", {}).get("out") == ["b.md"],
+          f"deep/c.md -> {docs.get('deep/c.md', {}).get('out')}")
+    check("b.md reports both documents that link to it",
+          sorted(docs.get("b.md", {}).get("in", [])) == ["a.md", "deep/c.md"],
+          f"{docs.get('b.md', {}).get('in')}")
+    check("the fence-only document is an orphan",
+          docs.get("fenced-only.md", {}).get("in") == [],
+          f"{docs.get('fenced-only.md', {}).get('in')}")
+
+    # ── titles ──────────────────────────────────────────────────────────────
+    print("\n── titles ──────────────────────────────────────────────────────────")
+    check("the first heading is the title",
+          docs.get("b.md", {}).get("title") == "Beta",
+          f"{docs.get('b.md', {}).get('title')!r}")
+    check("no heading falls back to the prettified filename",
+          docs.get("no-heading.md", {}).get("title") == "No heading",
+          f"{docs.get('no-heading.md', {}).get('title')!r}")
+
+    # ── the cache ───────────────────────────────────────────────────────────
+    #
+    # Keyed on (max mtime, file count) over the walk, so the two invalidations
+    # worth having are tested separately: an EDIT moves the maximum, a DELETE does
+    # not and is caught by the count. The second is the one a mtime-only key
+    # would miss, which is why it is not folded into the first.
+    print("\n── the cache: same answer twice, different after a change ──────────")
+    again = graph()
+    check("the second request is served from cache", again.get("cached") is True,
+          f"cached={again.get('cached')}")
+    check("...and says exactly the same thing",
+          again["docs"] == docs and again["scanned"] == b["scanned"])
+
+    # mtime has one-second granularity on some filesystems, and the key is the
+    # MAXIMUM mtime - so an edit within the same second as the walk would leave
+    # the key unchanged and the assertion below would fail for a reason that is
+    # not a bug in the cache.
+    time.sleep(1.1)
+    with open(f"{PROBE_DIR}/b.md", "a") as fh:
+        fh.write("\nNow it links to [Alpha](a.md).\n")
+    edited = graph()
+    check("an EDIT invalidates it (max mtime moved)",
+          edited.get("cached") is False, f"cached={edited.get('cached')}")
+    check("...and the new edge is there",
+          edited["docs"].get("b.md", {}).get("out") == ["a.md"],
+          f"b.md -> {edited['docs'].get('b.md', {}).get('out')}")
+
+    os.unlink(f"{PROBE_DIR}/no-heading.md")
+    deleted = graph()
+    check("a DELETE invalidates it too (the count fell)",
+          deleted.get("cached") is False, f"cached={deleted.get('cached')}")
+    check("...and the document is gone from the index",
+          "no-heading.md" not in deleted["docs"], f"{sorted(deleted['docs'])}")
+
+    # ── honesty and refusals ────────────────────────────────────────────────
+    print("\n── refusals and shape ──────────────────────────────────────────────")
+    check("truncation is always reported, null when nothing was cut",
+          "truncated" in b and b["truncated"] is None, f"{b.get('truncated')}")
+    r = s.get(f"{API}/links", params={"root": "../../etc"}, timeout=10)
+    check("an unknown root is refused", r.status_code == 400, f"got {r.status_code}")
+    r = s.get(f"{API}/links", params={"root": "home", "path": "../etc"}, timeout=20)
+    check("a path escaping the root is refused", r.status_code == 403,
+          f"got {r.status_code}")
+
+finally:
+    shutil.rmtree(PROBE_DIR, ignore_errors=True)
+
+print()
+print("OK - the link graph matches the corpus, and holds nothing the explorer hides."
+      if not fails else f"{fails} check(s) FAILED")
+sys.exit(1 if fails else 0)

--- a/apps/portal-files/checks/run.sh
+++ b/apps/portal-files/checks/run.sh
@@ -63,6 +63,13 @@ echo; echo "── search must not see what the explorer refuses to open ──�
 # file and requires that only the served one comes back.
 python3 checks/search_denied.py || fail=1
 
+echo; echo "── backlinks: the graph, and what must not be in it ─────────"
+# Runs after search_denied.py for the same reason it exists: /links walks with
+# safepath.collect() too, and an index is a place a denied file would sit
+# permanently rather than only appearing in one answer. Plants its corpus in
+# $HOME - never inside either repo - and removes it in a finally.
+python3 checks/links_index.py || fail=1
+
 echo; echo "── does anything SERVED look like a credential? ─────────────"
 # Baseline diff, not "fail on any hit" - the detector flags 40 files and the top
 # hits are .env.example and READMEs, so an absolute check would be noise nobody

--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -38,8 +38,17 @@ mv "$OUT/contract.js" "$OUT/contract.mjs"
 (cd "$WEB" && npx tsc src/lib/customThemes.ts --ignoreConfig \
   --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
 mv "$OUT/customThemes.js" "$OUT/user-themes-mod.mjs"
+# tree.ts is the one module here that is not import-free: it carries a TYPE-only
+# import, which tsc erases from the output but still uses to compute rootDir - so
+# this one lands at $OUT/pages/files/ rather than at the top. Moved rather than
+# forced with --rootDir, which makes tsc error on the very import it is about to
+# erase.
+(cd "$WEB" && npx tsc src/pages/files/tree.ts --ignoreConfig \
+  --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
+mv "$OUT/pages/files/tree.js" "$OUT/wikilinks-mod.mjs"
 cp "$HERE/status-classifier.mjs" "$HERE/relations.mjs" "$HERE/redirect-table.mjs" \
-   "$HERE/titles-table.mjs" "$HERE/theme-contract.mjs" "$HERE/user-themes.mjs" "$OUT/"
+   "$HERE/titles-table.mjs" "$HERE/theme-contract.mjs" "$HERE/user-themes.mjs" \
+   "$HERE/wikilinks.mjs" "$OUT/"
 
 echo "── truth table ─────────────────────────────────────────"
 node "$OUT/status-classifier.mjs"
@@ -87,6 +96,13 @@ echo "── a theme dropped in by hand is read correctly ───────�
 # it decides which base palette the pre-paint script stamps, so a light theme
 # would render its first frame on the dark base.
 node "$OUT/user-themes.mjs"
+
+echo
+echo "── a wikilink finds the right document ─────────────────"
+# `[[dns]]` carries no directory and no extension, so resolving one is a SEARCH
+# with a precedence order. Get the order wrong and the failure is not an error -
+# it is a link that quietly opens the wrong note.
+node "$OUT/wikilinks.mjs"
 
 echo
 echo "── every colour comes from a token ─────────────────────"

--- a/apps/portal-next/checks/wikilinks.mjs
+++ b/apps/portal-next/checks/wikilinks.mjs
@@ -1,0 +1,68 @@
+// `[[dns]]` has to find the right document, and the interesting cases are the
+// ones where more than one answer exists.
+//
+// WHY THIS IS WORTH A TABLE. A wikilink carries no directory and no extension,
+// so resolving one is a search, and a search has a precedence order. Get that
+// order wrong and the failure is not an error - it is a link that opens the
+// WRONG note, which nobody reports as a bug because it looks like it worked.
+//
+// The order under test, from resolveWikiIn's own comment: exact path, then
+// +.md, then /index.md, then by basename. Basename is last because it is the
+// one people write most and the only one that can be ambiguous.
+
+import { resolveWikiIn } from './wikilinks-mod.mjs';
+
+let bad = 0;
+const eq = (label, got, want) => {
+  const g = got ? got.path + got.frag : String(got);
+  const ok = g === want;
+  if (!ok) bad += 1;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label.padEnd(56)} ${ok ? g : `want=${want} got=${g}`}`);
+};
+
+// A tree with every collision the real one has: a name that exists at two
+// depths, a folder with an index, and a file whose name is a prefix of another.
+const TREE = [
+  'README.md',
+  'network/dns.md',
+  'network/index.md',
+  'machine/dns.md',
+  'machine/tooling.md',
+  'docs/kb/access.md',
+  'docs/kb/runbook-cant-reach.md',
+  'notes/DNS.MD',
+  'scripts/backup.sh',
+];
+
+console.log('── the resolution order ────────────────────────────────────────────');
+eq('an exact path wins', resolveWikiIn(TREE, 'network/dns.md'), 'network/dns.md');
+eq('a path without its extension', resolveWikiIn(TREE, 'network/dns'), 'network/dns.md');
+eq('a folder resolves to its index', resolveWikiIn(TREE, 'network'), 'network/index.md');
+eq('a bare name, by basename', resolveWikiIn(TREE, 'tooling'), 'machine/tooling.md');
+eq('a leading slash is not an escape hatch', resolveWikiIn(TREE, '/network/dns'), 'network/dns.md');
+
+console.log('\n── ambiguity, resolved the same way every time ─────────────────────');
+// dns.md exists twice. The answer must not depend on the order the tree was
+// listed in, so it is the shallowest path and then alphabetical.
+eq('the shallowest match wins', resolveWikiIn(TREE, 'dns'), 'machine/dns.md');
+eq('...and again with the tree reversed', resolveWikiIn([...TREE].reverse(), 'dns'), 'machine/dns.md');
+// An EXACT path must never lose to a basename match somewhere shallower.
+eq('an exact match beats a shallower basename', resolveWikiIn(TREE, 'network/dns.md'), 'network/dns.md');
+
+console.log('\n── fragments and case ──────────────────────────────────────────────');
+eq('a fragment is carried, not resolved', resolveWikiIn(TREE, 'dns#ttl'), 'machine/dns.md#ttl');
+eq('a fragment on an exact path', resolveWikiIn(TREE, 'network/dns#ttl'), 'network/dns.md#ttl');
+// Somebody writing [[DNS]] about a file called dns.md means that file.
+eq('basename matching ignores case', resolveWikiIn(TREE, 'ACCESS'), 'docs/kb/access.md');
+eq('...including the extension', resolveWikiIn(['a/Thing.Md'], 'thing'), 'a/Thing.Md');
+
+console.log('\n── what must NOT resolve ───────────────────────────────────────────');
+eq('a name nothing matches', resolveWikiIn(TREE, 'nonexistent'), 'null');
+eq('an empty target', resolveWikiIn(TREE, ''), 'null');
+eq('a bare fragment names no document', resolveWikiIn(TREE, '#heading'), 'null');
+// A wikilink is for documents. A shell script is not one, and resolving to it
+// would put a button on a page that opens a file the reader cannot read.
+eq('a non-document is not found by basename', resolveWikiIn(TREE, 'backup'), 'null');
+
+console.log(`\n${bad ? `${bad} FAILED` : 'all pass'}`);
+process.exit(bad ? 1 : 0);

--- a/apps/portal-next/web/src/index.css
+++ b/apps/portal-next/web/src/index.css
@@ -140,6 +140,27 @@
      exist reads as configurable when nothing can configure it. */
   --rest-opacity: .55;
 
+  /* ── reading ──────────────────────────────────────────────────────────────
+     The rendered-document scale, tokenised 2026-08-17. It was ~30 literal
+     values in editor.css, which meant a theme could restyle every colour in the
+     app and not touch the one surface people spend the most time reading.
+
+     STRUCTURAL, so a theme inherits these unless it opts in - the same
+     treatment radii and motion get. A theme is a palette; changing the reading
+     measure would make it a different product wearing the same name. But a
+     theme MAY set them, which is the point of their being tokens at all.
+
+     72ch is prose, not a terminal. The measure rule changes reading speed more
+     than the typeface does. */
+  --read-measure: 72ch;
+  --read-fs: 14.5px;
+  --read-lh: 1.65;
+  --read-gap: 13px;      /* between blocks */
+  --read-h1: 25px;
+  --read-h2: 19px;
+  --read-h3: 16px;
+  --read-h4: 14px;
+
   /* ── motion ─────────────────────────────────────────────────────────────── */
   --dur-fast: 120ms;   /* hover, colour */
   --dur:      180ms;   /* transform, elevation */

--- a/apps/portal-next/web/src/lib/files.ts
+++ b/apps/portal-next/web/src/lib/files.ts
@@ -681,3 +681,48 @@ export async function deleteFile(
   if (!r.ok) return { kind: 'refused', message: await errorText(r, 'the delete was refused') };
   return { kind: 'saved', res: { ok: true, path, mtime: 0, bytes: 0 } as WriteResult };
 }
+
+// ── the link graph ───────────────────────────────────────────────────────────
+//
+// Which documents point at which, for the reader's backlinks panel. Built
+// server-side because answering "what links HERE" needs every document, not the
+// one on screen - the browser holds one file at a time by design.
+
+export interface DocLinks {
+  title: string;
+  /** Documents this one points at, root-relative. */
+  out: string[];
+  /** Documents that point at this one. The inverse of `out`, computed by the
+   *  service so there is one implementation of what counts as a link. */
+  in: string[];
+}
+
+export interface LinkIndex {
+  root: string;
+  docs: Record<string, DocLinks>;
+  scanned: number;
+  truncated: { reason: string; limit?: number } | null;
+}
+
+/** The whole graph for a root.
+ *
+ *  One request per root rather than one per document: the index is built from a
+ *  walk either way, so asking per-document would repeat the expensive half and
+ *  still not let the reader say "3 documents link here" without it. Measured on
+ *  this box: 20 documents in 14ms warm, and the service caches on (max mtime,
+ *  count) so an unchanged tree costs a stat walk.
+ *
+ *  Absent is a supported answer. A root with no markdown, a service too old to
+ *  know the route, a 404 - all of them mean "no backlinks to show", which is a
+ *  panel that does not render rather than an error nobody can act on.
+ */
+export async function fetchLinks(root: string, signal?: AbortSignal): Promise<LinkIndex | null> {
+  try {
+    const r = await fetch(`${BASE}/links?root=${encodeURIComponent(root)}`, { signal });
+    if (!r.ok) return null;
+    const j = (await r.json()) as LinkIndex;
+    return j && typeof j.docs === 'object' ? j : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/portal-next/web/src/pages/files/FileView.tsx
+++ b/apps/portal-next/web/src/pages/files/FileView.tsx
@@ -36,7 +36,9 @@ type State =
   | { at: 'too-large'; why: string }
   | { at: 'error'; why: string };
 
-export function FileView({ root, path, view = 'preview', frag = '', onOpen, onLoad }: {
+export function FileView({
+  root, path, view = 'preview', frag = '', onOpen, onLoad, resolveWiki,
+}: {
   root: string;
   path: string;
   /** Controlled by the caller. A reader that wants a Preview/Source switch owns
@@ -44,6 +46,10 @@ export function FileView({ root, path, view = 'preview', frag = '', onOpen, onLo
   view?: View;
   /** The `#heading` to land on, if the caller arrived by following a link. */
   frag?: string;
+  /** Resolve a `[[wikilink]]` against the documents that exist. Passed down
+   *  rather than computed here for the reason md.tsx gives: answering one needs
+   *  the list of files, and neither this component nor the renderer holds it. */
+  resolveWiki?: (target: string) => { path: string; frag: string } | null;
   /** Follow a cross-document link. Absent means those links keep rendering as
    *  inert text, which is the honest state for a view with nowhere to send you. */
   onOpen?: (path: string, frag: string) => void;
@@ -172,7 +178,7 @@ export function FileView({ root, path, view = 'preview', frag = '', onOpen, onLo
         // Nothing on this surface reports a degraded image; the frame it falls
         // back to labels itself.
         onFallback={() => {}}
-        links={onOpen ? { dir, open: onOpen } : undefined}
+        links={onOpen ? { dir, open: onOpen, resolveWiki } : undefined}
       />
     </div>
   );

--- a/apps/portal-next/web/src/pages/files/Reader.tsx
+++ b/apps/portal-next/web/src/pages/files/Reader.tsx
@@ -40,7 +40,7 @@ import { SearchView } from './Search';
 import { SignInCard } from './SignInCard';
 import { Toc, useHeadings } from './Toc';
 import { filesHref } from './routes';
-import { baseName, dirName } from './tree';
+import { baseName, dirName, resolveWikiIn } from './tree';
 
 // shell.css carries the section scope (the full-height escape from `.content`,
 // the inset focus ring and the syntax palette) and editor.css carries `.fx-read`
@@ -335,6 +335,15 @@ export function Reader() {
                     // ~/claude-notes is built out of relative links, and a
                     // documentation site whose links do not click is not one.
                     onOpen={(p, at) => openDoc(root, p, at)}
+                    // Wikilinks resolve against the CURRENT root's listing,
+                    // which this page already has for the index beside it. Only
+                    // that root: `[[dns]]` in a note means the note called dns,
+                    // and reaching into another root to find one would make the
+                    // same link mean different things depending on what happened
+                    // to be loaded.
+                    resolveWiki={(t) => resolveWikiIn(
+                      (trees[root]?.entries ?? []).map((e) => e.path), t,
+                    )}
                     onLoad={setFile}
                   />
                 </div>

--- a/apps/portal-next/web/src/pages/files/Reader.tsx
+++ b/apps/portal-next/web/src/pages/files/Reader.tsx
@@ -41,6 +41,7 @@ import { SignInCard } from './SignInCard';
 import { Toc, useHeadings } from './Toc';
 import { filesHref } from './routes';
 import { baseName, dirName, resolveWikiIn } from './tree';
+import { fetchLinks, type LinkIndex } from '../../lib/files';
 
 // shell.css carries the section scope (the full-height escape from `.content`,
 // the inset focus ring and the syntax palette) and editor.css carries `.fx-read`
@@ -65,6 +66,15 @@ export function Reader() {
   const [needsAuth, setNeedsAuth] = useState(false);
   const [rootsErr, setRootsErr] = useState<string | null>(null);
   const [trees, setTrees] = useState<Record<string, RootTree | undefined>>({});
+  // The link graph for the open root. One request per root, not per document:
+  // the service builds it from a walk either way, and asking per-document would
+  // repeat the expensive half while still not answering "what links here".
+  //
+  // Deliberately NOT awaited before the document renders. Backlinks are context
+  // you read after the page, so blocking the page on them would trade the thing
+  // people came for against the thing they might glance at.
+  const [graph, setGraph] = useState<Record<string, LinkIndex | null>>({});
+
   const [openRoots, setOpenRoots] = useState<Set<string>>(new Set());
   const [allFiles, setAllFiles] = useState(false);
   const [tick, setTick] = useState(0);
@@ -83,6 +93,17 @@ export function Reader() {
 
   const docBox = useRef<HTMLDivElement | null>(null);
   const root = urlRoot;
+
+  useEffect(() => {
+    if (!root || root in graph) return;
+    const ac = new AbortController();
+    // `null` is written on failure as well as on success-with-nothing, because
+    // both mean the same thing to this page - no panel - and leaving the key
+    // absent would retry the request on every render.
+    fetchLinks(root, ac.signal).then((g) => setGraph((m) => ({ ...m, [root]: g })));
+    return () => ac.abort();
+  }, [root, graph]);
+
 
   // ── the roots ──────────────────────────────────────────────────────────────
   //
@@ -346,6 +367,14 @@ export function Reader() {
                     )}
                     onLoad={setFile}
                   />
+                  {/* AFTER the document, never beside it. Backlinks are context
+                      you want once you have read the thing, and a sidebar of
+                      them competes with the outline for the same glance. */}
+                  <Backlinks
+                    index={graph[root] ?? null}
+                    path={path}
+                    onOpen={(p) => openDoc(root, p, undefined)}
+                  />
                 </div>
               </>
             ) : (
@@ -372,5 +401,49 @@ export function Reader() {
         </div>
       )}
     </div>
+  );
+}
+
+/** "3 documents link here", and which ones.
+ *
+ *  WHY THIS IS WORTH A PANEL. A note in ~/claude-notes is written as if the
+ *  reader arrived from somewhere - "see the naming note" - and the reverse
+ *  question, "what refers to this", has no answer anywhere else on the box. The
+ *  index makes it a lookup; without it you are grepping.
+ *
+ *  It renders NOTHING when there is nothing to say. A panel reading "0 documents
+ *  link here" is a row of furniture on every orphan, and this reader's whole
+ *  argument is that the rarer case should not tax the common one.
+ */
+function Backlinks({ index, path, onOpen }: {
+  index: LinkIndex | null;
+  path: string;
+  onOpen: (path: string) => void;
+}) {
+  if (!index) return null;
+  const doc = index.docs[path];
+  const from = doc?.in ?? [];
+  if (!from.length) return null;
+
+  return (
+    <section className="rd-backlinks" aria-label="Documents that link here">
+      <h2>
+        {from.length} document{from.length === 1 ? '' : 's'} link
+        {from.length === 1 ? 's' : ''} here
+      </h2>
+      <ul>
+        {from.map((p) => (
+          <li key={p}>
+            {/* A button, not a link, for the reason md.tsx gives at length:
+                there is no URL for a file inside a root, and writing one would
+                be inventing an href this page cannot honour. */}
+            <button type="button" onClick={() => onOpen(p)} title={p}>
+              <span className="rd-bl-title">{index.docs[p]?.title || baseName(p)}</span>
+              <span className="rd-bl-path mono">{p}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }

--- a/apps/portal-next/web/src/pages/files/editor.css
+++ b/apps/portal-next/web/src/pages/files/editor.css
@@ -579,21 +579,21 @@
 /* ── read view (markdown) ────────────────────────────────────────────────── */
 .bothy-files .fx-read { flex: 1; min-height: 0; overflow: auto; margin: 0; padding: 24px 28px 44px; }
 .bothy-files .fx-read:focus-visible { outline: 2px solid var(--ring); outline-offset: -2px; }
-/* 72ch: prose, not a terminal. The measure rule changes reading speed more than
-   the typeface does. Full-bleed for the two things that are not prose. */
-.bothy-files .fx-read > * { max-width: 72ch; }
+/* The measure comes from --read-measure (index.css, where the reasoning is).
+   Full-bleed for the two things that are not prose. */
+.bothy-files .fx-read > * { max-width: var(--read-measure); }
 .bothy-files .fx-read > .md-tbl-wrap,
 .bothy-files .fx-read > .md-pre { max-width: 100%; }
 
-.bothy-files .md { color: var(--fg-muted); font-size: 14.5px; line-height: 1.65; }
+.bothy-files .md { color: var(--fg-muted); font-size: var(--read-fs); line-height: var(--read-lh); }
 .bothy-files .md .md-h { color: var(--fg); letter-spacing: -0.015em; line-height: 1.25; margin: 26px 0 10px; font-weight: 700; }
 .bothy-files .md > .md-h:first-child { margin-top: 0; }
-.bothy-files .md .md-h1 { font-size: 25px; font-weight: 800; }
-.bothy-files .md .md-h2 { font-size: 19px; padding-bottom: 6px; border-bottom: 1px solid var(--line); }
-.bothy-files .md .md-h3 { font-size: 16px; }
-.bothy-files .md .md-h4, .bothy-files .md .md-h5, .bothy-files .md .md-h6 { font-size: 14px; color: var(--fg-muted); }
-.bothy-files .md .md-p { margin: 0 0 13px; }
-.bothy-files .md .md-list { margin: 0 0 13px; padding-left: 22px; }
+.bothy-files .md .md-h1 { font-size: var(--read-h1); font-weight: 800; }
+.bothy-files .md .md-h2 { font-size: var(--read-h2); padding-bottom: 6px; border-bottom: 1px solid var(--line); }
+.bothy-files .md .md-h3 { font-size: var(--read-h3); }
+.bothy-files .md .md-h4, .bothy-files .md .md-h5, .bothy-files .md .md-h6 { font-size: var(--read-h4); color: var(--fg-muted); }
+.bothy-files .md .md-p { margin: 0 0 var(--read-gap); }
+.bothy-files .md .md-list { margin: 0 0 var(--read-gap); padding-left: 22px; }
 .bothy-files .md .md-list li { margin: 3px 0; }
 .bothy-files .md .md-list .md-list { margin-bottom: 0; }
 .bothy-files .md .md-hr { border: 0; border-top: 1px solid var(--line); margin: 22px 0; }

--- a/apps/portal-next/web/src/pages/files/md.tsx
+++ b/apps/portal-next/web/src/pages/files/md.tsx
@@ -10,6 +10,9 @@
 // and the Source toggle is one click away, so a mis-parse is cosmetic.
 
 import type { ReactNode } from 'react';
+import {
+  Info, Lightbulb, MessageSquareWarning, OctagonAlert, TriangleAlert,
+} from 'lucide-react';
 import { langFor } from '../../lib/files';
 import { highlight } from './highlight';
 import { resolveRelative } from './tree';
@@ -30,6 +33,16 @@ export interface MdLinks {
   /** Open a root-relative path in the same root. `frag` is the `#heading` the
    *  link carried, or `''`; the caller decides whether it can honour it. */
   open: (path: string, frag: string) => void;
+  /** Resolve a WIKILINK target - `[[dns]]`, `[[network/dns]]`, `[[dns#ttl]]` -
+   *  to a real path, or null.
+   *
+   *  Supplied by the caller rather than computed here, and that is the same
+   *  division this interface already draws: a wikilink has no extension and no
+   *  directory, so answering it needs the LIST OF DOCUMENTS, which is exactly
+   *  the knowledge this module is built not to have. Absent, wikilinks render
+   *  inert like any other unresolvable link - which is the honest result for a
+   *  caller that cannot say what exists. */
+  resolveWiki?: (target: string) => { path: string; frag: string } | null;
 }
 
 // Only http(s), mailto and anchors become an <a href>. Everything else is a
@@ -43,7 +56,9 @@ const RE_WEB = /^(https?:\/\/|#|mailto:)/i;
 // not a path; `//host/x` is not one either.
 const RE_SCHEME = /^([a-z][a-z0-9+.-]*:|\/\/)/i;
 
-function refLink(href: string, label: string, key: string, links?: MdLinks): ReactNode {
+function refLink(
+  href: string, label: string, key: string, links?: MdLinks, wiki = false,
+): ReactNode {
   // Today's rendering, and still the answer for anything that does not resolve:
   // the text, with the target beside it, because the target is information the
   // reader wanted and an unresolvable link is worth SEEING as unresolvable.
@@ -51,7 +66,22 @@ function refLink(href: string, label: string, key: string, links?: MdLinks): Rea
     <span className="md-reflink" key={key}>{label || href}<span className="md-reftarget">{href}</span></span>
   );
   if (!links || RE_SCHEME.test(href)) return inert;
-  const hit = resolveRelative(links.dir, href);
+  // A wikilink is resolved ONLY against the index, and never falls back to
+  // resolveRelative - which is the difference between the two syntaxes rather
+  // than an omission.
+  //
+  // resolveRelative normalises a path; it does not know what exists, because for
+  // a markdown link it does not have to - the author wrote a path and the reader
+  // can see whether it opens. `[[nothing-here]]` has no path in it at all, so
+  // falling through turned it into a live button pointing at a file of that
+  // name. Measured on a probe document: an unresolvable wikilink rendered as
+  // resolved, which is the worst of the three possible answers.
+  //
+  // resolveWikiIn handles `[[network/dns]]` too, so nothing is lost by not
+  // falling back.
+  const hit = wiki
+    ? (links.resolveWiki?.(href) ?? null)
+    : resolveRelative(links.dir, href);
   if (!hit) return inert;
   // A BUTTON, never an anchor. The `javascript:` argument above only stays true
   // as long as nothing here writes an href, and a handler that calls the
@@ -74,7 +104,10 @@ function refLink(href: string, label: string, key: string, links?: MdLinks): Rea
   );
 }
 
-const INLINE_RE = /(`[^`\n]+`)|(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)|(_[^_\n]+_)|(\[[^\]\n]*\]\([^)\s]+\))/g;
+// The wiki alternative comes FIRST and that is load-bearing: `[[dns]]` would
+// otherwise be matched by the inline-link arm as `[` followed by `[dns]`, and
+// the reader would print a stray bracket beside a broken link.
+const INLINE_RE = /(\[\[[^\]\n]+\]\])|(`[^`\n]+`)|(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)|(_[^_\n]+_)|(\[[^\]\n]*\]\([^)\s]+\))/g;
 
 function inlineMd(text: string, k: string, links?: MdLinks): ReactNode[] {
   const out: ReactNode[] = [];
@@ -89,7 +122,18 @@ function inlineMd(text: string, k: string, links?: MdLinks): ReactNode[] {
     // containing a link or a `code span` swallows it whole and prints the
     // markdown source - measured on docs/kb/access.md, whose second line is
     // exactly that shape. Code is terminal by definition: it is literal.
-    if (tok.startsWith('`')) out.push(<code className="md-code" key={key}>{tok.slice(1, -1)}</code>);
+    if (tok.startsWith('[[')) {
+      // `[[target]]` or `[[target|label]]`. It resolves through refLink, the
+      // SAME path a relative markdown link takes - so a wikilink inherits the
+      // property that file records at length: it never becomes an <a href>, and
+      // therefore `javascript:` can never reach one. A new syntax, an existing
+      // resolver.
+      const inner = tok.slice(2, -2);
+      const bar = inner.indexOf('|');
+      const target = (bar === -1 ? inner : inner.slice(0, bar)).trim();
+      const label = bar === -1 ? '' : inner.slice(bar + 1).trim();
+      out.push(refLink(target, label || target, key, links, true));
+    } else if (tok.startsWith('`')) out.push(<code className="md-code" key={key}>{tok.slice(1, -1)}</code>);
     else if (tok.startsWith('**')) out.push(<strong key={key}>{inlineMd(tok.slice(2, -2), `${key}s`, links)}</strong>);
     else if (tok.startsWith('[')) {
       const cut = tok.indexOf('](');
@@ -114,6 +158,32 @@ const RE_HEAD = /^(#{1,6})\s+(.*)$/;
 const RE_RULE = /^\s*(-{3,}|\*{3,}|_{3,})\s*$/;
 const RE_QUOTE = /^>\s?/;
 const RE_ITEM = /^(\s*)([-*+]|\d+[.)])\s+(.*)$/;
+
+// ── callouts ─────────────────────────────────────────────────────────────────
+//
+// `> [!warning] Optional title`, the syntax Obsidian and GitHub both understand.
+// Using theirs rather than inventing one matters here: ~/claude-notes is read in
+// this reader AND in an editor, and a note that renders as a panel in one and as
+// a literal `[!warning]` in the other is worse than plain prose in both.
+//
+// THE COLOURS ARE THE STATUS COLOURS, and that is a deliberate exemption from
+// the standing rule that `--st-*` is reserved for service state. The rule exists
+// so a green decoration is never read as "up"; in a rendered DOCUMENT there is
+// no service status on the page for an amber panel to be confused with. The
+// exemption is scoped to `.md-callout` and stated in read.css beside the rule.
+// If a callout is ever rendered somewhere that also shows service status, it is
+// void.
+const RE_CALLOUT = /^\s*\[!([a-z]+)\]\s*(.*)$/i;
+
+type CalloutKind = 'note' | 'tip' | 'important' | 'warning' | 'caution';
+
+const CALLOUTS: Record<CalloutKind, { title: string; tone: string; Icon: typeof Info }> = {
+  note:      { title: 'Note',      tone: 'note', Icon: Info },
+  tip:       { title: 'Tip',       tone: 'tip',  Icon: Lightbulb },
+  important: { title: 'Important', tone: 'note', Icon: MessageSquareWarning },
+  warning:   { title: 'Warning',   tone: 'warn', Icon: TriangleAlert },
+  caution:   { title: 'Caution',   tone: 'bad',  Icon: OctagonAlert },
+};
 
 function isBlockStart(line: string): boolean {
   return RE_FENCE.test(line) || RE_HEAD.test(line) || RE_RULE.test(line)
@@ -199,6 +269,34 @@ export function renderMd(src: string, k = 'b', links?: MdLinks): ReactNode[] {
     if (RE_QUOTE.test(line)) {
       const buf: string[] = [];
       while (i < lines.length && RE_QUOTE.test(lines[i])) buf.push(lines[i++].replace(RE_QUOTE, ''));
+
+      // A CALLOUT is a blockquote whose first line names a kind. Obsidian's
+      // syntax and GitHub's are the same here, which is the reason to use it
+      // rather than invent one: the notes in ~/claude-notes are read in both.
+      //
+      // Parsed as a branch of the quote rather than as its own block type,
+      // because that is exactly what it is - everything below the marker line
+      // is quote content and renders through the same path.
+      const marker = RE_CALLOUT.exec(buf[0] ?? '');
+      if (marker) {
+        const kind = marker[1].toLowerCase() as CalloutKind;
+        const meta = CALLOUTS[kind] ?? CALLOUTS.note;
+        const title = marker[2]?.trim() || meta.title;
+        const body = buf.slice(1).join('\n');
+        out.push(
+          <div className={`md-callout is-${meta.tone}`} key={key()} role="note">
+            <p className="md-callout-h">
+              <meta.Icon size={15} aria-hidden="true" />
+              <span>{title}</span>
+            </p>
+            {body.trim() && (
+              <div className="md-callout-b">{renderMd(body, `${key()}c`, links)}</div>
+            )}
+          </div>,
+        );
+        continue;
+      }
+
       out.push(<blockquote className="md-quote" key={key()}>{renderMd(buf.join('\n'), `${key()}q`, links)}</blockquote>);
       continue;
     }

--- a/apps/portal-next/web/src/pages/files/read.css
+++ b/apps/portal-next/web/src/pages/files/read.css
@@ -277,3 +277,47 @@
   .bothy-files.bothy-read .fx-read { padding: 16px 16px 40px; }
   .bothy-files .rd-empty { padding: 32px 16px; }
 }
+
+/* ── callouts ────────────────────────────────────────────────────────────────
+   `> [!warning] Title`, the syntax Obsidian and GitHub share.
+
+   THE STATUS COLOURS ARE USED HERE, and index.css's standing rule says they are
+   reserved for service state and never used as chrome. This is a deliberate,
+   scoped exemption, and the argument is that the rule's PURPOSE does not reach
+   this far: it exists so nobody reads a green decoration as "a service is up".
+   A rendered document has no service status anywhere on it, so there is nothing
+   for an amber panel to be mistaken for.
+
+   The exemption is scoped to .md-callout and it is VOID the moment a callout is
+   rendered on a surface that also shows service state. If that ever happens
+   these need their own token family; they do not get to keep borrowing.
+
+   Bordered on the left only, and tinted, rather than a full box: a document with
+   four boxed panels in it stops looking like prose and starts looking like a
+   dashboard, which is the opposite of what the reading view is for. */
+.bothy-files .md-callout {
+  margin: 0 0 var(--read-gap);
+  padding: 10px 14px;
+  border-left: 3px solid var(--st-unknown);
+  border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  background: var(--surface-2);
+}
+.bothy-files .md-callout-h {
+  display: flex; align-items: center; gap: 7px;
+  margin: 0; font-size: 12.5px; font-weight: 700;
+  letter-spacing: .01em; color: var(--fg);
+}
+.bothy-files .md-callout-h svg { flex: none; }
+/* The body inherits the reading scale; only its last block loses its margin, so
+   a one-paragraph callout is not padded twice at the bottom. */
+.bothy-files .md-callout-b { margin-top: 6px; }
+.bothy-files .md-callout-b > *:last-child { margin-bottom: 0; }
+
+.bothy-files .md-callout.is-note { border-left-color: var(--accent); background: var(--accent-bg); }
+.bothy-files .md-callout.is-note .md-callout-h { color: var(--accent-fg); }
+.bothy-files .md-callout.is-tip  { border-left-color: var(--st-up);   background: var(--st-up-bg); }
+.bothy-files .md-callout.is-tip .md-callout-h  { color: var(--st-up-fg); }
+.bothy-files .md-callout.is-warn { border-left-color: var(--st-warn); background: var(--st-warn-bg); }
+.bothy-files .md-callout.is-warn .md-callout-h { color: var(--st-warn-fg); }
+.bothy-files .md-callout.is-bad  { border-left-color: var(--st-down); background: var(--st-down-bg); }
+.bothy-files .md-callout.is-bad .md-callout-h  { color: var(--st-down-fg); }

--- a/apps/portal-next/web/src/pages/files/read.css
+++ b/apps/portal-next/web/src/pages/files/read.css
@@ -321,3 +321,39 @@
 .bothy-files .md-callout.is-warn .md-callout-h { color: var(--st-warn-fg); }
 .bothy-files .md-callout.is-bad  { border-left-color: var(--st-down); background: var(--st-down-bg); }
 .bothy-files .md-callout.is-bad .md-callout-h  { color: var(--st-down-fg); }
+
+/* ── backlinks ───────────────────────────────────────────────────────────────
+   Under the document, separated by a rule rather than boxed: it is a footnote
+   to the page, not a second panel competing with it. Renders nothing at all
+   when a document has no inbound links - see the component. */
+.bothy-files .rd-backlinks {
+  max-width: var(--read-measure);
+  margin: 34px 0 8px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+}
+.bothy-files .rd-backlinks h2 {
+  margin: 0 0 8px;
+  font-size: 11.5px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .05em;
+  color: var(--fg-subtle);
+}
+.bothy-files .rd-backlinks ul { margin: 0; padding: 0; list-style: none; }
+.bothy-files .rd-backlinks li { margin: 0; }
+.bothy-files .rd-backlinks button {
+  display: flex; align-items: baseline; gap: 10px;
+  width: 100%; padding: 5px 8px; margin-left: -8px;
+  border: 0; background: none; border-radius: var(--r-sm);
+  font: inherit; text-align: left; cursor: pointer; color: var(--fg-muted);
+}
+.bothy-files .rd-backlinks button:hover { background: var(--surface-2); color: var(--fg); }
+.bothy-files .rd-backlinks button:focus-visible {
+  outline: 2px solid var(--ring); outline-offset: -2px;
+}
+.bothy-files .rd-bl-title { font-size: 13px; font-weight: 600; }
+/* The path is the disambiguator - two notes can share a title - so it is
+   present but never competes with the name. */
+.bothy-files .rd-bl-path {
+  font-size: 10.5px; color: var(--fg-subtle);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}

--- a/apps/portal-next/web/src/pages/files/tree.ts
+++ b/apps/portal-next/web/src/pages/files/tree.ts
@@ -253,3 +253,57 @@ export function isFramedText(kind: Kind, path: string): boolean {
   const ext = path.slice(path.lastIndexOf('.') + 1).toLowerCase();
   return ext !== 'svgz';   // gzipped: bytes, not source
 }
+
+// ── wikilinks ────────────────────────────────────────────────────────────────
+//
+// `[[dns]]` names a DOCUMENT, not a path. That is the whole difference from a
+// markdown link, and it is why this needs the list of files while
+// resolveRelative() needs only a string: there is no directory in the target and
+// no extension on it, so the only way to answer is to look.
+//
+// The order below is the resolution order, and it is the order a person means:
+//
+//   1. exactly that path            [[network/dns.md]]
+//   2. that path plus .md           [[network/dns]]
+//   3. that path as a folder        [[network]]      -> network/index.md
+//   4. a document with that NAME    [[dns]]          -> network/dns.md
+//
+// 4 is last on purpose. It is the one people write most and the one that can be
+// ambiguous, so a target that resolves exactly must never be beaten by a
+// basename match somewhere else in the tree.
+//
+// AMBIGUITY IS RESOLVED BY SHORTEST PATH, and stated rather than left to the
+// order the walk happened to return. Two files named dns.md is not an error
+// worth refusing over - it is a note the reader still wants to reach - and "the
+// one nearest the top" is the only tie-break that does not depend on how the
+// tree was listed.
+const WIKI_SUFFIXES = ['.md', '.markdown'];
+
+export function resolveWikiIn(
+  paths: readonly string[],
+  target: string,
+): { path: string; frag: string } | null {
+  const cut = target.indexOf('#');
+  const frag = cut === -1 ? '' : target.slice(cut);
+  const raw = (cut === -1 ? target : target.slice(0, cut)).trim().replace(/^\/+/, '');
+  if (!raw) return null;
+
+  const has = new Set(paths);
+  if (has.has(raw)) return { path: raw, frag };
+  for (const ext of WIKI_SUFFIXES) {
+    if (has.has(raw + ext)) return { path: raw + ext, frag };
+    if (has.has(`${raw}/index${ext}`)) return { path: `${raw}/index${ext}`, frag };
+  }
+
+  // By basename, case-insensitively - a link written `[[DNS]]` to a file called
+  // dns.md is a link somebody meant.
+  const want = raw.toLowerCase();
+  const hits = paths.filter((p) => {
+    const base = p.slice(p.lastIndexOf('/') + 1).toLowerCase();
+    if (base === want) return true;
+    return WIKI_SUFFIXES.some((e) => base === want + e);
+  });
+  if (!hits.length) return null;
+  hits.sort((a, b) => a.split('/').length - b.split('/').length || a.localeCompare(b));
+  return { path: hits[0], frag };
+}

--- a/edge/dynamic/portal-files.yml
+++ b/edge/dynamic/portal-files.yml
@@ -52,7 +52,13 @@ http:
       # the file set /read serves - same safepath.collect(), same deny-list, same
       # per-root rules - and a separate router would imply a separate boundary.
       # It is a GET with the query in the query string, like every rule here.
-      rule: "Path(`/-/api/files/roots`) || Path(`/-/api/files/tree`) || Path(`/-/api/files/read`) || Path(`/-/api/files/search`) || Path(`/-/api/files/history`) || Path(`/-/api/files/repos`) || Path(`/-/api/files/status`) || Path(`/-/api/files/git/diff`)"
+      #
+      # /links is here for the same reason /search is: it reads exactly the file
+      # set /read serves, through the same safepath.collect(), and it returns
+      # nothing that /read would refuse - a document the walk skipped is not a
+      # node in the graph, so it cannot be a link target either. A separate router
+      # would imply a separate boundary where there is one.
+      rule: "Path(`/-/api/files/roots`) || Path(`/-/api/files/tree`) || Path(`/-/api/files/read`) || Path(`/-/api/files/search`) || Path(`/-/api/files/links`) || Path(`/-/api/files/history`) || Path(`/-/api/files/repos`) || Path(`/-/api/files/status`) || Path(`/-/api/files/git/diff`)"
       entryPoints: [web]
       priority: 100
       service: portal-files


### PR DESCRIPTION
Phase 3 of the plan — the four reader features you picked, minus nothing.

## Callouts

`> [!note]`, `[!tip]`, `[!important]`, `[!warning]`, `[!caution]` as titled panels. A branch of the **blockquote** handling rather than a new block type, because that is exactly what they are.

Obsidian's and GitHub's syntax rather than one invented here: `~/claude-notes` gets read in this reader *and* in an editor, and a note that renders as a panel in one and a literal `[!warning]` in the other is worse than plain prose in both.

They borrow the status colours, which the standing rule reserves for service state. **Deliberate, scoped exemption**: the rule exists so a green decoration is never read as "up", and a rendered document has no service status on it for an amber panel to be confused with. Written into `read.css` beside the rule, including what voids it.

## Wikilinks

`[[dns]]`, `[[network/dns]]`, `[[dns|label]]` — a new syntax feeding the resolver that already existed, so they inherit the never-becomes-an-`href` property for free.

The wiki alternative is **first** in the inline pattern, which is load-bearing: `[[dns]]` would otherwise match as `[` followed by `[dns]` and print a stray bracket beside a broken link.

**A bug this found:** a wikilink initially fell back to `resolveRelative`, which normalises a path *without knowing what exists* — it does not have to for a markdown link, where the author wrote a path. So `[[nothing-here]]` became a live button pointing at a file of that name: the unresolvable link rendered as **resolved**, the worst of the three possible answers. Wikilinks now resolve only against the index.

`resolveWikiIn()` is pure, in `tree.ts`, with a precedence order stated because getting it wrong is invisible: exact path → `+.md` → `/index.md` → basename. Basename last, because it is the one people write most and the only one that can be ambiguous — broken by shallowest-then-alphabetical so the answer does not depend on how the tree was listed. `checks/wikilinks.mjs` asserts exactly that: **the same tree reversed must give the same answer.**

## Backlinks

`GET /links?root=` builds the graph server-side, because answering "what links here" needs every document and the reader holds one at a time by design. One request per root, not per document — the service walks either way. Cached on `(max mtime, doc count)`; the count is what catches a delete that leaves max-mtime unchanged.

Resolution is a **lookup in the index, never a `stat()` of a path built from file content** — an edge can only name a file `collect()` already proved readable, so `[x](../../../.env)` resolves to nothing.

Renders nothing when there is nothing to say. A panel reading "0 documents link here" is furniture on every orphan.

## The reading scale is tokenised

~30 literals in `editor.css`, which meant a theme could restyle every colour in the app and not touch the one surface people spend the most time reading. Structural — a theme inherits them unless it opts in.

## Verified

- `just files-check` **0 FAIL** (including the new 27-assertion links suite), portal checks **0 FAIL**, `just verify` **23/23**.
- Both new check suites proved able to fail: the links checks went 5-red when the fence guard and the cache count were broken; the wikilink table is built around the ambiguity cases.
- Live: three callout tones render with custom and fallback titles, a plain blockquote stays distinct, `[[README]]` and `[[network/dns]]` resolve while `[[nothing-here]]` stays inert; `network/naming.md` shows **11 inbound links** and clicking one opens it; a real orphan shows no panel.
- Real numbers from this box: notes 20 docs / 87 edges / 14ms warm; stacks 140 / 540 / 83ms.
