### PR TITLE
A save no longer changes who can read the file

### DIFF
--- a/apps/portal-files/app.py
+++ b/apps/portal-files/app.py
@@ -1380,6 +1380,35 @@ class Handler(BaseHTTPRequestHandler):
             try:
                 with os.fdopen(tmpfd, "w", encoding="utf-8") as fh:
                     fh.write(content)
+                # ── THE MODE HAS TO BE PUT BACK ──────────────────────────────
+                #
+                # mkstemp creates 0600 - deliberately, because a temp file's
+                # content is nobody else's business - and os.replace PRESERVES
+                # the temp file's mode. So without this, every save through this
+                # service silently made its file owner-only, INCLUDING files that
+                # were 0644 a moment earlier. Editing a file changed who could
+                # read it, and nothing anywhere said so.
+                #
+                # It stayed invisible because this service reads back as the same
+                # uid it writes as, so every check here passed. It only surfaces
+                # when a DIFFERENT process has to read the file - which is
+                # exactly what a custom theme is: written here, served by nginx.
+                # A theme saved in the editor appeared in the picker (the
+                # directory is listable) and then 403'd when applied, because
+                # nginx could not read 0600. That was the bug report.
+                #
+                # OVERWRITE KEEPS THE FILE'S OWN MODE, so a deliberately
+                # restrictive file stays restrictive - replacing 0600 with 0644
+                # because someone edited it would be the same bug pointing the
+                # other way. A NEW file gets what a plain open() would have given
+                # it, 0666 masked by the process umask, so it matches everything
+                # else in the directory.
+                try:
+                    os.chmod(tmp, stat.S_IMODE(os.stat(res.abspath).st_mode))
+                except FileNotFoundError:
+                    cur = os.umask(0)
+                    os.umask(cur)
+                    os.chmod(tmp, 0o666 & ~cur)
                 os.replace(tmp, res.abspath)
             except BaseException:
                 # Never leave the temp behind - it would be listed and served as

--- a/apps/portal-files/checks/save_semantics.py
+++ b/apps/portal-files/checks/save_semantics.py
@@ -107,6 +107,55 @@ r = s.post(f"{API}/write", json={"root": "notes", "path": F,
                                  "content": "# no basemtime\n"}, timeout=20)
 check("write without baseMtime still succeeds", r.status_code == 200, f"got {r.status_code}")
 
+# ── the mode a save leaves behind ───────────────────────────────────────────
+#
+# tempfile.mkstemp() creates 0600 and os.replace PRESERVES the temp file's mode,
+# so the atomic-write path silently made every file it touched owner-only -
+# including files that were world-readable a moment before. Editing a file
+# changed who could read it, and nothing said so.
+#
+# IT PASSED EVERY CHECK HERE FOR AS LONG AS IT EXISTED, because this service
+# reads back as the same uid it writes as. It only surfaces when ANOTHER process
+# has to read the file, which is exactly what a custom theme is: written through
+# this API, served by nginx. A theme saved in the editor showed up in the picker
+# (the directory is listable) and then 403'd when applied.
+#
+# So the assertion is about the MODE, not about readability - a check that only
+# re-reads through this API is the check that missed it in the first place.
+print("\n── a save does not change who can read the file ─────────────────────")
+MODE_F = "_mode-probe.md"
+mode_path = f"{REPO}/{MODE_F}"
+try:
+    r = s.post(f"{API}/write", json={"root": "notes", "path": MODE_F,
+                                     "content": "probe\n"}, timeout=20)
+    got = os.stat(mode_path).st_mode & 0o777 if os.path.exists(mode_path) else 0
+    # What a plain open() would have produced, so it matches its neighbours
+    # rather than a number written out here - the umask is the machine's to set.
+    cur = os.umask(0); os.umask(cur)
+    want = 0o666 & ~cur
+    check("a NEW file gets the ordinary mode, not mkstemp's 0600",
+          got == want, f"got {oct(got)}, want {oct(want)}")
+
+    # The same bug pointing the other way: a deliberately restrictive file must
+    # not be flung open to everyone just because somebody edited it.
+    os.chmod(mode_path, 0o600)
+    mt = int(os.stat(mode_path).st_mtime)
+    s.post(f"{API}/write", json={"root": "notes", "path": MODE_F,
+                                 "content": "probe 2\n", "baseMtime": mt}, timeout=20)
+    got = os.stat(mode_path).st_mode & 0o777
+    check("an OVERWRITE keeps the file's own mode (0600 stays 0600)",
+          got == 0o600, f"got {oct(got)}")
+
+    os.chmod(mode_path, 0o644)
+    mt = int(os.stat(mode_path).st_mtime)
+    s.post(f"{API}/write", json={"root": "notes", "path": MODE_F,
+                                 "content": "probe 3\n", "baseMtime": mt}, timeout=20)
+    got = os.stat(mode_path).st_mode & 0o777
+    check("...and 0644 stays 0644", got == 0o644, f"got {oct(got)}")
+finally:
+    if os.path.exists(mode_path):
+        os.remove(mode_path)
+
 print("\n── cleanup ─────────────────────────────────────────────────────────")
 os.remove(f"{REPO}/{F}")
 check("probe file removed", not os.path.exists(f"{REPO}/{F}"))


### PR DESCRIPTION
Found by a 403 in the browser console: a custom theme saved in the editor appeared in the picker and then refused to load.

## The bug

`tempfile.mkstemp()` creates **0600** — correctly, a half-written temp file is nobody else's business — and `os.replace` **preserves the temp file's mode**. So the atomic-write path, which exists to make saves safe, was silently making every file it touched owner-only, *including files that were world-readable a moment earlier*.

Editing a file changed its permissions, and nothing said so.

## Why no check caught it

This service reads back as the same uid it writes as, so every assertion in the suite passed for as long as the bug existed. It only surfaces when a **different process** has to read the file — which is exactly what a custom theme is: written through this API, served by nginx. The directory is listable, so the theme showed up in the picker; nginx then couldn't read 0600, so applying it gave a 403 on a file that is plainly right there.

Confirmed on the box before changing anything:

```
-rw-------  deep.css            <- written by the editor
-rw-r--r--  solarized-dark.css  <- arrived by other means
-rw-r--r--  README.md
```

## The fix

- **New file** → what a plain `open()` would have given it: `0666 & ~umask`, so it matches its neighbours rather than a number hardcoded here.
- **Overwrite** → keeps the file's **own** mode. Forcing 0644 on save would be the same bug pointing the other way: a file somebody deliberately restricted must not be flung open because it got edited.

The `0600` in `safepath.py` is untouched and correct — those are snapshots, internal to this service, never read by anything else, and they can hold the contents of any file including a sensitive one.

## The check

Three cases in `save_semantics.py`, asserting the **mode** rather than readability — because a check that re-reads through this API is precisely the check that missed this:

- a new file gets the ordinary mode, not mkstemp's 0600
- an overwrite of a 0600 file leaves it 0600
- an overwrite of a 0644 file leaves it 0644

**Proved it can fail:** reverted the fix in the running container and two of the three went red (new file 0600; 0644 downgraded to 0600).

## Verified

`just files-check` exit 0, and a real save round-trip through the API now yields 0644 / 0600-kept / 0644-kept, with nginx serving the result 200.