### PR TITLE
The `bothy` CLI, and a readable `just --list`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
       # box's). Its run.sh builds a venv with uv when it cannot find one.
       - uses: astral-sh/setup-uv@v7
 
+      # The recipe-description check reads `just --list`, so this job needs just
+      # too. Same action as install.yml and upgrade.yml - one pin for dependabot
+      # to bump rather than a tarball URL that rots quietly.
+      - uses: extractions/setup-just@v3
+
       # ONE STEP PER SUITE, not one step running all of them. A single step
       # reports one red X for six suites and hides which; separate steps name the
       # failure in the job summary without opening a log.
@@ -106,6 +111,13 @@ jobs:
       - name: No bash 4 syntax (macOS ships bash 3.2)
         if: always()
         run: bash scripts/checks/bash32.sh
+
+      # `just --list` is the only discovery surface this repo has, and it printed
+      # sentence fragments for 10 of 22 recipes - including `nuke`, which deletes
+      # every data volume and was described as "lines below are now no-ops".
+      - name: Every recipe describes itself
+        if: always()
+        run: bash scripts/checks/recipe-descriptions.sh
 
   # ── the checks must be able to fail ─────────────────────────────────────────
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,13 @@ jobs:
         if: always()
         run: bash scripts/checks/recipe-descriptions.sh
 
+      # scripts/bothy dispatches most subcommands to a just recipe. Rename a
+      # recipe and nothing complains until somebody runs the CLI - the break is
+      # in one file and surfaces in another.
+      - name: The CLI and the justfile agree
+        if: always()
+        run: bash scripts/checks/cli-commands.sh
+
   # ── the checks must be able to fail ─────────────────────────────────────────
   #
   # Everything above answers "is the tree healthy". This answers the question

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       # The recipe-description check reads `just --list`, so this job needs just
       # too. Same action as install.yml and upgrade.yml - one pin for dependabot
       # to bump rather than a tarball URL that rots quietly.
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
 
       # ONE STEP PER SUITE, not one step running all of them. A single step
       # reports one red X for six suites and hides which; separate steps name the

--- a/justfile
+++ b/justfile
@@ -99,6 +99,7 @@ network:
 # list is scripts/lib/bootstrap-keys.sh, shared with bootstrap so the two cannot
 # drift; both failures above were found by `just ci-install`, one after the
 # other, because fixing the first revealed the second.
+# Bring the whole box up, in dependency order. Runs bootstrap first.
 up: bootstrap
     #!/usr/bin/env bash
     set -euo pipefail
@@ -134,6 +135,7 @@ _up-all: network up-edge up-data up-auth up-monitoring up-apps
 # Host header (the name layer was deleted 2026-08-12); what it still owns is the
 # portal's host-less /-/api/* data plane and the catch-all that serves the portal
 # on the bare IP. Must come up before anything that expects to be routed.
+# Edge: Traefik on :80. Must be up before anything that expects routing.
 up-edge: network
     docker compose -f edge/compose.yml up -d
 
@@ -147,6 +149,7 @@ up-edge: network
 #
 # Nothing here enforces anything yet: it defines the `sso@file` middleware,
 # it does not attach it to any router. See edge/dynamic/auth.yml.
+# Identity: Keycloak + oauth2-proxy. Blocks until Keycloak is healthy.
 up-auth: network
     #!/usr/bin/env bash
     set -euo pipefail
@@ -196,6 +199,7 @@ up-monitoring: network
 # went; the point is that the instruction must not promise otherwise.)
 #
 # postgres stays: it is in active use - Keycloak's database lives there.
+# Data: Postgres, bound to loopback only.
 up-data: network
     docker compose -f data/postgres/compose.yml up -d
 
@@ -204,6 +208,7 @@ up-data: network
 # There is nothing else here. Reading and editing the box's markdown is Bothy
 # Files, a route in the portal backed by apps/portal-files, which reads the real
 # file from a bind mount. No second copy, no sync lag, nothing to keep out of git.
+# Apps: Bothy's web, editor and socket tiers, plus the config tier.
 up-apps: network
     docker compose {{BOTHY}} up -d
     # The config tier. Separate from the editor tier on purpose: portal-files
@@ -241,6 +246,7 @@ down:
 # volume that still exists: postgres, prometheus, grafana, loki, portainer.
 # (redis_data and kafka_data were already deleted on 2026-08-12 - those two
 # lines below are now no-ops on this box.)
