### PR TITLE
Untrack mgmt/dozzle-users.yml — it should never have been committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,10 @@ apps/portal-next/data/themes/*.css
 # with every clone - a build artifact of whatever interpreter happened to run there.
 __pycache__/
 *.pyc
+
+# A dozzle users file, still on disk from before mgmt/ was deleted. It holds an
+# email and a bcrypt hash, so it must never be committed - and it WAS, once,
+# because this line was removed as "a file in a directory that no longer exists"
+# and `git add -A` then swept the untracked file it had been protecting. The
+# directory is gone; the rule stays until the file does.
+mgmt/dozzle-users.yml

--- a/mgmt/dozzle-users.yml
+++ b/mgmt/dozzle-users.yml
@@ -1,7 +1,0 @@
-users:
-    yr0556772363@gmail.com:
-        email: yr0556772363@gmail.com
-        name: Yehuda
-        password: $2a$11$wmPDdQ2QqFmNLLiW.MDz5.8DTC/ypmXzWhPkBu9/fGTXj6flU6WXG
-        filter: ""
-        roles: ""


### PR DESCRIPTION
`mgmt/dozzle-users.yml` holds an email address and a bcrypt hash, and commit `5be47d1` put it in a public repository. This removes it from the index and restores the ignore rule. The file stays on disk.

## How it happened

`mgmt/` was deleted in the previous change, so the sweep for dangling references found this line in `.gitignore`:

```
mgmt/dozzle-users.yml
```

and removed it as "a rule for a directory that no longer exists." That reasoning was wrong in the one way that matters: **an ignore rule doesn't describe the repository, it describes the working tree** — and the working tree still had the file, untracked, protected by exactly the line being deleted. The next `git add -A` swept it in.

So the rule outlives the directory. It stays until the file does.

## Two guards both missed it

- **gitleaks passed.** A bcrypt hash in a YAML file isn't a pattern it looks for, and an email address isn't a secret on its own.
- **I staged with `git add -A` in the same commit that edited `.gitignore`** — which is precisely when `add -A` stops being safe, because the set of files it will add has just changed underneath it.

## Impact

The hash is for a service that **no longer exists** — dozzle was deleted the same day and its container is gone — so nothing can authenticate with it.

It is still a bcrypt hash of a password a person chose, now in public git history. **The honest recommendation is to treat that password as disclosed anywhere else it is used.** Removing it from `HEAD` does not remove it from history; that needs a history rewrite, which is a separate decision.

## Verified

- `git ls-files mgmt/` → 0 files
- `git add -A` now stages nothing — the restored rule actually holds
- Audited every file added by today's commits: this was the only one that should not be there
- The other two sensitive untracked files (`.env`, `monitoring/prom-password.txt`) are still correctly ignored