### PR TITLE
feat(portability): one place that knows where things are, and what to call this box

### DIFF
--- a/justfile
+++ b/justfile
@@ -74,7 +74,11 @@ up-auth: network
     #!/usr/bin/env bash
     set -euo pipefail
     docker compose -f auth/compose.yml up -d
-    IP=$(tailscale ip -4 2>/dev/null | head -1); IP=${IP:-$BOX_IP}
+    # One resolver, not a second copy of the dance - see scripts/lib/box-addr.sh
+    # for the order. This one matters more than most: the address printed here
+    # has to be the address Keycloak's issuer was built from, or the admin
+    # console link works and the login it leads to does not.
+    IP=$(bash scripts/lib/box-addr.sh)
     echo ""
     echo "  Keycloak admin   http://$IP:8090/admin  (admin / DEV_LOGIN_PASSWORD in .env - the shared dev login)"
     echo "  OIDC discovery   http://$IP:8090/realms/devbox/.well-known/openid-configuration"
@@ -245,7 +249,7 @@ urls:
     #!/usr/bin/env bash
     # Identity is read from tailscale at run time and never stored in this repo:
     # the node name/IP identify the owner's tailnet, and this repo is public.
-    IP=$(tailscale ip -4 2>/dev/null | head -1); IP=${IP:-<this-node-ip>}
+    IP=$(bash scripts/lib/box-addr.sh)
     HOST=$(tailscale status --json 2>/dev/null | jq -r '.Self.DNSName // ""' | sed 's/\.$//'); HOST=${HOST:-<this-node>}
     echo "This box is a tailnet node: $HOST / $IP - reachable directly."
     echo "Access is by IP:port ($HOST:<port> also works - MagicDNS is free)."

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -9,7 +9,11 @@
 # portainer un-backed-up for six days without anything looking wrong.
 set -uo pipefail
 
-BK="${1:-/home/devssh/backups}"
+# shellcheck disable=SC1091
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/env.sh"
+# $1 still wins, because the systemd unit and a person at a prompt both pass one
+# sometimes; BACKUP_ROOT is the default and comes from .env or from $HOME.
+BK="${1:-$BACKUP_ROOT}"
 KEEP=14
 ts=$(date +%Y%m%d-%H%M%S)
 root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)

--- a/scripts/checks/portability.baseline
+++ b/scripts/checks/portability.baseline
@@ -50,6 +50,3 @@ host/windows/install-portproxy-refresh.cmd	tailnet-ip	1
 host/windows/refresh-portproxy.ps1	tailnet-ip	3
 justfile	tailnet-ip	1
 README.md	tailnet-ip	1
-scripts/backup.sh	home-path	1
-scripts/doctor.sh	home-path	1
-scripts/verify-access.sh	tailnet-ip	1

--- a/scripts/checks/portability.sh
+++ b/scripts/checks/portability.sh
@@ -41,8 +41,13 @@ TAILNET_RE='\b100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3
 #                   past and rewriting it would defeat the point of keeping it.
 #   .claude         agent worktrees live here and are copies of the repo, so
 #                   every hit inside one is a duplicate of a hit outside it.
-EXCLUDE=':(exclude).cleanup-trash/**' 
+EXCLUDE=':(exclude).cleanup-trash/**'
 EXCLUDE2=':(exclude).claude/**'
