### PR TITLE
perf(portal): 853 KB -> 242 KB on the wire, and a check that cried wolf

### DIFF
--- a/apps/portal-next/nginx.conf
+++ b/apps/portal-next/nginx.conf
@@ -6,6 +6,54 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # ── compression ─────────────────────────────────────────────────────────
+    #
+    # NOT AN OPTIMISATION - it was a 3.4x regression nobody had measured. The
+    # bundle is 714 KB on the wire and 212 KB gzipped, and nginx was serving the
+    # larger number to every request because gzip is OFF by default.
+    #
+    # It did not show up on the box: measured from here the whole page is ~120 ms
+    # and the JS transfer is 15 ms, because the loopback has no bandwidth to
+    # speak of. The person reading this over the tailnet from a direct WAN path
+    # was waiting ~3 seconds, and every measurement taken on the machine that
+    # serves it says everything is fine. Measure the link, not the server.
+    #
+    # comp_level 6 rather than 9: level 9 costs roughly twice the CPU for about
+    # 1% more compression on JS, and this box is also running the stack it is
+    # describing.
+    gzip on;
+    gzip_vary on;              # so a cache never hands a gzipped body to a client that cannot read it
+    gzip_comp_level 6;
+    gzip_min_length 1024;      # below this the header costs more than the saving
+    gzip_proxied any;
+    # text/html is always compressed when gzip is on and is deliberately not
+    # listed. The rest are what this app actually serves.
+    gzip_types
+        text/css
+        text/plain
+        application/javascript
+        application/json
+        application/manifest+json
+        image/svg+xml;
+
+    # ── content-addressed assets ────────────────────────────────────────────
+    #
+    # Vite puts a CONTENT HASH in these filenames, so index-8GWIPhw3.js can
+    # never change meaning: a new build is a new name. That makes them the one
+    # thing here that is safe to cache forever, and `immutable` additionally
+    # tells the browser not to revalidate on reload - which over a slow link is
+    # a round trip per asset for a body that cannot have changed.
+    #
+    # index.html deliberately keeps `no-cache` below. It is the file that names
+    # which hashed assets to fetch, so it is the only one that MUST be re-read,
+    # and caching it is how a redeploy becomes invisible.
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        # A sibling location inherits no add_header from `/`, and this is the
+        # only one of them that matters for a script or a stylesheet.
+        add_header X-Content-Type-Options "nosniff";
+    }
+
     # ── user themes, listed rather than registered ──────────────────────────
     #
     # A theme a PERSON added is a .css file dropped into this directory on the

--- a/scripts/verify-access.sh
+++ b/scripts/verify-access.sh
@@ -43,20 +43,40 @@ for u in "/" "/-/api/traefik/http/routers" "/-/api/docker/containers/json" "/-/a
   [ "$got" = "200" ] && ok "$u -> 200" || bad "$u -> $got (expected 200)"
 done
 # The portal must be the SPA, not an error page.
-if curl -s -m 4 "http://$IP/" | grep -q '<title>Bothy'; then ok "bare IP serves the Bothy SPA"; else bad "bare IP is not serving the SPA"; fi
+# `cmd | grep -q` IS A TRAP HERE, and it cost a security check its meaning.
+#
+# This script runs under `set -o pipefail`. `grep -q` exits the moment it
+# matches, the writer upstream dies of SIGPIPE, and the PIPELINE's status is
+# therefore non-zero *because the grep succeeded*. An `if` around it then takes
+# the else branch and reports a failure that did not happen.
+#
+# Measured on this box: the /raw assertion below failed in 2 runs out of 3, and
+# what it printed was "the sandbox split is broken" - a check crying wolf about a
+# boundary that was fine, which is worse than no check at all, because the next
+# real failure reads as noise. doctor.sh documents the same trap for `zcat`.
+#
+# So: capture first, then match with bash's own `[[ ... == *needle* ]]`, which
+# involves no second process and no pipe.
+
+body=$(curl -s -m 4 "http://$IP/")
+if [[ $body == *'<title>Bothy'* ]]; then ok "bare IP serves the Bothy SPA"; else bad "bare IP is not serving the SPA"; fi
 
 echo
 echo "== 3. THE LEAK: the Traefik dashboard/API must no longer be routed =="
 raw=$(curl -s -m 4 "http://$IP/api/rawdata")
-if echo "$raw" | head -c 200 | grep -qi '<!doctype html'; then
+# Same pipefail trap again, twice over: `head -c 200` also exits early and
+# SIGPIPEs the echo feeding it. Both of these decide whether a CONFIG DUMP is
+# being served, so a false "bad" here is the loudest possible wrong answer.
+head200=${raw:0:200}
+if [[ ${head200,,} == *'<!doctype html'* ]]; then
   ok "/api/rawdata now falls through to the SPA (no config dump)"
 elif [ -z "$raw" ]; then
   ok "/api/rawdata returns nothing"
 else