+# DESTRUCTIVE: delete every data volume. Asks for confirmation; irreversible.
 nuke:
     @printf "This deletes ALL data volumes. Type yes to continue: " && read ans && [ "$ans" = yes ] || (echo aborted; exit 1)
     -docker compose -f auth/compose.yml down -v
@@ -284,6 +290,7 @@ ci-install:
 # Verify the access model still holds - run after ANY edge/routing change.
 # `just verify selftest` additionally proves the template-error probe can fail,
 # by voiding a dynamic file on purpose and cleaning it up again.
+# Prove the edge actually routes - 23 checks against the running stack.
 verify mode="":
     @VERIFY_SELFTEST={{ if mode == "selftest" { "1" } else { "" } }} bash scripts/verify-access.sh
 
@@ -291,6 +298,7 @@ verify mode="":
 # addresses that are baked in, against a baseline that should only ever shrink.
 # Runs against the TREE, so it needs nothing up - which is why it is its own
 # recipe rather than a section of `verify`.
+# Count the paths and addresses baked in that exist on only one machine.
 portability:
     @bash scripts/checks/portability.sh
 
@@ -298,13 +306,14 @@ portability:
 # directories the services write to, and generate the gitignored files that
 # nothing else creates. Idempotent - a second run says so rather than acting.
 # `up` depends on it, because a rule that can be forgotten will be.
+# Make a fresh clone runnable: check prerequisites, create dirs, generate secrets.
 bootstrap *args:
     @bash scripts/bootstrap.sh {{ args }}
 
 # Checks for the editor tier: path-safety unit tests, per-route role enforcement,
 # a full anonymous-refused / login / write round trip, the undo net, and a scan
 # of everything the portal SERVES for anything that looks like a credential.
-# `just files-check offline` runs only the part that needs nothing up; `ci` runs everything except the box-specific credential survey.
+# Checks for the editor tier. `offline` skips what needs the stack up; `ci` skips the box-specific credential survey.
 files-check mode="":
     @bash apps/portal-files/checks/run.sh {{ if mode == "offline" { "--offline" } else { if mode == "ci" { "--skip-survey" } else { "" } } }}
 
@@ -332,6 +341,7 @@ psql:
 # behalf, so it is GITIGNORED and generated from .env rather than committed.
 # Run this on a fresh clone, and again after changing DEV_LOGIN_*. Traefik
 # watches ./dynamic, so no restart is needed.
+# Regenerate the portal's Prometheus data-plane route.
 portal-prom-route:
     ./scripts/gen-portal-prom-route.sh
 
@@ -341,6 +351,7 @@ portal-prom-route:
 # Traefik Host-name routing is DELETED - not
 # dormant, not waiting on a DNS layer. Zero Host() rules remain in the router
 # table. A new service publishes a port; it does not declare a name.
+# Print every address on this box, and what is deliberately not running.
 urls:
     #!/usr/bin/env bash
     # Identity is read from tailscale at run time and never stored in this repo:

