### PR TITLE
refactor(files-check): one resolver, and make the two of them agree

### DIFF
--- a/apps/portal-files/checks/authz_probe.py
+++ b/apps/portal-files/checks/authz_probe.py
@@ -28,7 +28,10 @@ import sys
 import urllib.parse
 import requests
 
-BASE = "http://100.117.176.85"
+# One resolver for the whole suite - checks/env.py. These were literals in
+# twelve files, which put this node's tailnet address in a public repo and
+# made the suite unrunnable by anyone but its author.
+from env import BASE
 USER = os.environ["DEV_LOGIN_USER"]
 PASS = os.environ["DEV_LOGIN_PASSWORD"]
 

--- a/apps/portal-files/checks/bytes_e2e.py
+++ b/apps/portal-files/checks/bytes_e2e.py
@@ -14,8 +14,10 @@ def _probe(path: str) -> str:
     return path
 atexit.register(lambda: [os.remove(p) for p in _PROBES if os.path.exists(p)])
 
-BASE = "http://100.117.176.85"
-SANDBOX = "http://100.117.176.85:8100"
+# One resolver for the whole suite - checks/env.py. These were literals in
+# twelve files, which put this node's tailnet address in a public repo and
+# made the suite unrunnable by anyone but its author.
+from env import BASE, NOTES, SANDBOX
 fails = 0
 
 
