### PR TITLE
A fresh install has a user, and the SPA stops assuming one person's home directory

### DIFF
--- a/apps/portal-next/checks/repo-roots.mjs
+++ b/apps/portal-next/checks/repo-roots.mjs
@@ -1,0 +1,148 @@
+// Where does Bothy think it is checked out?
+//
+// This is the check for the two functions that replaced a hardcoded home
+// directory. The failure they exist to prevent is silent in both directions and
+// neither one raises: get the stack root wrong and every service in the stack is
+// filed under "Projects"; get the config tier's root table wrong and every patch
+// comes back "outside-roots" and blames the file.
+//
+// The cases that matter are the ones a second machine produces, which is exactly
+// what could not be tested while the value was a literal:
+//
+//   * a repo checked out somewhere else entirely
+//   * a sibling directory whose path is a PREFIX of this one
+//   * no container mounting the repo at all (before the first `just up`)
+//   * a service that mounts four roots vs one that mounts one
+//
+// Run from checks/run.sh, which compiles discover.ts next door.
+import { stackRootFrom, repoRootsOf, classify } from './discover.mjs';
+
+let fails = 0;
+const eq = (label, got, want) => {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  if (!ok) fails++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label.padEnd(58)} ${ok ? '' : `got ${JSON.stringify(got)} want ${JSON.stringify(want)}`}`);
+};
+
+const bind = (Source, Destination) => ({ Type: 'bind', Source, Destination });
+const svc = (service, mounts) => ({
+  Labels: { 'com.docker.compose.service': service }, Mounts: mounts,
+});
+
+// ── the stack root ──────────────────────────────────────────────────────────
+console.log('── the stack root, from whatever docker reports ─────────────────────');
+
+eq('a checkout in someone else\'s home',
+  stackRootFrom([svc('portal-files', [bind('/Users/ada/src/bothy', '/repos/stacks')])]),
+  '/Users/ada/src/bothy/');
+
+eq('a trailing slash is added, never doubled',
+  stackRootFrom([svc('portal-files', [bind('/srv/bothy/', '/repos/stacks')])]),
+  '/srv/bothy/');
+
+eq('the config tier is an equally good witness',
+  stackRootFrom([svc('bothy-config', [bind('/opt/bothy', '/repos/stacks')])]),
+  '/opt/bothy/');
+
+// The whole reason the value is not just "any bind mount": /repos/notes and
+// /repos/home are mounted too, and either would be a plausible-looking answer.
+eq('the OTHER repo mounts are not mistaken for it',
+  stackRootFrom([svc('portal-files', [
+    bind('/home/ada/claude-notes', '/repos/notes'),
+    bind('/home/ada', '/repos/home'),
+    bind('/home/ada/stacks', '/repos/stacks'),
+  ])]),
+  '/home/ada/stacks/');
+
+eq('a NAMED VOLUME at the same destination is not a host path',
+  stackRootFrom([{ Mounts: [{ Type: 'volume', Name: 'x', Source: '/var/lib/docker/volumes/x/_data', Destination: '/repos/stacks' }] }]),
+  null);
+
+eq('nothing mounts the repo -> null, not a guess',
+  stackRootFrom([svc('traefik', [bind('/var/run/docker.sock', '/var/run/docker.sock')])]),
+  null);
+
+eq('no containers at all -> null',        stackRootFrom([]), null);
+eq('called with nothing -> null',         stackRootFrom(), null);
+
+// ── the prefix trap ─────────────────────────────────────────────────────────
+//
+// The single most likely way to get this wrong, and the reason asDir() exists:
+// `/home/ada/stacks-old` starts with `/home/ada/stacks`. Without the trailing
+// slash a second checkout beside the first is classified as part of it.
+console.log('\n── a sibling checkout is not this one ───────────────────────────────');
+
+const ROOT = stackRootFrom([svc('portal-files', [bind('/home/ada/stacks', '/repos/stacks')])]);
+const inRepo = (cfg) => classify(
+  { Labels: { 'com.docker.compose.project': 'demo', 'com.docker.compose.project.config_files': cfg } },
+  ROOT,
+).groupKind;
+
+eq('a file in this repo is stack',        inRepo('/home/ada/stacks/edge/compose.yml'), 'stack');
+eq('a file in stacks-old is NOT',         inRepo('/home/ada/stacks-old/edge/compose.yml'), 'project');
+eq('a file elsewhere is a project',       inRepo('/home/ada/projects/cvops/compose.yml'), 'project');
+
+// ── what classify() does with null ──────────────────────────────────────────
+//
+// Asserted rather than left to a comment, because the honest fallback is not
+// obvious: with no root, "does this live in the repo" cannot be answered, and
+// answering "no" would file the whole stack as third-party. It answers 'stack'
+// for everything and keeps recognising Bothy itself by project name, so the
+// portal never misfiles the page you are reading while its file tier is down.
+console.log('\n── with no root known, nothing is misfiled as third-party ───────────');
+
+const noRoot = (proj, cfg) => classify(
+  { Labels: { 'com.docker.compose.project': proj, 'com.docker.compose.project.config_files': cfg } },
+  null,
+).groupKind;
+
+eq('a stack service stays stack',         noRoot('monitoring', '/anywhere/monitoring/compose.yml'), 'stack');
+eq('Bothy is still recognised as infra',  noRoot('bothy', '/anywhere/apps/bothy/compose.yml'), 'infra');
+eq('edge is still recognised as infra',   noRoot('edge', '/anywhere/edge/compose.yml'), 'infra');
+eq('a container with no compose labels',  classify({ Labels: {} }, null).group, 'unmanaged');
+eq('no container at all',                 classify(null, null).group, 'host');
+
+// ── the config tier's root table ────────────────────────────────────────────
+console.log('\n── one service\'s roots, and only that service\'s ──────────────────────');
+
+const BOX = [
+  svc('portal-files', [
+    bind('/home/ada/stacks', '/repos/stacks'),
+    bind('/home/ada/claude-notes', '/repos/notes'),
+    bind('/home/ada/projects', '/repos/projects'),
+    bind('/home/ada', '/repos/home'),
+  ]),
+  svc('bothy-config', [
+    bind('/home/ada/stacks', '/repos/stacks'),
+    bind('/home/ada/stacks/apps/bothy-config/audit', '/audit'),
+  ]),
+];
+
+// THE POINT OF NAMING A SERVICE. bothy-config accepts exactly one root; the file
+// tier mounts four. A shared table would offer `notes` and `projects` as patch
+// targets and collect a 400 from the service for each.
+eq('bothy-config declares only what IT mounts',
+  repoRootsOf(BOX, 'bothy-config'), { stacks: '/home/ada/stacks/' });
+
+eq('the file tier declares all four',
+  repoRootsOf(BOX, 'portal-files'), {
+    stacks: '/home/ada/stacks/',
+    notes: '/home/ada/claude-notes/',
+    projects: '/home/ada/projects/',
+    home: '/home/ada/',
+  });
+
+eq('a mount outside /repos is not a root',
+  Object.keys(repoRootsOf(BOX, 'bothy-config')).includes('audit'), false);
+
+eq('a NESTED path under /repos is not a root name',
+  repoRootsOf([svc('x', [bind('/a', '/repos/stacks/docs')])], 'x'), {});
+
+eq('the service is not running -> empty, and that is handled',
+  repoRootsOf(BOX, 'bothy-config-that-is-off'), {});
+
+eq('no containers -> empty',              repoRootsOf([], 'bothy-config'), {});
+
+console.log();
+console.log(fails ? `${fails} check(s) FAILED` : 'all pass');
+process.exit(fails ? 1 : 0);

--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -48,7 +48,7 @@ mv "$OUT/customThemes.js" "$OUT/user-themes-mod.mjs"
 mv "$OUT/pages/files/tree.js" "$OUT/wikilinks-mod.mjs"
 cp "$HERE/status-classifier.mjs" "$HERE/relations.mjs" "$HERE/redirect-table.mjs" \
    "$HERE/titles-table.mjs" "$HERE/theme-contract.mjs" "$HERE/user-themes.mjs" \
-   "$HERE/wikilinks.mjs" "$OUT/"
+   "$HERE/wikilinks.mjs" "$HERE/repo-roots.mjs" "$OUT/"
 
 echo "── truth table ─────────────────────────────────────────"
 node "$OUT/status-classifier.mjs"
@@ -64,6 +64,14 @@ node "$OUT/redirect-table.mjs"
 echo
 echo "── document titles ─────────────────────────────────────"
 node "$OUT/titles-table.mjs"
+
+echo
+echo "── where this repo is, asked of docker not assumed ─────"
+# The two functions that replaced a hardcoded home directory. Every case here is
+# a SECOND MACHINE - a different checkout path, a sibling directory that is a
+# prefix of it, nothing mounted yet - which is precisely what could not be tested
+# while the value was a literal.
+node "$OUT/repo-roots.mjs"
 
 echo
 echo "── this box, right now ─────────────────────────────────"

--- a/apps/portal-next/web/src/components/SystemName.tsx
+++ b/apps/portal-next/web/src/components/SystemName.tsx
@@ -86,19 +86,25 @@ export function SystemName({
   onDrift?: (drift: Drift | null) => void;
 }) {
   const { me, loading: sessionLoading, canAct } = useOperator();
-  const { refresh } = usePortal();
+  const { data, refresh } = usePortal();
 
   // Every container in the system, reduced to the two things the derivation
   // needs. Recomputed when the poll lands, which is what makes the observed side
   // of the drift comparison current rather than a snapshot of page load.
+  // `configRoots` comes from the POLL, not from `nodes`. It is bothy-config's
+  // mount table, and these nodes are one system's - on every page but Bothy's
+  // own, bothy-config is not among them, so deriving it here would leave the
+  // table empty and answer `outside-roots` for a file that is perfectly
+  // writable.
   const target = useMemo<ComposeTarget>(
     () => composeTarget(
       nodes
         .filter((n) => n.container)
         .map((n) => ({ container: n.container!.name, labels: n.container!.labels ?? {} })),
       PROJECT_TITLE_FIELD,
+      data.configRoots,
     ),
-    [nodes],
+    [nodes, data.configRoots],
   );
 
   const file = target.t === 'file' ? target : null;

--- a/apps/portal-next/web/src/lib/api.ts
+++ b/apps/portal-next/web/src/lib/api.ts
@@ -9,8 +9,9 @@
 // Docker is enrichment. allSettled, never all - partial results are first-class.
 
 import { useEffect, useRef, useState } from 'react';
-import { allPorts, merge, type Container, type PortRow, type Router, type PortalNode, type Service } from './discover';
+import { allPorts, merge, repoRootsOf, type Container, type PortRow, type Router, type PortalNode, type Service } from './discover';
 import { withDeclared, type CollectorPayload, type CollectorProject } from './projects';
+import type { RootPaths } from './config';
 
 // /system/df - per-image / per-container / per-volume disk usage. Read-only,
 // carries no Env (see edge/dynamic/portal-api.yml). Purely additive enrichment:
@@ -51,6 +52,13 @@ export interface PortalData {
   routers: Router[];
   nodes: PortalNode[];
   ports: PortRow[];
+  /** bothy-config's roots, root name -> host path, read off its bind mounts.
+   *  A whole-poll fact like `nodes` and `ports`: it comes from ONE container and
+   *  is then the answer for every system the page renders, so it is resolved
+   *  where the container list already is rather than re-derived per card. The
+   *  card that needs it (SystemName) only ever sees ITS OWN system's nodes, and
+   *  bothy-config is usually not one of them. */
+  configRoots: RootPaths;
   df: SystemDf | null;
   // Projects that declared themselves via project.dev.yml, resolved against
   // host state by the collector. The only source that can report a project
@@ -70,8 +78,8 @@ export interface PortalData {
 }
 
 const EMPTY: PortalData = {
-  routers: [], nodes: [], ports: [], df: null, projects: [], projectsAt: null,
-  errors: [], at: 0, fails: 0,
+  routers: [], nodes: [], ports: [], configRoots: {}, df: null, projects: [],
+  projectsAt: null, errors: [], at: 0, fails: 0,
 };
 
 class HttpError extends Error {
@@ -94,6 +102,7 @@ export interface LoadResult {
   routers: Router[];
   nodes: PortalNode[];
   ports: PortRow[];
+  configRoots: RootPaths;
   df: SystemDf | null;
   projects: CollectorProject[];
   projectsAt: number | null;
@@ -148,6 +157,9 @@ export async function loadAll(): Promise<LoadResult> {
       routers: R,
       nodes: withDeclared(merge(R, S, C), P?.projects ?? []),
       ports: allPorts(C),
+      // The service key in apps/bothy-config/compose.yml. Named rather than
+      // matched loosely on purpose - see the RootPaths comment in config.ts.
+      configRoots: repoRootsOf(C, 'bothy-config'),
       df: D,
       projects: P?.projects ?? [],
       projectsAt: P?.generatedAt ?? null,

--- a/apps/portal-next/web/src/lib/config.ts
+++ b/apps/portal-next/web/src/lib/config.ts
@@ -46,29 +46,34 @@
  *  three chances to typo something that fails as "not declared in this file". */
 export const PROJECT_TITLE_FIELD = 'dev.portal.project';
 
-/** Where each of bothy-config's roots lives on the host.
+/** Where each of bothy-config's roots lives on the host: root name -> host path.
  *
  *  The service answers in `{root, path}` pairs and a container tells us an
  *  ABSOLUTE host path, so somebody has to hold the mapping between them. It is
  *  policy - apps/bothy-config/policy.toml declares exactly one root, `stacks`,
- *  mounted at /repos/stacks from /home/devssh/stacks - and the browser has no
- *  way to ask for it: /healthz lists the root NAMES and is deliberately not
- *  routed, precisely so the field allowlist is not on the tailnet.
+ *  mounted at /repos/stacks - and the browser cannot ask the service for it:
+ *  /healthz lists the root NAMES and is deliberately not routed, precisely so
+ *  the field allowlist is not on the tailnet.
  *
- *  discover.ts holds the same string as `STACK_ROOT` and this does not import
- *  it, which is a duplication worth stating rather than hiding. They answer
- *  different questions: STACK_ROOT decides whether a compose file makes a
- *  container a "project" or a "stack service", and would still be right if
- *  bothy-config were deleted tomorrow. This one is the patch service's mount
- *  list. Sharing them would tie a classification rule to a write policy, and
- *  the import would cost this module the property the header opens with. */
-export const ROOT_PATHS: Readonly<Record<string, string>> = {
-  // Trailing slash on purpose: without it `/home/devssh/stacks-old/x.yml` would
-  // match `stacks` and resolve to the relative path `-old/x.yml`, which the
-  // service would then refuse for reasons that have nothing to do with the
-  // mistake that was made.
-  stacks: '/home/devssh/stacks/',
-};
+ *  THIS WAS A LITERAL - one entry, mapping `stacks` to the absolute path of
+ *  its author's own checkout - and it was therefore wrong on every machine but
+ *  one. A clone into any other directory matched no root, so every patch came
+ *  back `outside-roots` and the form said the compose file lived somewhere
+ *  Bothy could not reach, which was a statement about a hardcoded string rather
+ *  than about the file. It is now derived from what docker reports for that
+ *  container's bind mounts and threaded in from the poll; see repoRoots.ts for
+ *  why the mount table is the honest source.
+ *
+ *  DERIVED FROM bothy-config's MOUNTS SPECIFICALLY, not from any container that
+ *  happens to bind /repos/<name>. The file tier mounts four roots and this
+ *  service accepts one, so a shared table would offer `notes` and `projects` as
+ *  patch targets and collect a 400 from the service for each. A root exists here
+ *  only if the service that must open it is the one that mounted it.
+ *
+ *  Empty is a real value and is handled: it means bothy-config is not running,
+ *  in which case there is nothing to patch anyway and `outside-roots` - "this
+ *  file is not somewhere Bothy can write" - is the true answer. */
+export type RootPaths = Readonly<Record<string, string>>;
 
 const CONFIG_FILES = 'com.docker.compose.project.config_files';
 const COMPOSE_SERVICE = 'com.docker.compose.service';
@@ -119,9 +124,9 @@ export type ComposeTarget =
   | { t: 'no-compose'; container: string }
   | { t: 'outside-roots'; abs: string; container: string };
 
-function underRoot(abs: string): { root: string; path: string } | null {
-  for (const root of Object.keys(ROOT_PATHS)) {
-    const prefix = ROOT_PATHS[root];
+function underRoot(abs: string, rootPaths: RootPaths): { root: string; path: string } | null {
+  for (const root of Object.keys(rootPaths)) {
+    const prefix = rootPaths[root];
     if (abs.startsWith(prefix) && abs.length > prefix.length) {
       return { root, path: abs.slice(prefix.length) };
     }
@@ -132,6 +137,7 @@ function underRoot(abs: string): { root: string; path: string } | null {
 export function composeTarget(
   bearers: readonly LabelBearer[],
   field: string = PROJECT_TITLE_FIELD,
+  rootPaths: RootPaths = {},
 ): ComposeTarget {
   if (bearers.length === 0) return { t: 'no-container' };
 
@@ -151,7 +157,7 @@ export function composeTarget(
 
   const candidates = raw.split(',').map((s) => s.trim()).filter(Boolean);
   for (const abs of candidates) {
-    const hit = underRoot(abs);
+    const hit = underRoot(abs, rootPaths);
     // The FIRST candidate inside a root wins, not the first candidate. A project
     // brought up as `-f compose.yml -f ~/local-override.yml` has one file this
     // service may open and one it may not, and refusing the whole system because

--- a/apps/portal-next/web/src/lib/discover.ts
+++ b/apps/portal-next/web/src/lib/discover.ts
@@ -32,7 +32,6 @@
 // rule and would be true again the moment anyone wrote one. What is gone is the
 // assumption that a host belongs to one specific namespace.
 
-const STACK_ROOT = '/home/devssh/stacks/';
 // 'bothy' is this app itself - web tier, editor tier and socket-proxy, all one
 // compose project since 2026-08-16. It was three ('portal', 'portal-next',
 // 'portal-files'), which made Bothy render as three separate cards in its own
@@ -558,12 +557,137 @@ export function nest(host: string | null): Nesting {
   return host ? { depth: null, parent: null, leaf: host } : NO_NESTING;
 }
 
+// ── Where this repository actually is ───────────────────────────────────────
+//
+// THE PROBLEM THESE REPLACE. Two modules held this repo's absolute path as a
+// string literal - this file as `STACK_ROOT`, config.ts as `ROOT_PATHS`. Both
+// were correct on exactly one machine. Somebody who clones Bothy into
+// ~/src/bothy got a portal that filed every one of its OWN services under
+// "Projects" (nothing starts with the literal) and a config tier that refused
+// every patch (no root matched), with no error anywhere pointing at the cause.
+//
+// THE FIX IS NOT A NEW SETTING. Adding BOTHY_ROOT to .env trades a wrong default
+// for a required one, and a value that has to be kept in step with where the
+// repo actually is goes stale the first time somebody moves it - the same class
+// of bug with a longer fuse.
+//
+// DOCKER ALREADY KNOWS. The compose fragments mount the repo RELATIVELY -
+// `- ../..:/repos/stacks:rw` in apps/portal-files/compose.yml - and compose
+// resolves that against the fragment's own directory when it creates the
+// container, so a running container carries the absolute host path as a fact
+// computed on the machine it is running on:
+//
+//     "Mounts": [{ "Type": "bind",
+//                  "Source": "<wherever this repo is>",   <- derived, not declared
+//                  "Destination": "/repos/stacks" }]
+//
+// /containers/json returns Mounts and the socket-proxy exposes them (this file
+// has read that array for volume sizes for a while), so the value arrives with
+// the poll the portal already makes: no extra request, no variable to set, and
+// nothing to update after a `mv`.
+//
+// `/repos/<name>` IS THE MAPPING. That is the convention every root in this
+// stack is mounted under, so the destination names the root and the source names
+// the host path - exactly the pair ROOT_PATHS used to spell out by hand.
+//
+// WHY THEY LIVE HERE AND NOT IN A repoRoots.ts. checks/run.sh compiles this file
+// with a bare `tsc <file>`, which works only while it imports nothing - the
+// property that whole truth-table harness is built on. A separate module would
+// have been tidier and would have cost the harness. They are also at home here:
+// deriving a whole-list fact from the container array is what projectNames() and
+// declaredOneShots() beside them already do.
+
+// Trailing slash, always, and never a doubled one. Load-bearing for the prefix
+// tests both callers do: without it a sibling checkout whose path merely STARTS
+// with this one - `<root>-old/x.yml` - is filed under this repo, or resolved to
+// the relative path `-old/x.yml` and then refused for a reason that has nothing
+// to do with the mistake that was made.
+const asDir = (p: string): string => (p.endsWith('/') ? p : `${p}/`);
+
+const REPOS_MOUNT = /^\/repos\/([^/]+)$/;
+
+/**
+ * Where the Bothy repository is checked out, or null if nothing says.
+ *
+ * ANY container that binds `/repos/stacks`, not a named service, because this
+ * asks about the REPOSITORY rather than about one tier's policy: the file tier
+ * and the config tier both mount it from the same relative path, so either is an
+ * equally good witness, and demanding a specific one would lose the answer
+ * exactly when that tier is the thing that is down.
+ *
+ * NULL IS A REAL ANSWER - true before the first `just up`, and true again if the
+ * file tier is removed - and classify() handles it rather than substituting a
+ * guess. See the note there for what it decides to do with it.
+ */
+export function stackRootFrom(containers: readonly Container[] = []): string | null {
+  for (const c of containers) {
+    for (const m of c.Mounts || []) {
+      if (m.Type === 'bind' && m.Source && m.Destination === '/repos/stacks') {
+        return asDir(m.Source);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * The host paths behind one compose service's `/repos/<name>` binds:
+ * root name -> host path. This is what config.ts needs, and it is asked of a
+ * NAMED service because a root there is a WRITE TARGET - see the RootPaths
+ * comment in that file for why sharing one table across services is wrong.
+ *
+ * Keyed on `com.docker.compose.service` rather than the container name: the
+ * service key is written in the yaml and is stable, while the container name
+ * carries a project prefix and a replica suffix that both change with how it was
+ * brought up.
+ *
+ * Binds only. A named volume mounted at /repos/x has no host path, and taking
+ * its docker-internal directory would offer a place on this disk that is not the
+ * one anybody means.
+ */
+export function repoRootsOf(
+  containers: readonly Container[] = [],
+  service: string,
+): Readonly<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const c of containers) {
+    if (c.Labels?.['com.docker.compose.service'] !== service) continue;
+    for (const m of c.Mounts || []) {
+      if (m.Type !== 'bind' || !m.Source) continue;
+      const hit = REPOS_MOUNT.exec(m.Destination || '');
+      if (hit) out[hit[1]] = asDir(m.Source);
+    }
+    // First matching container wins: a service scaled to several replicas has
+    // the same mounts on each, so there is nothing to merge and reading the rest
+    // could only introduce disagreement.
+    if (Object.keys(out).length) break;
+  }
+  return out;
+}
+
 // ── Pure: classification ────────────────────────────────────────────────────
 
 // project vs stack vs infra, from the compose file's location on disk.
 // No hand-maintained list: a project is simply a compose file that doesn't
-// live under ~/stacks.
-export function classify(container?: Container | null): Classification {
+// live under the Bothy repo.
+//
+// `stackRoot` is passed in rather than read from a constant: it is a fact about
+// the machine, derived from what docker reports for the repo's own bind mount
+// (see stackRootFrom below), and it used to be this author's home directory
+// hardcoded here. Threaded as a parameter so this stays a pure function of its inputs -
+// merge() and allPorts() resolve it ONCE from the container list, the same way
+// they already resolve projectNames() and declaredOneShots().
+//
+// NULL MEANS "NOTHING SAYS", and the honest reading of that is not "everything
+// is third-party" - it is that the stack/project split cannot be made. Bothy is
+// still recognised by project name (INFRA_PROJECTS below) so the portal does not
+// misfile ITSELF while its file tier is down; everything else falls to 'stack',
+// the answer that is right for every container on a box where this is the only
+// repo, and wrong only in the direction of under-claiming.
+export function classify(
+  container?: Container | null,
+  stackRoot?: string | null,
+): Classification {
   // No container = an @file host process. It has no compose labels to classify,
   // so the caller substitutes the hostname's own leaf as the group (see
   // makeNode). 'host' survives only as the last resort for a route whose
@@ -574,10 +698,10 @@ export function classify(container?: Container | null): Classification {
   const proj = labels['com.docker.compose.project'];
   // minikube and anything else started outside compose has neither.
   if (!cfg || !proj) return { group: 'unmanaged', groupKind: 'infra' };
+  const kind = INFRA_PROJECTS.has(proj) ? 'infra' : 'stack';
+  if (!stackRoot) return { group: proj, groupKind: kind };
   const first = cfg.split(',')[0];
-  if (first.startsWith(STACK_ROOT)) {
-    return { group: proj, groupKind: INFRA_PROJECTS.has(proj) ? 'infra' : 'stack' };
-  }
+  if (first.startsWith(stackRoot)) return { group: proj, groupKind: kind };
   return { group: proj, groupKind: 'project' };
 }
 
@@ -638,6 +762,7 @@ export function defaultName(
   host: string | null,
   container?: Container | null,
   names: Map<string, string> = new Map(),
+  stackRoot?: string | null,
 ): string {
   const n = nest(host);
   const proj = container?.Labels?.['com.docker.compose.project'];
@@ -665,7 +790,7 @@ export function defaultName(
   if (n.parent) return `${nice(n.parent)} · ${title}`;
   // Unrouted but owned by a project: cvops-postgres-1 -> "CVOps · Postgres",
   // so it can't be confused with the stack's own Postgres in another panel.
-  if (!host && proj && classify(container).groupKind === 'project' && titleCase(proj) !== title) {
+  if (!host && proj && classify(container, stackRoot).groupKind === 'project' && titleCase(proj) !== title) {
     return `${nice(proj)} · ${title}`;
   }
   return title;
@@ -830,8 +955,9 @@ export function merge(
 ): PortalNode[] {
   const svcByKey = new Map(services.map((s) => [s.name, s] as const));
   const names = projectNames(containers);
-  // Whole-list fact, so it is resolved once here rather than re-derived per node.
+  // Whole-list facts, so they are resolved once here rather than re-derived per node.
   const oneShots = declaredOneShots(containers);
+  const stackRoot = stackRootFrom(containers);
 
   // devnet ONLY. Traefik runs --providers.docker.network=devnet so every
   // docker-provider server URL is a devnet IP. Indexing all networks would
@@ -925,6 +1051,7 @@ export function merge(
         container: canonical.container,
         names,
         oneShots,
+        stackRoot,
         kind: canonical.container ? 'routed' : 'orphan-route',
         aliases: rest.map((c) => c.host),
       }),
@@ -956,7 +1083,7 @@ export function merge(
   // visually, so honesty costs less than the blind spot did.
   for (const c of containers) {
     if (claimed.has(c.Id)) continue;
-    nodes.push(makeNode({ route: null, host: null, container: c, names, oneShots, kind: 'unrouted' }));
+    nodes.push(makeNode({ route: null, host: null, container: c, names, oneShots, stackRoot, kind: 'unrouted' }));
   }
 
   return nodes;
@@ -977,6 +1104,13 @@ interface MakeNodeArgs {
    * can. Defaulted so the existing tests and any other caller stay valid.
    */
   oneShots?: Set<string>;
+  /**
+   * Where this repository is checked out on the host, or null if no running
+   * container reports it. The other whole-list fact, resolved once in merge()
+   * for the same reason as `oneShots`: it comes from a bind mount on ONE
+   * container and is then true for every node built from the poll.
+   */
+  stackRoot?: string | null;
 }
 
 function makeNode({
@@ -988,13 +1122,14 @@ function makeNode({
   names = new Map(),
   aliases = [],
   oneShots = new Set(),
+  stackRoot = null,
 }: MakeNodeArgs): PortalNode {
   const n = nest(host);
-  const cls = classify(container);
+  const cls = classify(container, stackRoot);
   const L = container?.Labels || {};
   const pick = <T>(key: string, fallback: T): string | T => L[`dev.portal.${key}`] ?? fallback;
 
-  const name = pick('name', defaultName(host, container, names));
+  const name = pick('name', defaultName(host, container, names, stackRoot));
   const path = pick('path', '');
   const browsable = isBrowsable(host, container);
 
@@ -1110,8 +1245,9 @@ export function allPorts(containers: Container[] = []): PortRow[] {
   // Same map merge() uses, so a port row and a service row can never disagree
   // about what a system is called.
   const names = projectNames(containers);
+  const stackRoot = stackRootFrom(containers);
   for (const c of containers) {
-    const cls = classify(c);
+    const cls = classify(c, stackRoot);
     for (const p of portsOf(c)) {
       rows.push({
         ...p,

--- a/auth/compose.yml
+++ b/auth/compose.yml
@@ -324,6 +324,10 @@ services:
     environment:
       KC_ADMIN_USER: ${KEYCLOAK_ADMIN_USER:-admin}
       KC_ADMIN_PASSWORD: ${DEV_LOGIN_PASSWORD:?set DEV_LOGIN_PASSWORD in .env}
+      # The seed identity is the box's one unified dev login, so a fresh
+      # installer has exactly one credential to know rather than two.
+      DEV_LOGIN_USER: ${DEV_LOGIN_USER:?set DEV_LOGIN_USER in .env}
+      DEV_LOGIN_PASSWORD: ${DEV_LOGIN_PASSWORD:?set DEV_LOGIN_PASSWORD in .env}
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |
@@ -338,6 +342,64 @@ services:
           --user "$$KC_ADMIN_USER" --password "$$KC_ADMIN_PASSWORD"
         /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE
         echo "master realm: sslRequired=NONE (plain HTTP admin console over the tailnet)"
+
+        # ── the first user ────────────────────────────────────────────────
+        #
+        # WITHOUT THIS A FRESH INSTALL REFUSES EVERYONE. realm-devbox.json
+        # declares four roles and ZERO users, and there is no defaultRole
+        # block, so every gated route - the whole file tier, the config tier,
+        # every action - answers 403 to the only person who has just installed
+        # it. The product looks broken rather than unconfigured.
+        #
+        # HERE AND NOT IN THE REALM FILE, and that is the load-bearing choice.
+        # The realm import runs at FIRST BOOT ONLY: add a user to that JSON on
+        # an existing install and nothing happens, silently, which is the trap
+        # its own volume comment already spends a paragraph on. This service
+        # re-runs on every `just up-auth`, so it is the only place that is
+        # correct on both a new box and an old one. It also keeps a seed
+        # identity out of a file that is public.
+        SEED="$$DEV_LOGIN_USER"
+        # LOOK UP BY EMAIL AS WELL AS USERNAME, and resolve the real username
+        # from whatever is found. Searching only by username was the first
+        # version and it broke on the box that already had an account: the
+        # existing user's USERNAME is a short name and the seed address is its
+        # EMAIL, so the query found nothing, `create` then failed on email
+        # uniqueness, and `set -e` aborted the script before any role was
+        # granted. A seeding step that breaks re-running on a configured box is
+        # worse than one that does nothing there.
+        WHO=$$(/opt/keycloak/bin/kcadm.sh get users -r devbox \
+                 -q email="$$SEED" --fields username --format csv --noquotes | head -1)
+        if [ -z "$$WHO" ]; then
+          WHO=$$(/opt/keycloak/bin/kcadm.sh get users -r devbox \
+                   -q username="$$SEED" --fields username --format csv --noquotes | head -1)
+        fi
+        if [ -z "$$WHO" ]; then
+          /opt/keycloak/bin/kcadm.sh create users -r devbox \
+            -s username="$$SEED" -s email="$$SEED" \
+            -s emailVerified=true -s enabled=true
+          /opt/keycloak/bin/kcadm.sh set-password -r devbox \
+            --username "$$SEED" --new-password "$$DEV_LOGIN_PASSWORD"
+          WHO="$$SEED"
+          echo "devbox realm: created $$WHO"
+        else
+          echo "devbox realm: $$WHO already exists - leaving their password alone"
+        fi
+
+        # ROLES ARE RE-ASSERTED EVERY RUN; the password is not. Granting a role
+        # somebody already holds is a no-op, so re-running restores a role
+        # revoked by accident in the console - the roles are declared in this
+        # repo, not in a console, and that is the property worth having. A
+        # password is the opposite: someone who changed theirs must not have it
+        # reset from under them on the next `just up-auth`, which is why
+        # set-password sits inside the create branch above.
+        #
+        # `shell` is DELIBERATELY NOT GRANTED. realm-devbox.json explains that
+        # the four roles are non-composite precisely so an arbitrary terminal
+        # cannot be reached by holding another one, and seeding it would undo
+        # that in the one place nobody would look.
+        /opt/keycloak/bin/kcadm.sh add-roles -r devbox --uusername "$$WHO" \
+          --rolename viewer --rolename editor --rolename operator
+        echo "devbox realm: $$WHO holds viewer, editor, operator (never shell)"
     deploy:
       resources:
         limits:

--- a/scripts/checks/portability.baseline
+++ b/scripts/checks/portability.baseline
@@ -6,8 +6,6 @@
 #
 # file<TAB>kind<TAB>count
 apps/portal-next/compose.yml	tailnet-ip	1
-apps/portal-next/web/src/lib/config.ts	home-path	3
-apps/portal-next/web/src/lib/discover.ts	home-path	1
 apps/portal-next/web/vite.config.ts	tailnet-ip	1
 auth/compose.yml	tailnet-ip	2
 docs/kb/access.md	tailnet-ip	6


### PR DESCRIPTION
Two independent reasons somebody who is not the author cannot run this, both found by the portability pass.

## 1. A fresh install refuses the person who just installed it

`realm-devbox.json` declares four roles and **zero users**, and there is no `defaultRole` block — so on a new box every gated route answers 403 to the only person there. The whole file tier, the config tier, every action. It looks broken rather than unconfigured, and the fix is one step nobody knows to take.

Seeding goes in `keycloak-init`, which already exists, already waits for Keycloak, already authenticates with kcadm, and already applies a fix the realm file structurally cannot express.

**Not in the realm file, and that is the load-bearing choice.** The import runs at **first boot only** — add a user to that JSON on an existing install and nothing happens, silently. This service re-runs on every `just up-auth`, so it is the only place correct on a new box *and* an old one. It also keeps a seed identity out of a public file.

**Roles are re-asserted every run; the password is not.** Granting a role somebody already holds is a no-op, so re-running restores a role revoked by accident in the console — roles are declared in this repo, not in a console. Proved by revoking `operator` with kcadm and watching `just up-auth` bring it back. A password is the opposite, so `set-password` runs only on create.

`shell` is deliberately not granted. The four roles are non-composite precisely so an arbitrary terminal cannot be reached by holding another.

**The first version broke the box it ran on**, which is worth recording. It looked the user up by *username* only; on a box that already had an account the seed address is its **email**, so the query found nothing, `create` failed on email uniqueness, `set -e` aborted before `add-roles`, and the container exited 1. It now looks up by email then username and resolves the real username from whatever it finds.

## 2. The SPA had this checkout's path hardcoded, twice

`discover.ts` as `STACK_ROOT`, `config.ts` as `ROOT_PATHS` — the last two places in the SPA that could only be right on one machine. Clone Bothy anywhere else and nothing errors; it is wrong quietly in two places:

- `classify()` files **every stack service** under "Projects", so the Overview claims nine third-party projects and no stack.
- `composeTarget()` answers `outside-roots` for every system, and the name form says the compose file "is not somewhere Bothy can reach" — a statement about a hardcoded string, presented as a fact about the file.

**Not solved with a setting.** `BOTHY_ROOT` in `.env` trades a wrong default for a required one, and goes stale the first time somebody moves the repo.

**Docker already knows.** The compose fragments mount the repo *relatively* (`- ../..:/repos/stacks:rw`) and compose resolves that against the fragment's own directory, so the container carries the absolute host path as a fact computed on the machine it runs on. `/containers/json` returns it in `Mounts`, which the socket-proxy already exposes. No extra request, no variable, nothing to update after a `mv`. `/repos/<name>` is the convention every root is mounted under, so the destination names the root and the source names the path — exactly the pair `ROOT_PATHS` spelled out by hand.

Two callers, two questions, so two functions: `stackRootFrom()` accepts *any* container binding `/repos/stacks` (either tier is an equally good witness, and demanding one loses the answer when that tier is down); `repoRootsOf()` takes a *named* service, because a root there is a write target and the file tier mounts four roots while bothy-config accepts one.

Threaded as parameters rather than module state, and resolved once per poll beside `projectNames()` and `declaredOneShots()`. **Null is handled**: before the first `just up` nothing mounts the repo, and answering "not in the repo" would file the whole stack as third-party — so Bothy and edge stay recognised by project name and everything else falls to `stack`.

They live in `discover.ts` rather than a tidier `repoRoots.ts` because `checks/run.sh` compiles that file with a bare `tsc <file>`, which works only while it imports nothing.

## Checks

`checks/repo-roots.mjs`, 22 cases — the check that could not be written while the value was a literal, because **every case is a second machine**: a checkout in another home, a trailing slash added but never doubled, `/repos/notes` and `/repos/home` not mistaken for the repo, a named volume at the same destination rejected, and the prefix trap `asDir()` exists for (a sibling `<root>-old` must not be filed under `<root>`).

Proved it can fail: made `asDir` the identity function and six cases failed, including the sibling.

## Verified

- `keycloak-init` exits 0, leaves the existing password alone, re-asserts roles; a real login returns viewer/editor/operator.
- Derived values equal the literals they replace.
- Overview still shows 3 projects / 6 stack / edge + Bothy infra.
- The name form resolves `stacks / edge/compose.yml` and `stacks / monitoring/compose.yml`.
- 23/23 `just verify`, `files-check` clean, 292/292 harness, portability baseline **loses** both entries rather than accepting them.