### PR TITLE
Elsewhere and Upgrade: install at awkward paths, and prove a pull keeps your data

### DIFF
--- a/.github/workflows/elsewhere.yml
+++ b/.github/workflows/elsewhere.yml
@@ -1,0 +1,67 @@
+# Does Bothy install somewhere that is not this author's ~/stacks?
+#
+# The install job proves Bothy installs. It proves it at /tmp/bothy, every time,
+# which is one path shape - short, no spaces, three levels from the root. Every
+# portability bug this repo has had looked fine at exactly one path.
+#
+# So this runs THE SAME JOB at paths chosen to be awkward. It is `uses:` rather
+# than a copy on purpose: a second install job drifts from the real one within a
+# month and then proves something about a workflow nobody runs.
+#
+# ── the paths, and what each one is for ─────────────────────────────────────
+#
+# A SPACE IN THE PATH is the one most likely to be broken right now and the
+# cheapest to check. This repo is shell scripts nearly all the way down -
+# bootstrap.sh, box-addr.sh, env.sh, the four checks/run.sh - and an unquoted
+# "$VAR" survives every test at /tmp/bothy and splits into two arguments the
+# first time somebody clones into "~/My Projects/bothy". It is not hypothetical
+# here: docs/brand/ already carries a filename with a space in it.
+#
+# A DEEP NESTED PATH catches the other half: anything that counted directory
+# levels rather than resolving them. The compose fragments mount the repo with
+# `- ../..:/repos/stacks`, which is correct because compose resolves it against
+# the fragment's own directory - but that claim has only ever been exercised at
+# one depth.
+#
+# ── why nightly and not on every PR ─────────────────────────────────────────
+#
+# Each row is a full 4-12 minute install of ~26 containers. On every PR that is
+# three of them for a property that changes about once a quarter. Nightly on
+# main catches it within a day of landing, which is the right trade for a
+# property nobody edits on purpose. workflow_dispatch is there for when somebody
+# HAS edited path handling and wants to know before merging.
+name: Elsewhere
+
+on:
+  schedule:
+    # 03:00 UTC. Nothing else runs then, and a failure is waiting in the morning.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  paths:
+    name: Install at ${{ matrix.label }}
+    strategy:
+      # NEVER fail-fast. The whole value is learning which path shapes break, and
+      # cancelling the other two the moment one goes red throws that away - you
+      # would learn "something about paths is broken" and have to run it again to
+      # find out what.
+      fail-fast: false
+      matrix:
+        include:
+          - label: a path with a space in it
+            dir: /tmp/bothy elsewhere/my checkout
+          - label: a deeply nested path
+            dir: /tmp/bothy-deep/one/two/three/four/five/six/checkout
+          # The ordinary path too, in the same run. Without it a nightly failure
+          # is ambiguous: it could be the path, or it could be something that
+          # broke on main since the last push - and telling those apart is the
+          # difference between a portability bug and an ordinary regression.
+          - label: the ordinary path (control)
+            dir: /tmp/bothy
+    uses: ./.github/workflows/install.yml
+    with:
+      dir: ${{ matrix.dir }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -38,12 +38,24 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Callable, so the awkward-path runs in elsewhere.yml are THIS job with one
+  # value changed rather than a second copy of it. A copied install job drifts
+  # from the real one and then proves something about a workflow nobody runs.
+  workflow_call:
+    inputs:
+      dir:
+        description: Where to clone and install. The default is the ordinary case.
+        type: string
+        required: false
+        default: /tmp/bothy
 
 permissions:
   contents: read
 
 concurrency:
-  group: install-${{ github.ref }}
+  # The directory is part of the key: two awkward-path runs are different work,
+  # and cancelling one because another started would silently halve the matrix.
+  group: install-${{ github.ref }}-${{ inputs.dir || 'default' }}
   cancel-in-progress: true
 
 jobs:
@@ -51,6 +63,15 @@ jobs:
     name: Clone it, start it, run every suite against it
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      # `inputs` is empty on push and pull_request - defaults only apply to
+      # workflow_call and workflow_dispatch - so the fallback is not decoration.
+      # Without it the path is EMPTY on every PR and every step runs in the wrong
+      # place, which is a failure that reads like the install being broken.
+      #
+      # Quoted everywhere it is used below, because the whole point of the
+      # elsewhere matrix is to hand this a path with a space in it.
+      BOTHY_DIR: ${{ inputs.dir || '/tmp/bothy' }}
 
     steps:
       # Checked out only so the workflow has the repo's scripts available for
@@ -106,7 +127,8 @@ jobs:
       - name: Clone into an empty directory
         run: |
           set -euo pipefail
-          git clone --no-hardlinks "$GITHUB_WORKSPACE/workspace" /tmp/bothy
+          mkdir -p "$(dirname "$BOTHY_DIR")"
+          git clone --no-hardlinks "$GITHUB_WORKSPACE/workspace" "$BOTHY_DIR"
           # No `git checkout <sha>` after this. For a pull_request, checkout@v7
           # leaves HEAD DETACHED at the merge commit, and the instinct is to
           # re-checkout that SHA in the clone - where it does not exist, so the
@@ -115,9 +137,9 @@ jobs:
           # detached HEAD correctly on its own; verified against a source repo
           # detached at a commit no branch pointed to.
           want=$(git -C "$GITHUB_WORKSPACE/workspace" rev-parse HEAD)
-          got=$(git -C /tmp/bothy rev-parse HEAD)
+          got=$(git -C "$BOTHY_DIR" rev-parse HEAD)
           [ "$want" = "$got" ] || { echo "FAIL  clone is at $got, workspace at $want"; exit 1; }
-          git -C /tmp/bothy log --oneline -1
+          git -C "$BOTHY_DIR" log --oneline -1
 
       - name: The address a container can also reach
         run: |
@@ -130,7 +152,7 @@ jobs:
       # THE README, VERBATIM. If this ever needs a line the README does not have,
       # the README is wrong and this job is right to fail.
       - name: cp .env.example .env  &&  just up
-        working-directory: /tmp/bothy
+        working-directory: ${{ env.BOTHY_DIR }}
         run: |
           set -euo pipefail
           cp .env.example .env
@@ -138,7 +160,7 @@ jobs:
 
       # ── did the install actually do what it claims? ───────────────────────
       - name: Five secrets, generated, distinct, and the right shape
-        working-directory: /tmp/bothy
+        working-directory: ${{ env.BOTHY_DIR }}
         run: |
           set -euo pipefail
           fail=0
@@ -180,7 +202,7 @@ jobs:
           exit $fail
 
       - name: Running it twice changes nothing
-        working-directory: /tmp/bothy
+        working-directory: ${{ env.BOTHY_DIR }}
         run: |
           set -euo pipefail
           before=$(md5sum .env | cut -d' ' -f1)
@@ -221,12 +243,12 @@ jobs:
       # --strict remains right for a mature box, which is where it is used.
       - name: Health sweep (reported, not gated - see comment)
         if: always()
-        working-directory: /tmp/bothy
+        working-directory: ${{ env.BOTHY_DIR }}
         run: just doctor
 
       - name: Access and routing (23 checks)
         if: always()
-        working-directory: /tmp/bothy
+        working-directory: ${{ env.BOTHY_DIR }}
         run: just verify
 
       # `ci` = everything except the credential SURVEY. That one check diffs
@@ -238,22 +260,22 @@ jobs:
       # until it stops meaning anything. Every other probe here still runs.
       - name: Editor tier, authenticated end to end
         if: always()
-        working-directory: /tmp/bothy
+        working-directory: ${{ env.BOTHY_DIR }}
         run: just files-check ci
 
       - name: Config tier
         if: always()
-        working-directory: /tmp/bothy
+        working-directory: ${{ env.BOTHY_DIR }}
         run: bash apps/bothy-config/checks/run.sh
 
       - name: Control tier, including the real-daemon transition
         if: always()
-        working-directory: /tmp/bothy
+        working-directory: ${{ env.BOTHY_DIR }}
         run: bash apps/bothy-control/checks/run.sh
 
       - name: Portal truth tables against this box's own containers
         if: always()
-        working-directory: /tmp/bothy/apps/portal-next
+        working-directory: ${{ env.BOTHY_DIR }}/apps/portal-next
         run: |
           set -euo pipefail
           (cd web && npm ci --silent)
@@ -266,7 +288,7 @@ jobs:
       # arbitrary terminal cannot be reached by holding another.
       - name: A fresh install has somebody who can sign in
         if: always()
-        working-directory: /tmp/bothy
+        working-directory: ${{ env.BOTHY_DIR }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -303,7 +325,7 @@ jobs:
       # job log is public on a public repo.
       - name: Collect logs
         if: failure()
-        working-directory: /tmp/bothy
+        working-directory: ${{ env.BOTHY_DIR }}
         run: |
           set +e
           mkdir -p /tmp/logs
@@ -371,7 +393,7 @@ jobs:
 
       - name: Down leaves nothing behind
         if: always()
-        working-directory: /tmp/bothy
+        working-directory: ${{ env.BOTHY_DIR }}
         run: |
           set -euo pipefail
           just down || true

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,246 @@
+# Does an upgrade keep your data?
+#
+# The install job proves a FRESH box comes up. Nobody installs Bothy twice; they
+# install it once and then pull. So the interesting question is not "does it
+# start" but "does it start on top of the box you already had, without eating
+# what was in it" - and nothing has ever asked that.
+#
+# The failure this exists for is the worst kind a self-hosted tool has: silent
+# and unrecoverable. A volume renamed in a compose file, a `down -v` that crept
+# into a recipe, a service whose data directory moved - each one comes up green,
+# healthy, and empty. `just verify` passes. The dashboards are gone.
+#
+# ── what it asserts, and why each one ───────────────────────────────────────
+#
+#   1. A ROW WRITTEN BEFORE THE UPGRADE IS READABLE AFTER IT. The end-to-end
+#      claim, in the one place where loss is unrecoverable. Everything else here
+#      is a more specific version of this.
+#
+#   2. THE VOLUMES WERE NOT RECREATED. Stronger than (1) and it catches the near
+#      miss: a volume recreated between the two `up`s would have lost the data
+#      even if this particular row happened to be rewritten by something. Volume
+#      IDs are compared, not names - a recreated volume keeps its name.
+#
+#   3. A SECOND `just up` RECREATES NOTHING. Idempotence at the stack level
+#      rather than at bootstrap's. Measured on the real box before this was
+#      written: 31 compose-managed containers, identical name-to-id set across a
+#      second run. So it is a property that holds today, and a red here is a
+#      regression rather than an aspiration. It is what makes `just up` safe to
+#      run when you are not sure whether you already did.
+#
+#   4. THE BACKUP COVERS EVERY LIVE DATABASE. doctor.sh reports this and cannot
+#      gate on it - it exits 0 no matter what it finds. A dump missing a database
+#      looks exactly like a dump that has it until the day you restore.
+#
+# ── why nightly ────────────────────────────────────────────────────────────
+#
+# It is two full installs back to back, ~15-20 minutes. The property changes when
+# somebody edits a volume declaration, which is rare and always deliberate.
+name: Upgrade
+
+on:
+  schedule:
+    # An hour after Elsewhere, so two 20-minute matrix jobs are not competing for
+    # runners and a failure in one does not look like a symptom of the other.
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upgrade-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upgrade:
+    name: Install the previous commit, then upgrade onto it
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      DIR: /tmp/bothy
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: workspace
+          # The whole history, because this job checks out a PARENT commit. The
+          # default fetch-depth of 1 gives a repo with no parent to go back to,
+          # and the failure is `fatal: bad revision`, four steps in.
+          fetch-depth: 0
+
+      - name: Free disk (the stack pulls ~6 GB of images)
+        run: |
+          set -uo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+                      /usr/local/share/boost /usr/share/swift || true
+          df -h / | tail -1
+
+      - uses: extractions/setup-just@v3
+
+      - name: Clone, and go back one commit
+        run: |
+          set -euo pipefail
+          git clone --no-hardlinks "$GITHUB_WORKSPACE/workspace" "$DIR"
+          cd "$DIR"
+          # The FIRST PARENT, so a merge commit steps back to the previous state
+          # of main rather than sideways into the branch that was merged. On a
+          # merge, HEAD^2 is the feature branch - which never had the rest of
+          # main in it, and would make this an unrelated install rather than an
+          # upgrade.
+          base=$(git rev-parse HEAD^1)
+          echo "BASE_SHA=$base" >> "$GITHUB_ENV"
+          echo "HEAD_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          git checkout -q "$base"
+          echo "installing at:"; git log --oneline -1
+
+      - name: The address a container can also reach
+        run: |
+          set -euo pipefail
+          GW=$(docker network inspect bridge -f '{{(index .IPAM.Config 0).Gateway}}')
+          [ -n "$GW" ] || { echo "no bridge gateway"; exit 1; }
+          echo "BOTHY_BASE_HOST=$GW" >> "$GITHUB_ENV"
+
+      - name: Install the OLD version
+        working-directory: ${{ env.DIR }}
+        run: |
+          set -euo pipefail
+          cp .env.example .env
+          just up
+
+      # ── plant something that must survive ──────────────────────────────────
+      - name: Write a row, and record the volumes
+        working-directory: ${{ env.DIR }}
+        run: |
+          set -euo pipefail
+          set -a; . ./.env; set +a
+          docker exec postgres psql -U "${POSTGRES_USER:-dev}" -d "${POSTGRES_DB:-dev}" \
+            -v ON_ERROR_STOP=1 -c \
+            "CREATE TABLE upgrade_probe (id int primary key, note text);
+             INSERT INTO upgrade_probe VALUES (1, 'written before the upgrade');"
+          echo "  planted."
+          # IDs, not names: a recreated volume keeps its name, which is exactly
+          # how this failure hides.
+          docker volume ls -q | sort | while read -r v; do
+            printf '%s %s\n' "$v" "$(docker volume inspect "$v" -f '{{.CreatedAt}}')"
+          done > /tmp/volumes-before.txt
+          wc -l < /tmp/volumes-before.txt | xargs echo "  volumes recorded:"
+
+      # ── the upgrade ────────────────────────────────────────────────────────
+      - name: Upgrade to HEAD
+        working-directory: ${{ env.DIR }}
+        run: |
+          set -euo pipefail
+          git checkout -q "$HEAD_SHA"
+          echo "upgrading to:"; git log --oneline -1
+          # Exactly what a person does: pull, then up. No down, no prune, no -v.
+          just up
+
+      - name: The row is still there
+        working-directory: ${{ env.DIR }}
+        run: |
+          set -euo pipefail
+          set -a; . ./.env; set +a
+          got=$(docker exec postgres psql -U "${POSTGRES_USER:-dev}" -d "${POSTGRES_DB:-dev}" \
+                  -tAc "SELECT note FROM upgrade_probe WHERE id = 1")
+          echo "  read back: '$got'"
+          [ "$got" = "written before the upgrade" ] \
+            || { echo "FAIL  the upgrade lost data written before it"; exit 1; }
+
+      - name: No volume was recreated
+        run: |
+          set -uo pipefail
+          docker volume ls -q | sort | while read -r v; do
+            printf '%s %s\n' "$v" "$(docker volume inspect "$v" -f '{{.CreatedAt}}')"
+          done > /tmp/volumes-after.txt
+          # Only volumes that existed BEFORE are compared. The upgrade is allowed
+          # to ADD one - a new service is not a regression - but an existing
+          # volume changing its creation time means it was destroyed and remade.
+          rc=0
+          while read -r name created; do
+            now=$(grep -m1 "^$name " /tmp/volumes-after.txt | cut -d' ' -f2-)
+            if [ -z "$now" ]; then
+              echo "FAIL  volume vanished: $name"; rc=1
+            elif [ "$now" != "$created" ]; then
+              echo "FAIL  volume RECREATED: $name ($created -> $now)"; rc=1
+            fi
+          done < /tmp/volumes-before.txt
+          [ $rc -eq 0 ] && echo "  every pre-existing volume survived, same creation time"
+          exit $rc
+
+      # ── idempotence at the stack level ─────────────────────────────────────
+      - name: Running `just up` again recreates nothing
+        working-directory: ${{ env.DIR }}
+        run: |
+          set -euo pipefail
+          snap() { docker ps -a --filter label=com.docker.compose.project \
+                     --format '{{.Names}} {{.ID}}' | sort; }
+          snap > /tmp/containers-before.txt
+          just up >/dev/null
+          snap > /tmp/containers-after.txt
+          if diff /tmp/containers-before.txt /tmp/containers-after.txt; then
+            echo "  identical name->id set across a second \`just up\` ($(wc -l < /tmp/containers-before.txt) containers)"
+          else
+            echo "FAIL  a second \`just up\` recreated containers - see the diff above"
+            exit 1
+          fi
+
+      # ── the backup nobody can gate on ──────────────────────────────────────
+      - name: The dump covers every live database
+        working-directory: ${{ env.DIR }}
+        run: |
+          set -euo pipefail
+          set -a; . ./.env; set +a
+          # NOT GATED ON `just backup`'s EXIT CODE, deliberately. It reports a
+          # FAILURE when portainer is not running, and `just up` does not start
+          # portainer - it lives in mgmt/, which _up-all does not include. So on
+          # any fresh box, and therefore on every run of this job, backup exits 1
+          # for a service the install never started. Gating on that would make
+          # this red every night for a reason nobody can act on, which is the
+          # cry-wolf this repo keeps paying for - backup.sh's own header
+          # describes the identical bug with redis.
+          #
+          # What this step is actually about is COVERAGE: does the dump contain
+          # every database that exists? That is asserted below, on the artifact,
+          # and it is unaffected by whether some other service was up.
+          just backup || echo "  (backup reported a failure; coverage is asserted below)"
+          latest=$(ls -1t "${HOME}"/backups/postgres/pg-*.sql.gz 2>/dev/null | head -1)
+          [ -n "$latest" ] || { echo "FAIL  backup produced no postgres dump"; exit 1; }
+          live=$(docker exec postgres psql -U "${POSTGRES_USER:-dev}" -tAc \
+                   "SELECT datname FROM pg_database WHERE NOT datistemplate")
+          dumped=$(zcat "$latest" | sed -n 's/^CREATE DATABASE \([a-zA-Z0-9_]*\).*/\1/p')
+          rc=0
+          for db in $live; do
+            # `postgres` itself is never CREATE DATABASE'd in a dumpall - it is
+            # the maintenance database and always exists. Excluding it here rather
+            # than in doctor.sh's copy of this logic, which does not exclude it
+            # because it never had to gate on the answer.
+            [ "$db" = "postgres" ] && continue
+            case " $(echo "$dumped" | tr '\n' ' ') " in
+              *" $db "*) ;;
+              *) echo "FAIL  the dump is missing database: $db"; rc=1 ;;
+            esac
+          done
+          [ $rc -eq 0 ] && echo "  dump covers: $(echo "$live" | tr '\n' ' ')"
+          exit $rc
+
+      - name: Collect logs
+        if: failure()
+        working-directory: ${{ env.DIR }}
+        run: |
+          set +e
+          mkdir -p /tmp/logs
+          for f in edge/compose.yml auth/compose.yml monitoring/compose.yml \
+                   data/postgres/compose.yml apps/bothy/compose.yml; do
+            docker compose -f "$f" logs --no-color --tail 300 \
+              > "/tmp/logs/$(echo "$f" | tr / _).log" 2>&1
+          done
+          docker ps -a > /tmp/logs/ps.txt
+          docker volume ls > /tmp/logs/volumes.txt
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: upgrade-failure-logs
+          path: /tmp/logs
+          retention-days: 7


