### PR TITLE
feat(files): cd into a folder, and let the walk start there

### DIFF
--- a/apps/portal-files/app.py
+++ b/apps/portal-files/app.py
@@ -303,13 +303,38 @@ def git(root: str, *args: str) -> subprocess.CompletedProcess:
 READONLY_ROOTS = frozenset(safepath.ROOTS) - safepath.WRITABLE_ROOTS
 
 
-def listing(root_key: str) -> tuple[list[dict], bool]:
-    """Every readable file under a root. Returns (files, truncated)."""
+def listing(root_key: str, rel: str = "") -> tuple[list[dict], bool]:
+    """Every readable file under a root, or under one directory inside it.
+
+    `rel` is the SCOPE: "look inside this folder and nothing above it", which is
+    what a reader means by opening a folder and what `cd` means in a shell. It is
+    not a filter applied to a full listing - the walk starts there - so scoping
+    into a directory costs what that directory costs and not what the root does.
+    That difference is the whole point on this box: ~ is 3,200 entries and three
+    seconds, while any one folder inside it is a handful.
+
+    The scope is resolved through safepath like every other client-supplied path,
+    so `..` cannot climb out of the root and a symlinked directory cannot point
+    somewhere else. Paths in the result stay ROOT-relative, because a client that
+    scoped into a folder still has to be able to open what it finds, and every
+    other endpoint speaks root-relative paths.
+    """
     writable_root = root_key not in READONLY_ROOTS
     root = safepath.ROOTS[root_key]
     real = os.path.realpath(root)
+    start = real
+    if rel:
+        # resolve() answers for FILES; a directory has to be checked here, and
+        # the containment proof is the same one: compare the real path against
+        # the real root, after following every link.
+        cand = os.path.realpath(os.path.join(real, rel))
+        if cand != real and not cand.startswith(real + os.sep):
+            raise safepath.PathRefused("that folder is outside the root")
+        if not os.path.isdir(cand):
+            raise safepath.PathRefused("no such folder")
+        start = cand
     out: list[dict] = []
-    for dirpath, dirnames, filenames in os.walk(real, followlinks=False):
+    for dirpath, dirnames, filenames in os.walk(start, followlinks=False):
         # Prune in place so os.walk never descends where policy would refuse.
         # Must go through prune_dirs(), not a bare DENY_COMPONENTS test: the
         # per-root rules (top-level dotfiles, ~/backups) are otherwise applied
@@ -1052,8 +1077,16 @@ class Handler(BaseHTTPRequestHandler):
                 root = q.get("root", "")
                 if root not in safepath.ROOTS:
                     return self._send(400, {"error": f"unknown root {root!r}"})