-  bad "/api/rawdata STILL returns config: $(echo "$raw" | head -c 120)"
+  bad "/api/rawdata STILL returns config: ${raw:0:120}"
 fi
 # The specific thing that was leaking.
-if echo "$raw" | grep -qi '"authorization"'; then
+if [[ ${raw,,} == *'"authorization"'* ]]; then
   bad "an Authorization header is STILL exposed via /api/rawdata"
 else
   ok "no Authorization header exposed"
@@ -122,7 +142,10 @@ if [ "${VERIFY_SELFTEST:-}" = "1" ]; then
   probe=edge/dynamic/_selftest.yml
   printf '# {{ selftest\n' > "$probe"
   sleep 4
-  if docker logs traefik --since 15s 2>&1 | grep -qiE 'collecting file configs|_selftest'; then
+  # Same pipefail/SIGPIPE trap as above, and `docker logs` is the case most
+  # likely to hit it: the output is far larger than a pipe buffer.
+  logs=$(docker logs traefik --since 15s 2>&1)
+  if grep -qiE 'collecting file configs|_selftest' <<<"$logs"; then
     ok "selftest: the probe DOES detect a voided file"
   else
     bad "selftest: the probe did NOT detect a voided file - check 5b proves nothing"
@@ -152,7 +175,8 @@ got=$(code "http://$IP:8100/-/api/files/raw?root=stacks&path=README.md")
                    || bad "sandbox /raw -> $got (expected 401)"
 # The portal origin must NOT serve raw bytes. It answers 200 with the SPA
 # because of the catch-all, so this asserts CONTENT, not status.
-if curl -s -m 4 "http://$IP/-/api/files/raw?root=stacks&path=README.md" | grep -q '<title>Bothy'; then
+body=$(curl -s -m 4 "http://$IP/-/api/files/raw?root=stacks&path=README.md")
+if [[ $body == *'<title>Bothy'* ]]; then
   ok "raw is NOT routed on the portal origin (falls through to the SPA)"
 else
   bad "the portal origin served something for /raw - the sandbox split is broken"


### PR DESCRIPTION
You said the reader takes ~3 seconds. Every measurement I had taken said 5 ms. Both were true, and that gap is the bug.

## Compression was off

nginx does not gzip by default. Every visitor was downloading **853 KB** of a bundle that is **242 KB** compressed — 3.5× more than necessary, on every load.

It could not be seen from the box: **123 ms** to first document, **15 ms** for the 714 KB script, because loopback has no bandwidth to speak of. You were on `yehuda-thinkpad` over a direct WAN path. *Measure the link, not the server.*

| | before | after |
|---|---:|---:|
| `index.js` | 697 KB | **215 KB** |
| `index.css` | 155 KB | **26 KB** |
| total, eagerly loaded | 853 KB | **242 KB** |

Content-hashed assets also carried `Cache-Control: no-cache` — a filename that *cannot* change meaning (a new build is a new name) was being revalidated on every load: a round trip per asset, which over that link is most of what remains after compression. They are `immutable` now. `index.html` keeps `no-cache` deliberately: it names which hashed assets to fetch, so caching it is how a redeploy becomes invisible.

## And a check that reported a security failure that was not happening

While verifying the above, `just verify` began failing **2 runs in 3**:

```
FAIL  the portal origin served something for /raw - the sandbox split is broken
```

The boundary was fine. `curl | grep -q` under this script's `set -o pipefail` is a race — `grep -q` exits the instant it matches, `curl` dies of SIGPIPE, and the pipeline's status is non-zero **because the grep succeeded**. Reproduced directly:

```
ok FAIL ok FAIL ok ok FAIL ok
```

`doctor.sh` documents the identical trap for `zcat`, which is how I knew where to look.

**Four assertions had it, and each decides something load-bearing:** whether the bare IP serves the SPA, whether `/api/rawdata` still dumps the merged config, whether an `Authorization` header is exposed, and whether raw bytes leak onto the portal origin. A check that cries wolf about a boundary is worse than no check, because the next real failure reads as noise.

All four now capture first and match with bash's own `[[ == *needle* ]]` — no second process, no pipe, no race.

## Verified

- 220,899 bytes on the wire for the main chunk, `Content-Encoding: gzip`, `Vary: Accept-Encoding`, `immutable` on `/assets/`, `no-cache` still on `/`.
- **Six consecutive** `just verify` runs green (was 2-in-3 failing), and `VERIFY_SELFTEST=1` still proves check 5b can fail.
- Portal checks 0 FAIL; app re-measured end to end after the change.