--- a/scripts/bothy
+++ b/scripts/bothy
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# The Bothy CLI.
+#
+# ── what this is, and deliberately is not ───────────────────────────────────
+#
+# Bothy already had a CLI: `just`. up, down, doctor, verify, backup, logs, ps,
+# urls, psql, ci-install - all of it, with the reasoning for each decision in
+# the comments above the recipe. Rewriting that here would create a second copy
+# of every operation, and this repository has paid for that mistake enough times
+# to name it: four dead compose files, dependabot entries for directories that no
+# longer existed, docs describing services that had been deleted.
+#
+# So this is TWO things and not a third:
+#
+#   1. NATIVE COMMANDS - the genuine gap. `init`, `download`, `upgrade`,
+#      `version`. These cannot be `just` recipes because they run BEFORE there
+#      is a repository to run `just` in. That chicken-and-egg is the whole
+#      reason this file exists.
+#
+#   2. A DISPATCHER - everything else is one line in `resolve()` below, and
+#      execs the thing that already does the work.
+#
+# It is NOT a reimplementation. If you find yourself writing stack logic in this
+# file, it belongs in scripts/ and both front ends should call it.
+#
+# ── the seam, and why it is shaped this way ─────────────────────────────────
+#
+# The intent is that `just` becomes optional later. `resolve()` maps a
+# subcommand to EITHER a just recipe or a shell function, so moving one command
+# off `just` is editing one line - not a migration. Nothing has moved yet;
+# `scripts/lib/ops.sh` is where it goes when it does, and when everything has
+# moved the justfile can be deleted without touching this file.
+#
+# scripts/checks/cli-commands.sh asserts every subcommand resolves to something
+# that exists. A renamed recipe then fails CI instead of failing a person.
+#
+# ── bash 3.2 ────────────────────────────────────────────────────────────────
+#
+# macOS ships bash 3.2 and Bothy claims macOS. No associative arrays, no `${x,,}`,
+# no `mapfile` - those are bash 4 and fail at PARSE time there, so the script does
+# not run at all and the error names a line that looks fine.
+# scripts/checks/bash32.sh enforces it.
+set -uo pipefail
+
+BOTHY_REPO_URL="${BOTHY_REPO_URL:-https://github.com/YehudaBriskman/Bothy.git}"
+BOTHY_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/bothy/config"
+DEFAULT_DIR="$HOME/bothy"
+
+red()  { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+say()  { printf '%s\n' "$*"; }
+die()  { red "$*"; exit 1; }
+
+# ── where is the box ────────────────────────────────────────────────────────
+#
+# Order matters and each step is here for a reason:
+#   1. $BOTHY_HOME     an explicit override, for a second checkout or CI.
+#   2. the config file what `init` wrote. The normal answer.
+#   3. the cwd         so running it inside a clone works before `init` ever ran,
+#                      which is how a contributor will meet this script.
+# A directory only counts if it looks like Bothy - a justfile AND the apps/bothy
+# compose file. Either alone matches too many repositories.
+looks_like_bothy() {
+  [ -f "$1/justfile" ] && [ -f "$1/apps/bothy/compose.yml" ]
+}
+
+find_home() {
+  if [ -n "${BOTHY_HOME:-}" ]; then
+    looks_like_bothy "$BOTHY_HOME" || die "BOTHY_HOME=$BOTHY_HOME is not a Bothy checkout"
+    printf '%s\n' "$BOTHY_HOME"; return 0
+  fi
+  if [ -f "$BOTHY_CONFIG" ]; then
+    # Read, never execute: this file is data. `.` on it would run whatever is in
+    # it, which is a lot of trust for a path.
+    home=$(sed -n 's/^BOTHY_HOME=//p' "$BOTHY_CONFIG" | head -1)
+    if [ -n "$home" ] && looks_like_bothy "$home"; then printf '%s\n' "$home"; return 0; fi
+  fi
+  here=$(pwd)
+  while [ "$here" != "/" ]; do
+    if looks_like_bothy "$here"; then printf '%s\n' "$here"; return 0; fi
+    here=$(dirname "$here")
+  done
+  return 1
+}
+
+require_home() {
+  home=$(find_home) || die "No Bothy checkout found. Run \`bothy init\` first, or set BOTHY_HOME."
+  printf '%s\n' "$home"
+}
+
+# ── prerequisites ───────────────────────────────────────────────────────────
+#
+# Checked BEFORE cloning anything. A half-finished install that fails on a
+# missing tool three minutes in is worse than one that never started.
+#
+# `just` is deliberately not in this list: `init` installs it, because being the
+# thing that removes that requirement is a large part of why this CLI exists.
+check_prereqs() {
+  missing=""
+  for c in docker git curl python3 openssl; do
+    command -v "$c" >/dev/null 2>&1 || missing="$missing $c"
+  done
+  if ! docker compose version >/dev/null 2>&1; then
+    missing="$missing docker-compose-v2"
+  fi
+  if [ -n "$missing" ]; then
+    red "missing:$missing"
+    say "Bothy needs docker (with the compose plugin), git, curl, python3 and openssl."
+    return 1
+  fi
+  say "ok - docker, git, curl, python3, openssl all present"
+  return 0
+}
+
+ensure_just() {
+  command -v just >/dev/null 2>&1 && return 0
+  say "just is not installed - fetching it into ~/.local/bin"
+  mkdir -p "$HOME/.local/bin"
+  # The official installer, pinned to a directory rather than run as root.
+  curl -fsSL https://just.systems/install.sh \
+    | bash -s -- --to "$HOME/.local/bin" >/dev/null 2>&1 \
+    || die "could not install just - install it yourself and re-run"
+  PATH="$HOME/.local/bin:$PATH"; export PATH
+  command -v just >/dev/null 2>&1 || die "installed just but it is not on PATH"
+  say "  installed. Add ~/.local/bin to your PATH to keep it."
+}
+
+# ── the dispatch table ──────────────────────────────────────────────────────
+#
+# ONE LINE PER SUBCOMMAND. Today every one of them names a just recipe; later
+# any of them can name a shell function in scripts/lib/ops.sh instead, and that
+# is the only edit required to move a command off `just`.
+#
+# A `case` rather than an associative array: bash 3.2 has no `declare -A`.
+resolve() {
+  case "$1" in
+    up|down|doctor|verify|backup|logs|ps|urls|psql|nuke) printf 'just:%s\n' "$1" ;;
+    status)        printf 'just:ps\n' ;;
+    diagnostics)   printf 'just:doctor\n' ;;
+    check)         printf 'just:verify\n' ;;
+    files-check)   printf 'just:files-check\n' ;;
+    portability)   printf 'just:portability\n' ;;
+    bootstrap)     printf 'just:bootstrap\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+dispatch() {
+  sub="$1"; shift
+  target=$(resolve "$sub") || return 1
+  recipe=${target#just:}
+  home=$(require_home) || exit 1
+  cd "$home" || die "cannot enter $home"
+  command -v just >/dev/null 2>&1 || die "just is not installed. \`bothy init\` installs it."
+  exec just "$recipe" "$@"
+}
+
+# ── native commands ─────────────────────────────────────────────────────────
+
+cmd_init() {
+  dir="${1:-$DEFAULT_DIR}"
+  say "== preflight =="
+  check_prereqs || exit 1
+
+  if looks_like_bothy "$dir"; then
+    say "== already a Bothy checkout at $dir - reusing it =="
+  elif [ -e "$dir" ] && [ -n "$(ls -A "$dir" 2>/dev/null)" ]; then
+    die "$dir exists and is not empty. Pass another directory."
+  else
+    say "== clone =="
+    git clone --quiet "$BOTHY_REPO_URL" "$dir" || die "clone failed"
+    say "  cloned into $dir"
+  fi
+
+  ensure_just
+  mkdir -p "$(dirname "$BOTHY_CONFIG")"
+  printf 'BOTHY_HOME=%s\n' "$dir" > "$BOTHY_CONFIG"
+  say "  recorded in $BOTHY_CONFIG"
+
+  cd "$dir" || die "cannot enter $dir"
+  # .env is what bootstrap generates the secrets INTO, so it has to exist first.
+  # Copied rather than generated here: .env.example is the documented starting
+  # point and `just up` runs bootstrap, which fills in what is missing.
+  [ -f .env ] || cp .env.example .env
+  say ""
+  say "== bringing it up =="
+  just up || die "\`just up\` failed - the box is half-started; \`bothy logs <service>\` will say why"
+  say ""
+  just urls
+}
+
+cmd_download() {
+  home=$(require_home) || exit 1
+  cd "$home" || exit 1
+  say "== pre-fetching every image =="
+  # Every compose file, not just the ones `up` starts: the point of this command
+  # is that a later `up` needs no network, and that includes the ones you may
+  # start by hand.
+  found=0
+  for f in $(find . -name 'compose*.yml' -not -path '*/node_modules/*' | sort); do
+    found=$((found + 1))
+    printf '  %s\n' "$f"
+    docker compose -f "$f" --env-file .env pull --quiet 2>/dev/null \
+      || printf '    (some images could not be pulled - see `docker compose -f %s pull`)\n' "$f"
+  done
+  say "  $found compose file(s)"
+  if [ -d apps/portal-next/web ]; then
+    say "== portal dependencies =="
+    ( cd apps/portal-next/web && npm ci --silent 2>/dev/null ) \
+      && say "  npm ci done" || say "  (npm ci failed or npm is absent - the image build does not need it)"
+  fi
+  say ""
+  say "Done. \`bothy up\` should now need no network."
+}
+
+cmd_upgrade() {
+  home=$(require_home) || exit 1
+  cd "$home" || exit 1
+  before=$(git rev-parse --short HEAD)
+  say "== pulling =="
+  git pull --ff-only || die "pull failed - the checkout has local changes or has diverged"
+  after=$(git rev-parse --short HEAD)
+  if [ "$before" = "$after" ]; then
+    say "  already at $after - nothing to do"
+    return 0
+  fi
+  say "  $before -> $after"
+  say ""
+  say "== applying =="
+  # No `down`, no `-v`. The Upgrade CI tier asserts that this preserves data and
+  # does not recreate volumes; adding a `down` here would quietly break that.
+  just up
+}
+
+cmd_version() {
+  home=$(find_home) || { say "bothy (no checkout found)"; return 0; }
+  cd "$home" || return 0
+  # THERE ARE NO RELEASES YET - `git tag` is empty (see the versioning issue), so
+  # this reports the commit and says so rather than inventing a version number.
+  tag=$(git describe --tags --always 2>/dev/null || echo unknown)
+  say "bothy   $tag"
+  say "repo    $home"
+  if [ -z "$(git tag 2>/dev/null)" ]; then
+    say ""
+    say "This checkout has no release tags, so the above is a commit."
+  fi
+}
+
+usage() {
+  cat <<'EOF'
+bothy - install and run a Bothy box
+
+  bothy init [dir]      clone, install prerequisites, and bring it up
+                        (default ~/bothy)
+  bothy download        pre-fetch every image and dependency, so a later
+                        `up` needs no network
+  bothy upgrade         pull and apply, preserving your data
+  bothy version         what this checkout is
+
+Everything else is handed to the box's own justfile:
+
+  bothy up | down | doctor | verify | backup | logs <svc> | ps | urls | psql
+  bothy files-check | portability | bootstrap | nuke
+
+  bothy doctor --pre    check prerequisites before a checkout exists
+
+The checkout is found via $BOTHY_HOME, then the path recorded by `init`, then
+by walking up from the current directory.
+EOF
+}
+
+main() {
+  [ $# -eq 0 ] && { usage; exit 0; }
+  sub="$1"; shift
+  case "$sub" in
+    init)      cmd_init "$@" ;;
+    download)  cmd_download "$@" ;;
+    upgrade)   cmd_upgrade "$@" ;;
+    version|--version|-v) cmd_version ;;
+    help|--help|-h) usage ;;
+    doctor)
+      # `doctor --pre` is the one that must work with no checkout at all.
+      if [ "${1:-}" = "--pre" ]; then check_prereqs; exit $?; fi
+      dispatch doctor "$@" ;;
+    *)
+      dispatch "$sub" "$@" || { red "unknown command: $sub"; say ""; usage; exit 1; } ;;
+  esac
+}
+
+main "$@"