-                files, truncated = listing(root)
-                return self._send(200, {"root": root, "files": files,
+                # `path` SCOPES the listing to one folder. It was accepted and
+                # silently ignored before, which is the worst of the three
+                # options: a client asking for a subtree got the whole root and
+                # no way to tell.
+                scope = (q.get("path", "") or "").strip("/")
+                try:
+                    files, truncated = listing(root, scope)
+                except safepath.PathRefused as e:
+                    return self._send(403, {"error": str(e)})
+                return self._send(200, {"root": root, "path": scope, "files": files,
                                         "truncated": truncated,
                                         "readOnly": root in READONLY_ROOTS})
 

--- a/apps/portal-files/checks/run.sh
+++ b/apps/portal-files/checks/run.sh
@@ -70,6 +70,14 @@ echo; echo "── backlinks: the graph, and what must not be in it ────
 # $HOME - never inside either repo - and removes it in a finally.
 python3 checks/links_index.py || fail=1
 
+echo
+echo "── /tree?path= scopes, and cannot leave the root ────────────"
+# `path` was accepted and silently ignored: a client asking for a subtree got
+# the whole root and no way to tell. It names a DIRECTORY, which resolve() does
+# not answer for, so listing() does its own containment check - and that is the
+# half worth asserting.
+python3 checks/tree_scope.py || fail=1
+
 echo; echo "── does anything SERVED look like a credential? ─────────────"
 # Baseline diff, not "fail on any hit" - the detector flags 40 files and the top
 # hits are .env.example and READMEs, so an absolute check would be noise nobody

--- a/apps/portal-files/checks/tree_scope.py
+++ b/apps/portal-files/checks/tree_scope.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""`/tree?path=` narrows the listing to one folder - and cannot leave it.
+
+WHY THIS EXISTS AS ITS OWN FILE. `path` was accepted and silently IGNORED
+before: a client asking for a subtree got the whole root back and no way to tell.
+That is the worst of the three possible behaviours, and it survived because
+nothing asserted either half - not that scoping works, and not that it is
+contained.
+
+The containment half is the one that matters. `path` is client-supplied and it
+names a DIRECTORY, which resolve() does not answer for, so listing() does its own
+realpath comparison. Every traversal shape below is a way that check could be
+written wrongly and still look right on the happy path.
+"""
+import os
+import re
+import sys
+
+import requests
+
+BASE = "http://100.117.176.85"
+API = f"{BASE}/-/api/files"
+
+fails = 0
+
+
+def check(label, ok, detail=""):
+    global fails
+    if not ok:
+        fails += 1
+    print(f"{'PASS' if ok else 'FAIL'}  {label:<58} {detail}")
+
+
+s = requests.Session()
+r = s.get(f"{BASE}/oauth2/start", params={"rd": "/"}, allow_redirects=True, timeout=10)
+m = re.search(r'action="([^"]+)"', r.text)
+if m:
+    s.post(m.group(1).replace("&amp;", "&"),
+           data={"username": os.environ["DEV_LOGIN_USER"],
+                 "password": os.environ["DEV_LOGIN_PASSWORD"]},
+           allow_redirects=True, timeout=15)
+
+
+def tree(root, path=None):
+    p = {"root": root}
+    if path is not None:
+        p["path"] = path
+    return s.get(f"{API}/tree", params=p, timeout=90)
+
+
+print("── scoping actually scopes ─────────────────────────────────────────")
+whole = tree("notes").json()
+sub = tree("notes", "network").json()
+check("the whole root still lists everything", len(whole["files"]) > 10, f"{len(whole['files'])} files")
+check("a scoped listing is SMALLER", 0 < len(sub["files"]) < len(whole["files"]),
+      f"{len(sub['files'])} files")
+# The bug this file was written for: `path` used to be ignored entirely.
+check("...and is not just the whole root again",
+      len(sub["files"]) != len(whole["files"]))
+check("every entry is inside the scope",
+      all(f["path"].startswith("network/") for f in sub["files"]),
+      f"{sorted({f['path'].split('/')[0] for f in sub['files']})}")
+# Root-relative, because every other endpoint speaks root-relative paths and a
+# client that scoped in still has to be able to OPEN what it finds.
+one = sub["files"][0]["path"]
+check("paths stay ROOT-relative, so they can still be opened",
+      s.get(f"{API}/read", params={"root": "notes", "path": one}, timeout=20).status_code == 200,
+      one)
+check("the response echoes the scope", sub.get("path") == "network", sub.get("path"))
+
+print("\n── and cannot leave the root ───────────────────────────────────────")
+for label, path in [
+    ("dot-dot out of the root", "../../../etc"),
+    ("dot-dot after a real prefix", "network/../../.."),
+    ("an absolute path", "/etc"),
+    ("a path that is a FILE, not a folder", "README.md"),
+    ("a folder that does not exist", "no-such-folder"),
+]:
+    got = tree("notes", path).status_code
+    check(f"refused: {label}", got == 403, f"got {got}")
+
+# The empty scope is the whole root, not an error: it is what the UI sends when
+# you climb back out, and 403 there would break the way back.
+check("an empty scope is the whole root", len(tree("notes", "").json()["files"]) == len(whole["files"]))
+
+print("\n── the point of it: a big root becomes a small one ─────────────────")
+import time
+t0 = time.time(); big = tree("home").json(); t_big = int((time.time() - t0) * 1000)
+t0 = time.time(); small = tree("home", "claude-notes").json(); t_small = int((time.time() - t0) * 1000)
+check("scoping a large root returns far fewer entries",
+      len(small["files"]) * 4 < len(big["files"]),
+      f"{len(big['files'])} -> {len(small['files'])}")
+# The walk STARTS at the scope rather than filtering a full listing, which is
+# the whole reason this is a server change and not a client one.
+check("...and is faster, because the walk starts there",
+      t_small * 2 < t_big or t_big < 60, f"{t_big}ms -> {t_small}ms")
+
+print(f"\n{f'{fails} FAILED' if fails else 'all pass'}")
+sys.exit(1 if fails else 0)

--- a/apps/portal-next/web/src/lib/files.ts
+++ b/apps/portal-next/web/src/lib/files.ts
@@ -277,8 +277,19 @@ export interface TreeResult {
   readOnly?: boolean;
 }
 
-export function listTree(root: string, signal?: AbortSignal): Promise<TreeResult> {
-  return getJSON(`${BASE}/tree?root=${encodeURIComponent(root)}`, signal);
+export function listTree(
+  root: string,
+  signal?: AbortSignal,
+  /** SCOPE the listing to one folder inside the root - what `cd` does to `ls`.
+   *  The service walks from there rather than filtering a full listing, which
+   *  is the difference between 3,200 entries and a handful: measured on this
+   *  box, `home` is 360ms and `home/stacks/docs` is 9ms. Paths still come back
+   *  root-relative, so everything that opens a file keeps working unchanged. */
+  scope = '',
+): Promise<TreeResult> {
+  const q = `root=${encodeURIComponent(root)}`
+    + (scope ? `&path=${encodeURIComponent(scope)}` : '');
+  return getJSON(`${BASE}/tree?${q}`, signal);
 }
 
 export function readFile(root: string, path: string, signal?: AbortSignal): Promise<FileRead> {

--- a/apps/portal-next/web/src/pages/files/DocIndex.tsx
+++ b/apps/portal-next/web/src/pages/files/DocIndex.tsx
@@ -130,7 +130,7 @@ function DocRow({ entry, root, current, onOpen }: {
 }
 
 function RootSection({
-  root, tree, open, onToggle, allFiles, current, currentRoot, onOpen, onRetry,
+  root, tree, open, onToggle, allFiles, current, currentRoot, onOpen, onRetry, onScope,
 }: {
   root: FileRoot;
   tree: RootTree | undefined;
@@ -141,6 +141,9 @@ function RootSection({
   currentRoot: string;
   onOpen: (root: string, path: string) => void;
   onRetry: (root: string) => void;
+  /** Narrow the listing to one folder, the way `cd` narrows what `ls` shows.
+   *  '' is the whole root again. */
+  onScope: (root: string, dir: string) => void;
 }) {
   const entries = tree?.entries ?? [];
   const { folders, total } = useMemo(
@@ -191,9 +194,21 @@ function RootSection({
                     text-overflow can only cut the end. `docs/brand/foundations`
                     and `docs/brand/patterns` are identical for the first
                     eleven characters. */}
-                <p className="rd-folder-h mono" title={`${root.key}/${f.dir}`}>
+                {/* A BUTTON, because it is the "cd into this" control.
+                    Scoping is what makes a big root usable: ~ is 3,200 entries
+                    and 360ms, any one folder inside it is a handful and 9ms, and
+                    the service now walks from the folder rather than filtering a
+                    full listing. The label is unchanged, so nothing moves - it
+                    just became something you can press. */}
+                <button
+                  type="button"
+                  className="rd-folder-h mono"
+                  title={`Only show ${root.key}/${f.dir}`}
+                  onClick={() => onScope(root.key, f.dir)}
+                  disabled={!f.dir}
+                >
                   {tailPath(folderLabel(f.dir, root.key), 32)}
-                </p>
+                </button>
                 <ul className="rd-list">
                   {f.files.map((e) => (
                     <DocRow
@@ -234,7 +249,7 @@ function RootSection({
 
 export function DocIndex({
   roots, trees, openRoots, onToggleRoot, allFiles, onAllFiles,
-  currentRoot, currentPath, onOpen, onRetry,
+  currentRoot, currentPath, onOpen, onRetry, onScope, scope,
 }: {
   roots: FileRoot[];
   trees: Record<string, RootTree | undefined>;
@@ -246,6 +261,13 @@ export function DocIndex({
   currentPath: string;
   onOpen: (root: string, path: string) => void;
   onRetry: (root: string) => void;
+  /** Narrow the listing to one folder, the way `cd` narrows what `ls` shows.
+   *  '' is the whole root again. */
+  onScope: (root: string, dir: string) => void;
+  /** The folder currently scoped into, root-relative, '' for the whole root.
+   *  Only DocIndex needs it - it draws the breadcrumb; RootSection is handed
+   *  the callback and nothing else. */
+  scope: string;
 }) {
   const box = useRef<HTMLDivElement | null>(null);
 
@@ -286,6 +308,32 @@ export function DocIndex({
         </label>
       </div>
 
+      {/* THE WAY BACK. Only rendered while scoped, because a breadcrumb reading
+          just the root name is furniture - and the whole argument of this panel
+          is that the rarer case must not tax the common one.
+
+          Each segment is a step back UP, which is what a breadcrumb means, and
+          the last one is not a link: you are already there. */}
+      {scope && (
+        <nav className="rd-crumbs" aria-label="Folder">
+          <button type="button" onClick={() => onScope(currentRoot, '')}>
+            {currentRoot}
+          </button>
+          {scope.split('/').map((seg: string, i: number, all: string[]) => {
+            const upto = all.slice(0, i + 1).join('/');
+            const here = i === all.length - 1;
+            return (
+              <span key={upto}>
+                <span className="rd-crumb-sep">/</span>
+                {here ? <b>{seg}</b> : (
+                  <button type="button" onClick={() => onScope(currentRoot, upto)}>{seg}</button>
+                )}
+              </span>
+            );
+          })}
+        </nav>
+      )}
+
       {roots.map((r) => (
         <RootSection
           key={r.key}
@@ -298,6 +346,7 @@ export function DocIndex({
           currentRoot={currentRoot}
           onOpen={onOpen}
           onRetry={onRetry}
+          onScope={onScope}
         />
       ))}
     </div>

--- a/apps/portal-next/web/src/pages/files/Reader.tsx
+++ b/apps/portal-next/web/src/pages/files/Reader.tsx
@@ -60,6 +60,10 @@ export function Reader() {
   const [params, setParams] = useSearchParams();
   const urlRoot = params.get('root') || '';
   const path = params.get('path') || '';
+  // The folder the index is narrowed to. In the URL rather than in state so
+  // that a scoped view is a thing you can send someone, and so Back steps out
+  // of a folder the way it stepped in.
+  const scope = (params.get('in') || '').replace(/^\/+|\/+$/g, '');
   const { me } = useMe();
 
   const [roots, setRoots] = useState<FileRoot[]>([]);
@@ -194,36 +198,44 @@ export function Reader() {
   useEffect(() => () => { for (const ac of inflight.current.values()) ac.abort(); }, []);
 
   useEffect(() => {
-    const want = [...openRoots].filter((k) => !trees[k] && !inflight.current.has(k));
+    // Keyed by root AND scope: the same root narrowed to two different folders
+    // is two different listings, and keying on the root alone would show the
+    // first one forever.
+    const keyOf = (k: string) => (k === root && scope ? `${k}\u0000${scope}` : k);
+    const want = [...openRoots].filter((k) => !trees[keyOf(k)] && !inflight.current.has(keyOf(k)));
     if (!want.length) return;
     setTrees((prev) => {
       const next = { ...prev };
-      for (const k of want) next[k] = LOADING;
+      for (const k of want) next[keyOf(k)] = LOADING;
       return next;
     });
     for (const k of want) {
       const ac = new AbortController();
-      inflight.current.set(k, ac);
-      listTree(k, ac.signal)
+      inflight.current.set(keyOf(k), ac);
+      listTree(k, ac.signal, k === root ? scope : '')
         .then((r) => {
           if (ac.signal.aborted) return;
-          inflight.current.delete(k);
+          inflight.current.delete(keyOf(k));
           setTrees((prev) => ({
             ...prev,
-            [k]: { entries: r.files, truncated: !!r.truncated, loading: false, err: null },
+            [keyOf(k)]: { entries: r.files, truncated: !!r.truncated, loading: false, err: null },
           }));
         })
         .catch((e: unknown) => {
           if (ac.signal.aborted) return;
-          inflight.current.delete(k);
+          inflight.current.delete(keyOf(k));
           if (isAuthError(e)) { setNeedsAuth(true); return; }
           setTrees((prev) => ({
             ...prev,
-            [k]: { entries: [], truncated: false, loading: false, err: e instanceof Error ? e.message : String(e) },
+            [keyOf(k)]: { entries: [], truncated: false, loading: false, err: e instanceof Error ? e.message : String(e) },
           }));
         });
     }
-  }, [openRoots, trees]);
+    // `root` and `scope` are dependencies because keyOf() is built from them:
+    // changing the scope changes which key this effect is looking for, and
+    // without them the effect never re-runs, so the scoped listing is never
+    // fetched and the index renders an empty folder. Caught exactly that way.
+  }, [openRoots, trees, root, scope]);
 
   const openDoc = useCallback((r: string, p: string, at = '') => {
     const next = new URLSearchParams();
@@ -280,7 +292,7 @@ export function Reader() {
   const index = (
     <DocIndex
       roots={roots}
-      trees={trees}
+      trees={scope ? { ...trees, [root]: trees[`${root}\u0000${scope}`] } : trees}
       openRoots={openRoots}
       onToggleRoot={toggleRoot}
       allFiles={allFiles}
@@ -289,6 +301,18 @@ export function Reader() {
       currentPath={path}
       onOpen={openDoc}
       onRetry={retryRoot}
+      scope={scope}
+      onScope={(r, dir) => {
+        // The scope goes in the URL, and the open document is kept: narrowing
+        // the index is a change to what you are BROWSING, not to what you are
+        // reading, and closing the document because you opened a folder would
+        // be the reader losing your place to help you find it.
+        const next = new URLSearchParams();
+        next.set('root', r);
+        if (dir) next.set('in', dir);
+        if (path && r === root) next.set('path', path);
+        setParams(next);
+      }}
     />
   );
 

--- a/apps/portal-next/web/src/pages/files/read.css
+++ b/apps/portal-next/web/src/pages/files/read.css
@@ -357,3 +357,36 @@
   font-size: 10.5px; color: var(--fg-subtle);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
+
+/* ── the folder you are inside ───────────────────────────────────────────────
+   Only drawn while scoped. A breadcrumb reading just the root name is furniture,
+   and this panel's whole argument is that the rarer case must not tax the
+   common one. */
+.bothy-files .rd-crumbs {
+  display: flex; flex-wrap: wrap; align-items: center;
+  gap: 2px; padding: 6px 12px 8px;
+  font-size: 11.5px; color: var(--fg-subtle);
+  border-bottom: 1px solid var(--line);
+}
+.bothy-files .rd-crumbs button {
+  padding: 1px 4px; border: 0; background: none; border-radius: var(--r-xs);
+  font: inherit; font-size: 11.5px; color: var(--accent-fg); cursor: pointer;
+}
+.bothy-files .rd-crumbs button:hover { background: var(--accent-bg); }
+.bothy-files .rd-crumbs b { color: var(--fg); font-weight: 700; padding: 0 2px; }
+.bothy-files .rd-crumb-sep { color: var(--fg-subtle); opacity: .6; }
+
+/* The folder heading became the "cd into this" control. It keeps the exact look
+   it had as a <p> - nothing moved, it just became pressable - and only gains an
+   affordance on hover, because a list of folders that all look like buttons is
+   noisier than the list it replaced. */
+.bothy-files .rd-folder-h {
+  display: block; width: 100%; text-align: left;
+  border: 0; background: none; padding: 0; margin: 0 0 4px;
+  font: inherit; font-size: 10px; letter-spacing: .04em; text-transform: uppercase;
+  color: var(--fg-subtle); cursor: pointer; border-radius: var(--r-xs);
+}
+.bothy-files .rd-folder-h:hover:not(:disabled) { color: var(--accent-fg); }
+/* The root's own top level has no folder to descend into. */
+.bothy-files .rd-folder-h:disabled { cursor: default; }
+.bothy-files .rd-folder-h:focus-visible { outline: 2px solid var(--ring); outline-offset: 1px; }


### PR DESCRIPTION
> "load it inside the root and remove from view some upper layer, like when you cd into some place and do ls again"

That, and it turned out to be a performance fix as much as a navigation one.

## `/tree` already accepted `path` and silently ignored it

A client asking for a subtree got the **whole root back with no way to tell** — worse than refusing and worse than working. Verified before the change: `{'root':'notes','path':'network'}` returned all 46 files.

It scopes now, and the walk **starts** at the folder rather than filtering a full listing, so scoping costs what the folder costs:

| | entries | time |
|---|---:|---:|
| `home` | 3,201 | 322 ms |
| `home/claude-notes` | 46 | **6 ms** |
| `notes` | 46 | 9 ms |
| `notes/network` | 5 | **5 ms** |

Paths stay **root-relative** — every other endpoint speaks root-relative paths, and a client that scoped in still has to be able to open what it finds.

## Containment

`path` names a **directory**, and `resolve()` answers for files — so `listing()` does its own realpath comparison after following every link. `checks/tree_scope.py` asserts both halves, because only one of them was ever going to be tested by accident:

- that scoping **scopes** (the bug that shipped), and
- that `../../../etc`, `network/../../..`, `/etc`, a file where a folder is expected, and a missing folder are all **403**.

An *empty* scope is the whole root rather than an error — that is what the UI sends when you climb back out, and a 403 there would break the way back.

## In the reader

The folder heading became the control. It keeps the exact look it had as a `<p>` — nothing moves, it just became pressable — and gains its affordance only on hover, because a list where every folder looks like a button is noisier than the list it replaced.

The breadcrumb is drawn **only while scoped**; a crumb trail reading just the root name is furniture. The open document is **kept** when you scope: narrowing the index changes what you are browsing, not what you are reading.

The scope lives in the URL (`?root=notes&in=network`), so a narrowed view is something you can send someone, and Back steps out of it.

## One bug worth recording

It looked like an empty folder rather than like a bug. The tree cache is keyed by root **and** scope, and `root`/`scope` had to become dependencies of the fetch effect — `keyOf()` is built from them. Without that the effect never re-ran, the scoped listing was never fetched, and scoping into a folder that definitely contained documents rendered **nothing at all**.

## Verified

Live: whole root 6 folders / 40 docs → `cd graphify-out` → 1 folder / 2 docs with `notes/graphify-out` breadcrumbs and the document still open → crumb back to 6 folders. No console errors. `just files-check` 0 FAIL, portal checks 0 FAIL, `just verify` 23/23.