+# And this file. It CONTAINS the patterns, so it matches itself - the comment
+# above naming the CGNAT range is a hit by its own rule. Baselining that would
+# be accepting a line of noise forever; excluding it says what is actually true,
+# which is that a description of an address is not an address.
+EXCLUDE3=':(exclude)scripts/checks/portability.*'
 
 hits() {
   # FILE and COUNT, not file:line, and not the matching text.
@@ -59,8 +64,8 @@ hits() {
   # catches a genuinely new occurrence (the count goes up), and it shrinks
   # visibly as the work lands.
   {
-    git grep -cE "$HOME_RE" -- . "$EXCLUDE" "$EXCLUDE2" | sed 's/^\(.*\):\([0-9]*\)$/\1\thome-path\t\2/'
-    git grep -cE "$TAILNET_RE" -- . "$EXCLUDE" "$EXCLUDE2" | sed 's/^\(.*\):\([0-9]*\)$/\1\ttailnet-ip\t\2/'
+    git grep -cE "$HOME_RE" -- . "$EXCLUDE" "$EXCLUDE2" "$EXCLUDE3" | sed 's/^\(.*\):\([0-9]*\)$/\1\thome-path\t\2/'
+    git grep -cE "$TAILNET_RE" -- . "$EXCLUDE" "$EXCLUDE2" "$EXCLUDE3" | sed 's/^\(.*\):\([0-9]*\)$/\1\ttailnet-ip\t\2/'
   } | sort -u
 }
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # One-glance health check of the whole dev environment.
 set -uo pipefail
+# BACKUP_ROOT, POSTGRES_USER and the rest, with defaults. See scripts/lib/env.sh
+# for why they are derived rather than declared here.
+# shellcheck disable=SC1091
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/env.sh"
 green() { printf '  \033[32m✓\033[0m %s\n' "$*"; }
 red()   { printf '  \033[31m✗\033[0m %s\n' "$*"; }
 # Neither a pass nor a fault: something deliberately switched off. Without this
@@ -104,7 +108,7 @@ echo "== backups =="
 # check unnoticed, because a failed pg_dumpall still leaves behind a perfectly
 # valid gzip of nothing. Age and size are what separate a backup from a file
 # that is merely named like one.
-latest=$(ls -1t /home/devssh/backups/postgres/*.sql.gz 2>/dev/null | head -1)
+latest=$(ls -1t "$BACKUP_ROOT"/postgres/*.sql.gz 2>/dev/null | head -1)
 if [ -z "$latest" ]; then
   red "no postgres backups yet"
 else
@@ -134,7 +138,7 @@ else
   #
   # backup.sh uses pg_dumpall deliberately for exactly this reason; this check is
   # what would notice if anyone ever narrowed it to a list.
-  live=$(docker exec postgres psql -U dev -tAc \
+  live=$(docker exec postgres psql -U "${POSTGRES_USER:-dev}" -tAc \
     "SELECT datname FROM pg_database WHERE datistemplate = false AND datname <> 'postgres';" 2>/dev/null | tr -d '\r')
   if [ -n "$live" ]; then
     # Read the dump's database list ONCE, then compare in-shell.

--- a/scripts/lib/box-addr.sh
+++ b/scripts/lib/box-addr.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# What address does a browser use to reach this box? Prints it, or nothing.
+#
+# THE ORDER IS THE ARGUMENT, and each rung exists because the one below it is
+# wrong in some real case:
+#
+#   1. $BOTHY_BASE_HOST   an explicit override. CI, a tunnel, a second address.
+#   2. tailscale ip -4    the truth when tailscale is running, and it survives
+#                         the address changing without anybody editing a file.
+#   3. $BOX_IP from .env  the declared answer. Also what Keycloak's issuer and
+#                         redirect URI are built from, so on a box with a stale
+#                         tailscale this at least AGREES with the thing that
+#                         will actually validate the login.
+#   4. 127.0.0.1          not a fallback so much as an admission: no tailnet, no
+#                         declared address, so the only honest answer is "here".
+#
+# BOX_IP KEEPS ITS NAME on purpose. auth/compose.yml spends thirty lines
+# explaining that the issuer, the redirect URI and the cookie domain are all
+# built from one value so they cannot drift apart, and introducing a second name
+# for the same address is precisely the failure it warns about.
+set -uo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+. "$here/env.sh"
+
+if [ -n "${BOTHY_BASE_HOST:-}" ]; then
+  printf '%s\n' "$BOTHY_BASE_HOST"
+  exit 0
+fi
+
+# `tailscale status` first: `tailscale ip` answers even when the daemon is down
+# or the node is logged out, and an address nothing is listening on is worse
+# than no address, because every later failure looks like a service fault.
+if command -v tailscale >/dev/null 2>&1 \
+   && tailscale status --json >/dev/null 2>&1; then
+  ip=$(tailscale ip -4 2>/dev/null | head -1)
+  [ -n "$ip" ] && { printf '%s\n' "$ip"; exit 0; }
+fi
+
+if [ -n "${BOX_IP:-}" ]; then
+  printf '%s\n' "$BOX_IP"
+  exit 0
+fi
+
+printf '127.0.0.1\n'

--- a/scripts/lib/env.sh
+++ b/scripts/lib/env.sh
@@ -1,0 +1,40 @@
+# Where things are, and what this box is called. Sourced, never executed.
+#
+#   . "$(dirname "${BASH_SOURCE[0]}")/lib/env.sh"
+#
+# WHY THIS EXISTS. Four scripts each worked out the repo root, each read .env
+# their own way, and two of them simply hardcoded a path under one person's home
+# directory. That is four places to be wrong and four places to fix, and it is
+# the reason `just verify` could only ever be run by its author.
+#
+# Everything here has a DEFAULT. `cp .env.example .env && just up` has to work
+# without editing any of it, so a missing value is never an error - it is the
+# ordinary case.
+
+# The repo root, DERIVED and never configured. A declared root is a value that
+# can disagree with reality after a `mv`; this one cannot. `..` twice because
+# this file is scripts/lib/env.sh.
+BOTHY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export BOTHY_ROOT
+
+# The repo's own .env, if there is one. `set -a` exports everything it declares
+# so a child process sees it too, which is what the compose files and the python
+# checks expect.
+if [ -f "$BOTHY_ROOT/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091  # path is computed, shellcheck cannot follow it
+  . "$BOTHY_ROOT/.env"
+  set +a
+fi
+
+# The same names, and the same defaults, that apps/portal-files/compose.yml
+# uses. Written twice - once there for compose, once here for shell - and that
+# duplication is real. It is guarded by scripts/checks/portability.sh rather
+# than by machinery, because a variable indirection between a compose file and a
+# shell script costs more to read than the two lines it saves.
+: "${NOTES_ROOT:=$HOME/claude-notes}"
+: "${PROJECTS_ROOT:=$HOME/projects}"
+: "${HOME_ROOT:=$HOME}"
+: "${STATE_ROOT:=$HOME/.local/state}"
+: "${BACKUP_ROOT:=$HOME/backups}"
+export NOTES_ROOT PROJECTS_ROOT HOME_ROOT STATE_ROOT BACKUP_ROOT

--- a/scripts/verify-access.sh
+++ b/scripts/verify-access.sh
@@ -15,7 +15,14 @@
 #
 # Run AFTER `docker compose ... up -d` has applied the edits.
 set -uo pipefail
-IP=100.117.176.85
+# The box's address, resolved rather than declared - see scripts/lib/box-addr.sh
+# for the order and why each rung is there. It was a literal, which meant this
+# whole script only ever verified one machine.
+IP=$("$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/box-addr.sh")
+if [ -z "$IP" ]; then
+  echo "FAIL  could not work out this box's address - set BOX_IP in .env"
+  exit 1
+fi
 pass=0; fail=0
 ok()   { printf '  \033[32mPASS\033[0m  %s\n' "$1"; pass=$((pass+1)); }
 bad()  { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; fail=$((fail+1)); }


### PR DESCRIPTION
Four scripts each worked out the repo root, each read `.env` their own way, and two hardcoded a path under one person's home directory. `verify-access.sh` opened with `IP=100.117.176.85`, which is why `just verify` could only ever be run by its author.

## `scripts/lib/env.sh`

Derives `BOTHY_ROOT` from its own location and never declares it — a declared root is a value that can disagree with reality after a `mv`. Loads `.env` if present and supplies the same defaults `apps/portal-files/compose.yml` now uses, so nothing has to be set for the box to start.

## `scripts/lib/box-addr.sh`

Answers "what address does a browser use", and **the order is the argument** — each rung exists because the one below it is wrong in a real case:

| | |
|---|---|
| `$BOTHY_BASE_HOST` | explicit override — CI, a tunnel, a second address |
| `tailscale ip -4` | the truth when it is running, and survives the address changing with nobody editing a file |
| `$BOX_IP` from `.env` | the declared answer, and the one Keycloak's issuer was built from |
| `127.0.0.1` | not a fallback so much as an admission |

The tailscale rung checks `tailscale status` **first**, because `tailscale ip` answers even when the daemon is down or the node is logged out — and an address nothing is listening on is worse than no address, since every later failure then looks like a service fault.

**`BOX_IP` keeps its name.** `auth/compose.yml` spends thirty lines explaining that the issuer, redirect URI and cookie domain are built from one value so they cannot drift apart. A second name for the same address is exactly the failure it warns about.

## Two bugs found on the way

- The **justfile did the tailscale-then-`BOX_IP` dance inline, twice.** It calls the resolver now — and this one matters more than most: the admin URL it prints has to be the address Keycloak's issuer was built from, or the link works and the login it leads to does not.
- **`doctor.sh` asserted `psql -U dev`** while `just psql` correctly used `${POSTGRES_USER:-dev}`. Change the user and the backup-coverage section went red with a false claim.

## The check now excludes itself

It *contains* the patterns, so the comment naming the CGNAT range `100.64.0.0/10` was a hit by its own rule. Baselining that would be accepting a line of noise forever; excluding it states what is actually true — a description of an address is not an address.

## Numbers

**106 references / 48 pairs → 97 / 45.**

Verified unchanged on this box: `just verify` 23/23, `doctor` clean *including* the backup section it now reaches through `BACKUP_ROOT`, portal checks 0 FAIL. All four resolver rungs exercised — including the last, by masking tailscale with no `.env` present.