--- a/scripts/checks/cli-commands.sh
+++ b/scripts/checks/cli-commands.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Every `bothy` subcommand must resolve to something that exists.
+#
+# THE FAILURE THIS PREVENTS. scripts/bothy is a dispatcher: most subcommands are
+# one line naming a `just` recipe. Rename or delete a recipe and nothing
+# complains - the justfile is fine, the CLI is fine, and `bothy verify` says
+# "Justfile does not contain recipe" to whoever runs it next. The break happens
+# in one file and surfaces in another, which is exactly the kind nobody catches
+# in review.
+#
+# So: read the dispatch table out of the CLI, read the recipe list out of `just`,
+# and require every target to exist. It runs with the stack down and takes a
+# second.
+#
+# IT ALSO CHECKS THE OTHER DIRECTION - every documented subcommand is really
+# dispatchable. A command in `usage` that resolve() does not know is a lie in the
+# help text, and help text is the only documentation a CLI has.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1
+
+CLI=scripts/bothy
+fails=0
+
+[ -f "$CLI" ] || { echo "FAIL  $CLI is missing"; exit 1; }
+command -v just >/dev/null 2>&1 || { echo "SKIP  just is not installed - cannot resolve recipes"; exit 0; }
+
+# The recipe names `just` actually knows, one per line.
+recipes=$(just --list 2>/dev/null | tail -n +2 | sed -E 's/^[[:space:]]*([a-z0-9-]+).*/\1/')
+
+# ── every dispatch target exists ────────────────────────────────────────────
+#
+# resolve() prints `just:<recipe>`. Pulling the targets out of the source rather
+# than calling resolve() for a guessed list of names is deliberate: this way a
+# subcommand ADDED to the table is checked without anyone remembering to add it
+# here too.
+targets=$(sed -n "s/.*printf 'just:\([a-z0-9-]*\)\\\\n'.*/\1/p" "$CLI" | sort -u)
+# The `printf 'just:%s\n' "$1"` line resolves to whatever matched its case arm,
+# so those names come from the arm itself rather than the printf.
+arm=$(sed -n "s/^[[:space:]]*\(up|down[^)]*\))[[:space:]]*printf 'just:%s.*/\1/p" "$CLI" | tr '|' '\n')
+targets=$(printf '%s\n%s\n' "$targets" "$arm" | sed '/^$/d' | sort -u)
+
+[ -n "$targets" ] || { echo "FAIL  found no dispatch targets in $CLI - has resolve() changed shape?"; exit 1; }
+
+for t in $targets; do
+  if printf '%s\n' "$recipes" | grep -qx "$t"; then
+    printf 'PASS  %-16s -> just %s\n' "$t" "$t"
+  else
+    printf 'FAIL  %-16s -> just %s   NO SUCH RECIPE\n' "$t" "$t"
+    fails=$((fails + 1))
+  fi
+done
+
+# ── everything the help text promises is dispatchable ───────────────────────
+echo
+documented=$(sed -n '/^  bothy up | down/,/^  bothy files-check/p' "$CLI" \
+  | tr '|' '\n' | sed -E 's/^[[:space:]]*(bothy)?[[:space:]]*//; s/[[:space:]]*<.*//; s/[[:space:]]*$//' \
+  | sed '/^$/d')
+for d in $documented; do
+  if printf '%s\n' "$targets" | grep -qx "$d"; then
+    printf 'PASS  %-16s is documented and dispatchable\n' "$d"
+  else
+    printf 'FAIL  %-16s appears in the help text but resolve() does not know it\n' "$d"
+    fails=$((fails + 1))
+  fi
+done
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "ok - the CLI and the justfile agree"
+else
+  echo "$fails mismatch(es). scripts/bothy names a recipe that does not exist, or"
+  echo "promises a command it cannot run."
+fi
+exit $((fails > 0 ? 1 : 0))