@@ -110,7 +112,7 @@ for label, hdr in [("multi-range", "bytes=0-10,20-30"),
 # A zero-length file has no "last N bytes". The suffix branch returned before
 # the validation, so it produced (0, -1) -> `206 Content-Range: bytes 0--1/0`,
 # which is not a parseable field value. Any empty file in a repo reaches it.
-empty = _probe("/home/devssh/claude-notes/_empty-probe.md")
+empty = _probe(f"{NOTES}/_empty-probe.md")
 open(empty, "w").close()
 r = s.get(f"{SANDBOX}/-/api/files/raw",
           params={"root": "notes", "path": "_empty-probe.md"},
@@ -147,7 +149,7 @@ print("\n── the new viewers ────────────────
 # makes it safe. checks/sandbox_escape.mjs proves the containment; this only
 # proves the content type is right.
 import tempfile
-probe = _probe("/home/devssh/claude-notes/_viewer-probe.svg")
+probe = _probe(f"{NOTES}/_viewer-probe.svg")
 open(probe, "w").write('<svg xmlns="http://www.w3.org/2000/svg"><text>x</text></svg>')
 r = s.get(f"{SANDBOX}/-/api/files/raw",
           params={"root": "notes", "path": "_viewer-probe.svg"}, timeout=20)
@@ -224,7 +226,7 @@ r = s.post(f"{BASE}/-/api/files/write",
            headers={"Sec-Fetch-Site": "cross-site"}, timeout=15)
 check("a cross-site write is refused", r.status_code == 403, f"got {r.status_code}")
 check("and neither left a file behind",
-      not os.path.exists("/home/devssh/claude-notes/csrf.md"))
+      not os.path.exists(f"{NOTES}/csrf.md"))
 
 print("\n── anonymous ───────────────────────────────────────────────────────")
 a = requests.Session()

--- a/apps/portal-files/checks/delete_semantics.py
+++ b/apps/portal-files/checks/delete_semantics.py
@@ -22,13 +22,16 @@ import sys
 
 import requests
 
-BASE = "http://100.117.176.85"
+# One resolver for the whole suite - checks/env.py. These were literals in
+# twelve files, which put this node's tailnet address in a public repo and
+# made the suite unrunnable by anyone but its author.
+from env import BASE, NOTES, PROJECTS, TRASH
+
 API = f"{BASE}/-/api/files"
 # ~/claude-notes, not ~/stacks. e2e.py ends in `git reset --hard` on stacks and
 # snapshots.py plants its probe at the top of it; sharing a repo with either
 # means one check's cleanup is another's missing file.
-REPO = "/home/devssh/claude-notes"
-TRASH = "/home/devssh/.local/state/bothy/trash"
+REPO = NOTES
 PROBE = "_delete_probe.md"
 PROBE_DIR = "_delete_probe_dir"
 DISK = f"{REPO}/{PROBE}"
@@ -115,7 +118,7 @@ try:
     check("...and it named the ROOT, not the path", "read-only" in str(out.get("error")),
           out.get("error"))
     check("...and that real file is untouched",
-          os.path.exists(f"/home/devssh/projects/{victim}"))
+          os.path.exists(f"{PROJECTS}/{victim}"))
 
     # A directory must be refused ON PURPOSE. If this ever returns 500 the
     # refusal has become an accident of os.unlink raising EISDIR, which is one

--- a/apps/portal-files/checks/e2e.py
+++ b/apps/portal-files/checks/e2e.py
@@ -18,9 +18,13 @@ import subprocess
 import sys
 import requests
 
-BASE = "http://100.117.176.85"
+# One resolver for the whole suite - checks/env.py. These were literals in
+# twelve files, which put this node's tailnet address in a public repo and
+# made the suite unrunnable by anyone but its author.
+from env import BASE, STACKS
+
 API = f"{BASE}/-/api/files"
-REPO = "/home/devssh/stacks"
+REPO = STACKS
 TESTFILE = "docs/kb/_editor-tier-e2e.md"   # cleaned up at the end
 
 # This test writes a real file into a real repo and cleans up after itself. It no

--- a/apps/portal-files/checks/env.py
+++ b/apps/portal-files/checks/env.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Where this box is, and where its files are - resolved, not written down.
+
+Every check in this directory used to open by writing down two answers - this
+node's literal tailnet address, and a literal path under one person's home
+directory - which made the whole suite unrunnable by anyone else and put that
+address into a public repository twelve times over. scripts/checks/portability.sh
+counts exactly that, and this file is deliberately written so that it does not
+add to the count itself: the old values are described here, never quoted.
+
+This module is the single place those answers are worked out, so there is one
+thing to fix when the box moves rather than twelve.
+
+WHY A MODULE AND NOT AN EXPORTED ENVIRONMENT. The checks are run directly
+(`python3 checks/e2e.py`) as often as through run.sh, and a check that only works
+when its wrapper has already exported six variables is a check people stop
+running. Everything below has a default that is correct on an unconfigured
+machine, and nothing here requires the caller to have done anything.
+
+Nothing in here is a policy decision - the values mirror what
+apps/portal-files/compose.yml already mounts, deliberately. If a name here
+disagrees with a name there, the container and the check are looking at two
+different directories and every assertion becomes a coin toss.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import urllib.parse
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# The repository root: DERIVED from this file, never declared.
+#
+# .../apps/portal-files/checks/env.py -> checks -> portal-files -> apps -> root,
+# which is `parents[3]`. A configured STACKS_ROOT was the obvious alternative and
+# it is worse in the one way that matters: a declared path can disagree with
+# reality. After a `mv` or a clone under a different name the variable still
+# points at the old location, the checks read a directory the service is not
+# serving, and every "the write really landed" assertion fails somewhere far from
+# the cause. A path derived from __file__ cannot be stale by construction.
+#
+# This is the same argument apps/portal-files/compose.yml makes for mounting
+# `../..` instead of an absolute path - one repo, one rule.
+STACKS = str(Path(__file__).resolve().parents[3])
+
+
+def _dotenv(path: str) -> dict[str, str]:
+    """The repo `.env`, parsed well enough for the handful of names below.
+
+    Read HERE rather than left to the caller because run.sh already sets the
+    precedent (`. "$HERE/../../../.env"`), and because a check invoked directly
+    has no wrapper to do it. Not a full shell parser on purpose: this reads
+    `KEY=value` lines and nothing else, so a `.env` containing command
+    substitution is ignored rather than executed - the checks are not a reason
+    to run arbitrary code from a file.
+    """
+    values: dict[str, str] = {}
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            lines = fh.readlines()
+    except OSError:
+        # No .env is normal - a fresh clone has not copied .env.example yet, and
+        # every value below still resolves. Missing config must not be a crash.
+        return values
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].strip()
+        key, sep, val = line.partition("=")
+        if not sep:
+            continue
+        val = val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        values[key.strip()] = val
+    return values
+
+
+_ENV = _dotenv(os.path.join(STACKS, ".env"))
+
+# And PUT IT IN THE ENVIRONMENT, because the checks read more out of .env than
+# the names below: DEV_LOGIN_USER and DEV_LOGIN_PASSWORD are read straight from
+# os.environ by six of them. run.sh already does this (`set -a; . .env`), so
+# under the runner nothing changes - what changes is that `python3
+# checks/e2e.py` on its own now works instead of dying on a KeyError, which is
+# how these are run while something is being fixed.
+#
+# setdefault, never assignment: an explicitly exported variable is a deliberate
+# override for one run and must outrank a committed file.
+for _k, _v in _ENV.items():
+    os.environ.setdefault(_k, _v)
+
+
+def _conf(name: str, default: str = "") -> str:
+    """A real environment variable beats the file, and the file beats nothing.
+
+    That order and not the reverse: `BOTHY_BASE=... python3 checks/e2e.py` has to
+    win over a committed default, or the override rung below is decorative.
+    """
+    val = os.environ.get(name) or _ENV.get(name) or ""
+    return val.strip() or default
+
+
+def _tailscale_ip() -> str:
+    """This node's tailnet address, asked of tailscale rather than remembered.
+
+    Guarded three ways because this runs on machines that have never heard of
+    tailscale: shutil.which for "not installed", returncode for "installed but
+    the daemon is down" (it exits non-zero and prints to stderr), and a timeout
+    because a wedged tailscaled blocks instead of failing - the exact behaviour
+    network/tailnet-troubleshooting.md was written about.
+    """
+    exe = shutil.which("tailscale")
+    if not exe:
+        return ""
+    try:
+        proc = subprocess.run([exe, "ip", "-4"], capture_output=True,
+                              text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    # `tailscale ip -4` can print more than one address; the first is this node.
+    addrs = proc.stdout.split()
+    return addrs[0] if addrs else ""
+
+
+def _box_host() -> str:
+    """The host the portal answers on, in four rungs, most explicit first.
+
+    1. $BOX_IP, from the environment or the repo .env. THE canonical name for
+       this value already: auth/compose.yml builds Keycloak's KC_HOSTNAME, the
+       oauth2-proxy redirect URI, the OIDC issuer and the cookie whitelist from
+       it, and warns at length that they must all agree. Inventing a second name
+       for the same address is precisely how they stop agreeing - the issuer in
+       the token and the issuer oauth2-proxy expects differ by one letter and
+       login fails with a message about neither.
+    2. `tailscale ip -4`, for a box that has a tailnet but no .env yet. This is
+       the same fallback `just urls` uses (justfile line 77), in the same order.
+    3. 127.0.0.1, so a bare clone with nothing configured still runs the checks
+       against a locally published portal instead of dying on a KeyError.
+    """
+    return _conf("BOX_IP") or _tailscale_ip() or "127.0.0.1"
+
+
+# $BOTHY_BASE outranks all of the above and is a whole ORIGIN, not a host: CI and
+# tunnels reach this service on a name and a port that no amount of IP resolution
+# would ever produce (https://, a forwarded 8443, a hostname). Anything narrower
+# than a full origin cannot express those.
+_OVERRIDE = _conf("BOTHY_BASE").rstrip("/")
+
+if _OVERRIDE:
+    BASE = _OVERRIDE
+    _split = urllib.parse.urlsplit(BASE)
+    HOST = _split.hostname or "127.0.0.1"
+    _SCHEME = _split.scheme or "http"
+else:
+    HOST = _box_host()
+    BASE = f"http://{HOST}"
+    _SCHEME = "http"
+
+# The sandbox origin: the SAME host, port 8100. Same host and a different port is
+# the entire point - the raw/archive endpoints are served from a second origin so
+# the browser treats them as cross-origin, and a sandbox that shared BASE's
+# origin would be no sandbox at all. Overridable separately because a tunnel that
+# reaches BASE has no reason to also expose 8100 on the same name.
+SANDBOX = _conf("BOTHY_SANDBOX").rstrip("/") or f"{_SCHEME}://{HOST}:8100"
+
+# ---------------------------------------------------------------------------
+# Host paths. Every name below is the one apps/portal-files/compose.yml already
+# uses for the same mount, with the same default - see the WHY at the top.
+
+# `${HOME_ROOT:-${HOME}}` -> /repos/home. The `home` root, and the parent the
+# probe corpora are planted under (never inside a git repo - links_index.py's
+# docstring explains what happened the time one was).
+HOME_DIR = _conf("HOME_ROOT") or os.path.expanduser("~")
+
+# `${NOTES_ROOT:-${HOME}/claude-notes}` -> /repos/notes. Outside the repository,
+# so unlike STACKS it genuinely has to be configurable; a default rather than a
+# requirement so an unedited .env still works.
+NOTES = _conf("NOTES_ROOT") or os.path.join(HOME_DIR, "claude-notes")
+
+# `${PROJECTS_ROOT:-${HOME}/projects}` -> /repos/projects, mounted `ro`.
+PROJECTS = _conf("PROJECTS_ROOT") or os.path.join(HOME_DIR, "projects")
+
+# `${STATE_ROOT:-${HOME}/.local/state}/bothy/trash` -> /var/lib/bothy/trash. The
+# undo net: the checks read it directly to prove the bytes a save destroyed are
+# really there, which a response field claiming `snapshot: true` cannot.
+STATE = _conf("STATE_ROOT") or os.path.join(HOME_DIR, ".local", "state")
+TRASH = os.path.join(STATE, "bothy", "trash")
+
+# `./audit:/audit` in the same compose file, i.e. relative to the service
+# directory - so it is derived from STACKS and not from HOME.
+AUDIT_LOG = os.path.join(STACKS, "apps", "portal-files", "audit", "writes.log")
+
+
+def _sh() -> str:
+    """The same answers, as shell `export` lines, for the ONE check that is not
+    python: checks/sandbox_escape.mjs.
+
+    run.sh evals this in a subshell before running node, so the browser check
+    reads the values out of process.env instead of resolving them a second time.
+    Re-implementing the four rungs in javascript is the alternative and it is the
+    worse one - two resolvers disagree eventually, and the first symptom would be
+    a security check quietly probing the wrong origin and passing.
+
+    Single quotes with the standard `'\\''` escape: a path can contain anything.
+    """
+    out = []
+    for name, val in (("BOTHY_BASE", BASE), ("BOTHY_SANDBOX", SANDBOX),
+                      ("NOTES_ROOT", NOTES), ("HOME_ROOT", HOME_DIR)):
+        out.append("export %s='%s'" % (name, val.replace("'", "'\\''")))
+    return "\n".join(out)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if "--sh" in sys.argv[1:]:
+        print(_sh())
+        raise SystemExit(0)
+
+    # `python3 checks/env.py` prints what the suite is about to talk to. Worth a
+    # main block: "the check failed" and "the check was pointed at the wrong box"
+    # look identical from a failing assertion, and this separates them in one
+    # command.
+    rung = ("$BOTHY_BASE" if _OVERRIDE else
+            "$BOX_IP" if _conf("BOX_IP") else
+            "tailscale ip -4" if _tailscale_ip() else
+            "127.0.0.1 fallback")
+    print(f"BASE      {BASE}   (from {rung})")
+    print(f"SANDBOX   {SANDBOX}")
+    print(f"STACKS    {STACKS}   (derived from {__file__})")
+    print(f"NOTES     {NOTES}")
+    print(f"HOME_DIR  {HOME_DIR}")
+    print(f"PROJECTS  {PROJECTS}")
+    print(f"TRASH     {TRASH}")
+    print(f"AUDIT_LOG {AUDIT_LOG}")

--- a/apps/portal-files/checks/env.py
+++ b/apps/portal-files/checks/env.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 import subprocess
 import urllib.parse
 from pathlib import Path
@@ -144,7 +145,31 @@ def _box_host() -> str:
     3. 127.0.0.1, so a bare clone with nothing configured still runs the checks
        against a locally published portal instead of dying on a KeyError.
     """
-    return _conf("BOX_IP") or _tailscale_ip() or "127.0.0.1"
+    # TAILSCALE BEFORE BOX_IP, and this was the other way round until the two
+    # resolvers on this box were compared - scripts/lib/box-addr.sh does the
+    # shell side of the same job and had the opposite order. One of them had to
+    # be wrong, and it was this one.
+    #
+    # BOX_IP is the DECLARED address; tailscale reports the actual one. When
+    # they agree - the ordinary case - the order does not matter. When they
+    # disagree, the declared value is the one that cannot be reached, and
+    # .env.example ships BOX_IP as a placeholder in the CGNAT range, so a fresh
+    # clone that never edited it would resolve to an address nothing answers on.
+    # (Written out rather than quoted, because quoting it here would put a
+    # tailnet-shaped literal back into the repo that scripts/checks/portability.sh
+    # is here to keep out - and a description of an address is not an address.)
+    #
+    # But a disagreement is worth SAYING rather than silently resolving: BOX_IP
+    # is what Keycloak's issuer and redirect URI were built from, so if it has
+    # drifted, pages load and logins fail. Warning is the only outcome that
+    # points at the actual problem.
+    ts, declared = _tailscale_ip(), _conf("BOX_IP")
+    if ts and declared and ts != declared:
+        print(f"  ! BOX_IP is {declared} but tailscale reports {ts} - using {ts}.\n"
+              f"    Keycloak's issuer is built from BOX_IP, so logins will fail "
+              f"until .env is updated and `just up-auth` is re-run.",
+              file=sys.stderr)
+    return ts or declared or "127.0.0.1"
 
 
 # $BOTHY_BASE outranks all of the above and is a whole ORIGIN, not a host: CI and
@@ -229,8 +254,8 @@ if __name__ == "__main__":
     # look identical from a failing assertion, and this separates them in one
     # command.
     rung = ("$BOTHY_BASE" if _OVERRIDE else
-            "$BOX_IP" if _conf("BOX_IP") else
             "tailscale ip -4" if _tailscale_ip() else
+            "$BOX_IP" if _conf("BOX_IP") else
             "127.0.0.1 fallback")
     print(f"BASE      {BASE}   (from {rung})")
     print(f"SANDBOX   {SANDBOX}")

--- a/apps/portal-files/checks/git_ops.py
+++ b/apps/portal-files/checks/git_ops.py
@@ -19,9 +19,13 @@ import sys
 
 import requests
 
-BASE = "http://100.117.176.85"
+# One resolver for the whole suite - checks/env.py. These were literals in
+# twelve files, which put this node's tailnet address in a public repo and
+# made the suite unrunnable by anyone but its author.
+from env import BASE, NOTES
+
 API = f"{BASE}/-/api/files"
-REPO = "/home/devssh/claude-notes"
+REPO = NOTES
 F = "_git-view-probe.md"
 
 fails = 0

--- a/apps/portal-files/checks/links_index.py
+++ b/apps/portal-files/checks/links_index.py
@@ -38,12 +38,16 @@ import time
 
 import requests
 
-BASE = "http://100.117.176.85"
+# One resolver for the whole suite - checks/env.py. These were literals in
+# twelve files, which put this node's tailnet address in a public repo and
+# made the suite unrunnable by anyone but its author.
+from env import BASE, HOME_DIR
+
 API = f"{BASE}/-/api/files"
 # Under $HOME rather than under either repo - see the module docstring. Named so
 # that a leftover from a crashed run is unmistakable and greppable.
 PROBE_REL = "_bothy-links-probe-4c81de"
-PROBE_DIR = f"/home/devssh/{PROBE_REL}"
+PROBE_DIR = f"{HOME_DIR}/{PROBE_REL}"
 
 fails = 0
 

--- a/apps/portal-files/checks/run.sh
+++ b/apps/portal-files/checks/run.sh
@@ -86,12 +86,17 @@ python3 checks/served_secrets.py || fail=1
 
 echo; echo "── the sandbox must actually contain a hostile document ────"
 # Needs a browser: the claim is about browser enforcement, so nothing else can
-# test it. Skipped rather than failed if playwright-core is absent.
-if [ -d /home/devssh/.npm/_npx/705bc6b22212b352/node_modules/playwright-core ]; then
-  node checks/sandbox_escape.mjs || fail=1
-else
-  echo "  SKIP: playwright-core not installed"
-fi
+# test it. Skipped rather than failed if playwright-core is absent - the SKIP now
+# lives INSIDE the check, which is the only place that can tell the difference
+# between "no browser here" and "the browser is somewhere else". The guard this
+# replaced stat'd one literal path in one person's npx cache, so it printed SKIP
+# on every other machine and on this one the moment npx rehashed the directory.
+#
+# In a SUBSHELL, and that is the point of the parentheses: env.py is the suite's
+# one resolver and this is the one check that cannot import it, so the values are
+# handed over as exported variables. Scoping them here keeps the rest of the run
+# on the ordinary resolution path rather than on a $BOTHY_BASE this script set.
+( eval "$(python3 checks/env.py --sh)"; node checks/sandbox_escape.mjs ) || fail=1
 
 echo; echo "── raw bytes + archives (the sandbox origin) ───────────────"
 python3 checks/bytes_e2e.py || fail=1

--- a/apps/portal-files/checks/sandbox_escape.mjs
+++ b/apps/portal-files/checks/sandbox_escape.mjs
@@ -3,11 +3,85 @@
 // where an untested assumption would be an actual vulnerability: the whole
 // argument for rendering SVG and HTML at all is "sandbox + opaque origin stops
 // it", and that is a claim about browser behaviour, not about our code.
-import { chromium } from '/home/devssh/.npm/_npx/705bc6b22212b352/node_modules/playwright-core/index.mjs';
-import { writeFileSync, unlinkSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { readdirSync, writeFileSync, unlinkSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+// WHERE PLAYWRIGHT COMES FROM, and why it is not an import at the top.
+//
+// This used to be a literal path into one person's npx cache, hash and all
+// (`/home/<user>/.npm/_npx/705bc6b22212b352/...`), which is unrunnable anywhere
+// else and is not even stable HERE - npx recomputes that hash from the package
+// set it was invoked with. A static `import` of a missing module is also a
+// parse-time failure, so it could not be caught: run.sh had to stat that same
+// literal path first and print the SKIP itself. Resolving dynamically moves the
+// decision into this file, where the reason for it lives.
+//
+// SKIP, NOT FAIL, when nothing is found. A browser is a heavy dependency the
+// rest of the suite does not need, and "the machine has no chromium" is not a
+// finding about the sandbox. Exit 0 so run.sh's `|| fail=1` stays quiet - that
+// is the behaviour this replaced and it is deliberate.
+const require = createRequire(import.meta.url);
+
+// Every place a playwright-core could be, most legitimate first.
+function candidates() {
+  const out = [];
+  // A real dependency, if this repo ever grows one. `require.resolve` from
+  // import.meta.url walks node_modules upwards exactly like an ordinary import.
+  try { out.push(require.resolve('playwright-core')); } catch { /* not a dependency here */ }
+  // The npx cache, because on the box this check was written for that is the
+  // only copy - portal-files ships no third-party dependencies on purpose, so
+  // there is no package.json to put playwright in. SCANNED, not named: the hash
+  // directory is derived from the package set npx was invoked with, so a literal
+  // one goes stale the next time anyone runs npx differently. Sorted so the
+  // choice does not depend on directory order.
+  const cache = join(process.env.npm_config_cache || join(homedir(), '.npm'), '_npx');
+  let entries = [];
+  try { entries = readdirSync(cache).sort(); } catch { return out; }
+  for (const e of entries) {
+    const mods = join(cache, e, 'node_modules');
+    if (!existsSync(join(mods, 'playwright-core'))) continue;
+    try { out.push(require.resolve('playwright-core', { paths: [mods] })); }
+    catch { /* a half-removed cache entry - keep looking */ }
+  }
+  return out;
+}
+
+// PICK ONE THAT CAN ACTUALLY LAUNCH, which is a separate question from "is
+// playwright installed". Each playwright-core pins one browser BUILD NUMBER and
+// downloads it into ~/.cache/ms-playwright; a cache entry left behind by an old
+// `npx playwright` still imports perfectly and then dies with "Executable
+// doesn't exist at .../chromium-1234/...". That is exactly what the hardcoded
+// path this replaced had rotted into - it named a copy whose browser had been
+// cleaned up, so the check FAILED the suite every run while looking like a
+// finding about the sandbox. Ask for executablePath() and require the file.
+let chromium = null;
+for (const entry of candidates()) {
+  let mod;
+  try { mod = await import(pathToFileURL(entry).href); }
+  catch { continue; }
+  // `?? .default` because playwright-core's main entry is CommonJS and node only
+  // sometimes detects its named exports.
+  const c = mod.chromium ?? mod.default?.chromium;
+  if (!c) continue;
+  try { if (!existsSync(c.executablePath())) continue; } catch { continue; }
+  chromium = c;
+  break;
+}
+if (!chromium) {
+  console.log('  SKIP: playwright-core not installed');
+  process.exit(0);
+}
+
 const [U,P]=[process.env.DEV_LOGIN_USER,process.env.DEV_LOGIN_PASSWORD];
-const BASE='http://100.117.176.85', SB='http://100.117.176.85:8100';
-const F='/home/devssh/claude-notes/_hostile-probe.svg';
+// Resolved ONCE, by checks/env.py, and handed here through the environment by
+// run.sh. A second implementation of the same four-rung lookup in javascript
+// would drift, and the first symptom would be this check probing an origin
+// nobody is serving and reporting "nothing escaped".
+const BASE=process.env.BOTHY_BASE, SB=process.env.BOTHY_SANDBOX;
+const F=join(process.env.NOTES_ROOT || join(homedir(), 'claude-notes'), '_hostile-probe.svg');
 
 // An SVG that tries to exfiltrate. If the sandbox holds, none of it runs.
 writeFileSync(F, `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80">

--- a/apps/portal-files/checks/save_semantics.py
+++ b/apps/portal-files/checks/save_semantics.py
@@ -13,9 +13,13 @@ import time
 
 import requests
 
-BASE = "http://100.117.176.85"
+# One resolver for the whole suite - checks/env.py. These were literals in
+# twelve files, which put this node's tailnet address in a public repo and
+# made the suite unrunnable by anyone but its author.
+from env import BASE, NOTES
+
 API = f"{BASE}/-/api/files"
-REPO = "/home/devssh/claude-notes"
+REPO = NOTES
 F = "_save-semantics-probe.md"
 
 fails = 0

--- a/apps/portal-files/checks/search_denied.py
+++ b/apps/portal-files/checks/search_denied.py
@@ -34,9 +34,13 @@ import sys
 
 import requests
 
-BASE = "http://100.117.176.85"
+# One resolver for the whole suite - checks/env.py. These were literals in
+# twelve files, which put this node's tailnet address in a public repo and
+# made the suite unrunnable by anyone but its author.
+from env import BASE, STACKS
+
 API = f"{BASE}/-/api/files"
-REPO = "/home/devssh/stacks"
+REPO = STACKS
 PROBE_REL = "docs/kb/_search-probe"
 PROBE_DIR = f"{REPO}/{PROBE_REL}"
 

--- a/apps/portal-files/checks/snapshots.py
+++ b/apps/portal-files/checks/snapshots.py
@@ -18,11 +18,14 @@ import sys
 
 import requests
 
-BASE = "http://100.117.176.85"
+# One resolver for the whole suite - checks/env.py. These were literals in
+# twelve files, which put this node's tailnet address in a public repo and
+# made the suite unrunnable by anyone but its author.
+from env import AUDIT_LOG, BASE, STACKS, TRASH
+
 API = f"{BASE}/-/api/files"
-TRASH = "/home/devssh/.local/state/bothy/trash"
 PROBE = "_snap_probe.md"
-DISK = f"/home/devssh/stacks/{PROBE}"
+DISK = f"{STACKS}/{PROBE}"
 SNAPS = f"{TRASH}/stacks/{PROBE}"
 
 fails = 0
@@ -112,7 +115,7 @@ try:
         check("and says so honestly: snapshot=false", out.get("snapshot") is False,
               f"snapshot={out.get('snapshot')}")
         check("the write really landed", open(DISK).read() == "version three\n")
-        log = subprocess.run(["tail", "-3", "/home/devssh/stacks/apps/portal-files/audit/writes.log"],
+        log = subprocess.run(["tail", "-3", AUDIT_LOG],
                              capture_output=True, text=True).stdout
         check("and the failure is in the audit log", "NOSNAPSHOT" in log,
               log.strip().splitlines()[-1][:58] if log.strip() else "(empty)")
@@ -138,7 +141,7 @@ finally:
     if os.path.exists(DISK):
         os.remove(DISK)
     subprocess.run(["rm", "-rf", SNAPS], check=False)
-    dirty = subprocess.run(["git", "-C", "/home/devssh/stacks", "status", "--porcelain",
+    dirty = subprocess.run(["git", "-C", STACKS, "status", "--porcelain",
                             "--", PROBE], capture_output=True, text=True).stdout.strip()
     check("the probe left nothing behind", not dirty and not os.path.exists(DISK), dirty)
 

--- a/apps/portal-files/checks/tree_scope.py
+++ b/apps/portal-files/checks/tree_scope.py
@@ -18,7 +18,10 @@ import sys
 
 import requests
 
-BASE = "http://100.117.176.85"
+# One resolver for the whole suite - checks/env.py. These were literals in
+# twelve files, which put this node's tailnet address in a public repo and
+# made the suite unrunnable by anyone but its author.
+from env import BASE
 API = f"{BASE}/-/api/files"
 
 fails = 0

--- a/scripts/checks/portability.baseline
+++ b/scripts/checks/portability.baseline
@@ -29,7 +29,3 @@ host/windows/install-portproxy-refresh.cmd	tailnet-ip	1
 host/windows/refresh-portproxy.ps1	tailnet-ip	3
 justfile	tailnet-ip	1
 README.md	tailnet-ip	1
-scripts/backup.sh	home-path	1
-scripts/checks/portability.sh	tailnet-ip	1
-scripts/doctor.sh	home-path	1
-scripts/verify-access.sh	tailnet-ip	1

--- a/scripts/checks/portability.baseline
+++ b/scripts/checks/portability.baseline
@@ -5,27 +5,6 @@
 # adding a reason - say why in the commit message.
 #
 # file<TAB>kind<TAB>count
-apps/portal-files/checks/authz_probe.py	tailnet-ip	1
-apps/portal-files/checks/bytes_e2e.py	home-path	3
-apps/portal-files/checks/bytes_e2e.py	tailnet-ip	2
-apps/portal-files/checks/delete_semantics.py	home-path	3
-apps/portal-files/checks/delete_semantics.py	tailnet-ip	1
-apps/portal-files/checks/e2e.py	home-path	1
-apps/portal-files/checks/e2e.py	tailnet-ip	1
-apps/portal-files/checks/git_ops.py	home-path	1
-apps/portal-files/checks/git_ops.py	tailnet-ip	1
-apps/portal-files/checks/links_index.py	home-path	1
-apps/portal-files/checks/links_index.py	tailnet-ip	1
-apps/portal-files/checks/run.sh	home-path	1
-apps/portal-files/checks/sandbox_escape.mjs	home-path	2
-apps/portal-files/checks/sandbox_escape.mjs	tailnet-ip	1
-apps/portal-files/checks/save_semantics.py	home-path	1
-apps/portal-files/checks/save_semantics.py	tailnet-ip	1
-apps/portal-files/checks/search_denied.py	home-path	1
-apps/portal-files/checks/search_denied.py	tailnet-ip	1
-apps/portal-files/checks/snapshots.py	home-path	4
-apps/portal-files/checks/snapshots.py	tailnet-ip	1
-apps/portal-files/checks/tree_scope.py	tailnet-ip	1
 apps/portal-next/compose.yml	tailnet-ip	1
 apps/portal-next/web/src/lib/config.ts	home-path	3
 apps/portal-next/web/src/lib/discover.ts	home-path	1
@@ -51,5 +30,6 @@ host/windows/refresh-portproxy.ps1	tailnet-ip	3
 justfile	tailnet-ip	1
 README.md	tailnet-ip	1
 scripts/backup.sh	home-path	1
+scripts/checks/portability.sh	tailnet-ip	1
 scripts/doctor.sh	home-path	1
 scripts/verify-access.sh	tailnet-ip	1

--- a/scripts/lib/box-addr.sh
+++ b/scripts/lib/box-addr.sh
@@ -34,7 +34,22 @@ fi
 if command -v tailscale >/dev/null 2>&1 \
    && tailscale status --json >/dev/null 2>&1; then
   ip=$(tailscale ip -4 2>/dev/null | head -1)
-  [ -n "$ip" ] && { printf '%s\n' "$ip"; exit 0; }
+  if [ -n "$ip" ]; then
+    # A DISAGREEMENT IS WORTH SAYING. tailscale reports the address that
+    # actually reaches the box, so it wins - but BOX_IP is what Keycloak's
+    # issuer and redirect URI were built from, so when they differ, pages load
+    # and logins fail with a mismatch nobody can read from the error. Silently
+    # picking either one hides that; saying so points at the real problem.
+    #
+    # stderr, because this script's stdout IS the address and every caller
+    # takes it with $(...).
+    if [ -n "${BOX_IP:-}" ] && [ "$BOX_IP" != "$ip" ]; then
+      printf '  ! BOX_IP is %s but tailscale reports %s - using %s.\n' "$BOX_IP" "$ip" "$ip" >&2
+      printf '    Keycloak'"'"'s issuer is built from BOX_IP, so logins will fail until\n' >&2
+      printf '    .env is updated and `just up-auth` is re-run.\n' >&2
+    fi
+    printf '%s\n' "$ip"; exit 0
+  fi
 fi
 
 if [ -n "${BOX_IP:-}" ]; then

--- a/scripts/lib/env.sh
+++ b/scripts/lib/env.sh
@@ -21,10 +21,31 @@ export BOTHY_ROOT
 # so a child process sees it too, which is what the compose files and the python
 # checks expect.
 if [ -f "$BOTHY_ROOT/.env" ]; then
-  set -a
-  # shellcheck disable=SC1091  # path is computed, shellcheck cannot follow it
-  . "$BOTHY_ROOT/.env"
-  set +a
+  # THE ENVIRONMENT WINS OVER THE FILE, which is the opposite of what
+  # `set -a; . .env` does and the reason that is not used here.
+  #
+  # Sourcing overwrites anything already exported, so `BOX_IP=x just verify`
+  # silently did nothing - the file put its own value back. Docker Compose
+  # resolves it the other way (a variable already in the environment beats
+  # .env), and having the shell scripts disagree with the compose files about
+  # the same file is a difference nobody would think to look for.
+  #
+  # Read, do not source: `.` on a file of KEY=value also EXECUTES anything in
+  # it, so a value containing a backtick or $( ) would run. That is a real
+  # hazard for a file this repo tells people to paste secrets into.
+  while IFS= read -r line; do
+    case "$line" in ''|'#'*) continue ;; esac
+    key=${line%%=*}
+    val=${line#*=}
+    case "$key" in *[!A-Za-z0-9_]*|'') continue ;; esac
+    # Strip one layer of surrounding quotes, which .env files commonly carry.
+    case "$val" in
+      \"*\") val=${val#\"}; val=${val%\"} ;;
+      \'*\') val=${val#\'}; val=${val%\'} ;;
+    esac
+    # `:=` only assigns when unset or empty, so the environment keeps its value.
+    eval ": \"\${$key:=\$val}\"" 2>/dev/null && eval "export $key" 2>/dev/null
+  done < "$BOTHY_ROOT/.env"
 fi
 
 # The same names, and the same defaults, that apps/portal-files/compose.yml


### PR DESCRIPTION
The check suite hardcoded this node's tailnet address and this user's home paths in **twelve files** — a private address in a public repo, and a suite nobody else could run. `checks/env.py` is now the one place that answers where things are; the ten python checks import it instead of declaring literals. No assertion changed.

**101 references in 49 file/kind pairs → 67 in 24.** The checks directory goes from 30 hits to **zero**.

## Then the two resolvers disagreed

The shell side (`scripts/lib/box-addr.sh`, landed in #73) asks tailscale before `BOX_IP`. This one asked `BOX_IP` first. Both are defensible, only one can be right, and two answers to "what is this box called" is exactly the failure `auth/compose.yml` spends thirty lines warning about.

**Tailscale wins.** `BOX_IP` is the *declared* address; tailscale reports the *actual* one. When they agree the order is irrelevant; when they disagree the declared value is the one that cannot be reached — and `.env.example` ships a placeholder, so a fresh clone that never edited it would resolve to an address nothing answers on.

But a disagreement is now **said** rather than silently resolved:

```
! BOX_IP is 100.64.0.1 but tailscale reports 100.117.176.85 - using 100.117.176.85.
  Keycloak's issuer is built from BOX_IP, so logins will fail until
  .env is updated and `just up-auth` is re-run.
```

Both resolvers print it, to **stderr**, because stdout is the address and every caller takes it with `$(...)`.

## A bug that warning exposed

`scripts/lib/env.sh` did `set -a; . .env`, which **overwrites anything already exported** — so `BOX_IP=x just verify` silently did nothing, the file put its own value back, and that is exactly why the warning failed to fire when I first tested it.

Docker Compose resolves it the other way: a variable already in the environment beats `.env`. Two halves of one repo disagreeing about the precedence of the same file is a difference nobody would think to look for.

Fixed — and while fixing it, the sourcing became a **read**: `.` on a `KEY=value` file also *executes* it, so a value containing a backtick or `$( )` would run. That is a real hazard in the one file this repo tells people to paste secrets into.

## Also fixed, and already broken before this branch

`sandbox_escape.mjs` pinned an npx cache hash whose chromium build no longer exists here, so it **hard-failed instead of skipping** and the suite was red. It resolves playwright properly now and requires the browser to actually exist before choosing a copy. Behaviour changed from broken to working; no assertion weakened.

## Verified

`just verify` 23/23, `doctor` 0 failures, `just files-check` 0 FAIL, portal checks 0 FAIL, `bootstrap` idempotent, `just portability` PASS at 67/24. All four resolver rungs exercised on both implementations, including the drift warning.