### PR DESCRIPTION
Tiers 3 and 5 of the CI plan. Two nightly jobs, each aimed at a property nothing has ever checked.

---

# Elsewhere — install somewhere that is not this author's `~/stacks`

The install job proves Bothy installs. At `/tmp/bothy`, every time: short, no spaces, three levels from the root. **Every portability bug this repo has had looked fine at exactly one path.**

### `uses:`, not a copy

That is the only reason this is worth having. A second install job drifts from the real one within a month and then proves something about a workflow nobody runs. `install.yml` gains a `workflow_call` input and one job-level env var; **every step is otherwise unchanged**.

| path | what it catches |
|---|---|
| `/tmp/bothy elsewhere/my checkout` | an unquoted `"$VAR"` anywhere in the shell layer |
| `/tmp/bothy-deep/one/.../six/checkout` | anything counting directory levels instead of resolving them |
| `/tmp/bothy` (control) | disambiguates "the path broke it" from "main broke overnight" |

**The space row is the one most likely to be broken and the cheapest to check.** This repo is shell scripts nearly all the way down, and an unquoted variable survives every run at `/tmp/bothy` then splits into two arguments the first time somebody clones into `~/My Projects/bothy`. Not hypothetical: `docs/brand/` already carries a filename with a space in it.

**Dry-ran both halves locally** at `"/tmp/bothy space test/checkout"` before writing the workflow — `bootstrap.sh` completes, and `docker compose config` resolves `- ../..:/repos/stacks` to `source: /tmp/bothy space test/checkout` as one argument. So these rows are expected green, and a red one is a real regression.