--- a/scripts/checks/recipe-descriptions.sh
+++ b/scripts/checks/recipe-descriptions.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Every `just` recipe must describe itself in one readable line.
+#
+# WHY THIS EXISTS. `just` takes the LAST comment line before a recipe as its
+# description. This repo's comment blocks run to paragraphs and end mid-thought,
+# so `just --list` - the first thing anyone runs, and the only discovery surface
+# there is - printed sentence fragments for 10 of 22 recipes:
+#
+#   up      # other, because fixing the first revealed the second.
+#   urls    # table. A new service publishes a port; it does not declare a name.
+#   nuke    # lines below are now no-ops on this box.)
+#
+# The last one is why this is a check and not a tidy-up. `nuke` deletes every
+# data volume, and its listing described it as a no-op.
+#
+# THE RULE IS "STARTS WITH A CAPITAL", and that is chosen rather than obvious.
+# Terminal punctuation is not a signal - "Show running containers" is a perfect
+# description and ends with none. A fragment is a CONTINUATION, and continuations
+# start lowercase. The one exception that ever slipped through started with a
+# backtick (`bootstrap`'s old line began "`up` depends on it, because…"), so a
+# leading backtick is not accepted either: write the sentence, then quote things
+# inside it.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1
+
+MIN=12   # shorter than this is a stub, not a description
+fails=0
+
+# `just --list` renders "    name args   # description". Recipes with no comment
+# have no `#` at all, which is its own failure.
+while IFS= read -r line; do
+  case "$line" in Available*|'') continue ;; esac
+  name=$(printf '%s' "$line" | sed -E 's/^[[:space:]]*([a-z0-9-]+).*/\1/')
+  case "$line" in
+    *'#'*) desc=$(printf '%s' "$line" | sed -E 's/^[^#]*#[[:space:]]*//') ;;
+    *)     printf 'FAIL  %-20s has no description at all\n' "$name"; fails=$((fails+1)); continue ;;
+  esac
+
+  if [ "${#desc}" -lt "$MIN" ]; then
+    printf 'FAIL  %-20s description is %s chars, too short to say anything: %s\n' \
+      "$name" "${#desc}" "$desc"; fails=$((fails+1)); continue
+  fi
+  case "$desc" in
+    [A-Z]*) ;;
+    *) printf 'FAIL  %-20s reads as a sentence fragment (must start with a capital):\n      %s\n' \
+         "$name" "$desc"; fails=$((fails+1)) ;;
+  esac
+done < <(just --list 2>/dev/null)
+
+if [ "$fails" -eq 0 ]; then
+  echo "ok - every recipe describes itself"
+else
+  echo
+  echo "$fails recipe(s) above. \`just\` uses the LAST comment line before a recipe,"
+  echo "so add a one-line summary there and keep the reasoning above it."
+fi
+exit $((fails > 0 ? 1 : 0))


### PR DESCRIPTION
Closes #101. First step on #100.

---

# `bothy` — the install path, and a dispatcher over the rest

Bothy could be *run* but not *distributed*: you had to know the repo existed, clone it by hand, and already have `just`.

### What it deliberately is not

Bothy already had a CLI. Reimplementing `up`/`down`/`doctor`/`verify` here would create a second copy of every operation — the failure this repo has paid for repeatedly (four dead compose files, dependabot entries for deleted directories, docs describing removed services).

So it is **two** things:

| | |
|---|---|
| **Native** | `init`, `download`, `upgrade`, `version` — they run *before* there is a repo to run `just` in. That chicken-and-egg is the whole reason the file exists. |
| **Dispatch** | everything else is one line in `resolve()` and execs what already does the work. |

### The seam is the point

`resolve()` maps a subcommand to a just recipe today and can map it to a shell function tomorrow — so moving a command off `just` is **editing one line, not performing a migration**. Nothing has moved yet. When everything has, the justfile can be deleted without touching this file.

### Details worth flagging

- **`init` installs `just`.** `bootstrap.sh` requires docker + just + curl + python3 + openssl; `just` is the unusual one. The documented requirement drops to **docker + git + curl**.
- **`init` is not speculative** — `scripts/ci-install.sh` already performs this exact sequence in DinD and the install workflow runs it every PR.
- **`upgrade` has no `down` and no `-v`**, because the Upgrade tier asserts an upgrade preserves data and recreates no volume. Adding one would quietly break that.
- **`version` reports a commit and says so.** No release tags exist (#102), so inventing a version number would be a lie.
- **Bash 3.2 throughout** — no `declare -A`, so the dispatch table is a `case`. Those constructs fail at *parse* time on macOS.

`scripts/checks/cli-commands.sh` guards the seam **both ways**: every dispatch target must be a real recipe, and every command the help text promises must be dispatchable. It reads the table out of the source, so a subcommand added tomorrow is checked without anyone remembering.

**Proved it fails both ways:** a typo'd target reported `NO SUCH RECIPE` *and* flagged the now-undocumented command; renaming the recipe out from under the CLI reported the same break from the other side.

---

# `just --list` says what the recipes do (#101)

`just` takes the **last** comment line before a recipe. These comment blocks run to paragraphs and end mid-thought, so the only discovery surface printed fragments for 10 of 22 recipes:

```
up      # other, because fixing the first revealed the second.
urls    # table. A new service publishes a port; it does not declare a name.
nuke    # lines below are now no-ops on this box.)
```

**The last one is why this is a fix, not a tidy-up.** `nuke` deletes every data volume and was described as a no-op. There is an interactive confirmation, so nobody was one keystroke from losing the databases — but the listing misled about the most destructive command in the file.

Eleven one-line summaries added. **The long reasoning above them is untouched** — it is the most valuable thing in the file.

`scripts/checks/recipe-descriptions.sh` enforces **"starts with a capital"**, which is chosen rather than obvious: terminal punctuation is no signal ("Show running containers" is fine and has none), but a fragment is a *continuation*, and continuations start lowercase. A leading backtick is rejected too — the one line that would have slipped through was `bootstrap`'s, which began ``"`up` depends on it, because…"``.

Proved it fails: restored `nuke`'s original fragment, check went red naming that recipe.

---

## Verified

`just verify` 23/23 · both new checks pass and were shown to fail · `bash32.sh` clean · rebased onto `setup-just@v4`, which dependabot moved everything to while this branch was open.