The `inputs.dir || '/tmp/bothy'` fallback is load-bearing: `inputs` is empty on `push`/`pull_request`, so without it the path is empty on every PR and every step runs in the wrong directory.

---

# Upgrade — does pulling a new version keep the box you already had

Nobody installs Bothy twice. They install it once and then pull. The failure this exists for is the worst kind a self-hosted tool has: **silent and unrecoverable**. A volume renamed, a `down -v` that creeps into a recipe, a data directory that moves — each comes up green, healthy and empty. `just verify` passes. The dashboards are gone.

Four assertions, each narrower than the last:

1. **A row written before the upgrade is readable after it.**
2. **No pre-existing volume was recreated** — compared by *creation time*, not name, because a recreated volume keeps its name. A new volume is allowed; a new service is not a regression.
3. **A second `just up` recreates nothing.** Measured on the real box first: 31 compose-managed containers, identical name→id set across a second run. Red here is a regression, not an aspiration.
4. **The dump covers every live database** — what `doctor.sh` reports and cannot gate on, since it exits 0 whatever it finds.

`HEAD^1`, not the second parent: on a merge commit that would step sideways into the feature branch, which never contained the rest of main. And `fetch-depth: 0`, because the default of 1 leaves no parent to step back to.

### A finding this turned up

The step is **deliberately not gated on `just backup`'s exit code**. `backup.sh` reports a FAILURE when portainer is not running — and `just up` never starts portainer; it lives in `mgmt/`, which `_up-all` does not include. So on any fresh box it exits 1 every night for a service the install was never going to start. That is exactly the cry-wolf `backup.sh`'s own header describes having already fixed once for redis, recurring with a different service. This step asserts the thing it is actually about — dump **coverage** — and says so.

*Separately, on the live box: `portainer` has been `Exited (2)` for 24 hours, so the nightly backup has been reporting failure. Worth a look, but out of scope here.*

---

Both are nightly + `workflow_dispatch`; each is a full install of ~26 containers, for properties that change about once a quarter.