### PR TITLE
The docs reader: images render, and a document is set like a document

### DIFF
--- a/apps/portal-next/web/src/index.css
+++ b/apps/portal-next/web/src/index.css
@@ -153,13 +153,19 @@
      72ch is prose, not a terminal. The measure rule changes reading speed more
      than the typeface does. */
   --read-measure: 72ch;
-  --read-fs: 14.5px;
+  /* 16px, not 14.5px. The measure was already right - 72ch, verified rendering
+     at exactly 72 characters - but the body was set at the app's UI size, and a
+     document is not a dashboard. 14.5px is a good size for a control that sits
+     beside a chart and a tiring one for a page of prose you actually read.
+     The measure is in `ch`, so raising the size keeps the line at 72 characters
+     and simply makes the column physically wider - which is the point. */
+  --read-fs: 16px;
   --read-lh: 1.65;
-  --read-gap: 13px;      /* between blocks */
-  --read-h1: 25px;
-  --read-h2: 19px;
-  --read-h3: 16px;
-  --read-h4: 14px;
+  --read-gap: 15px;      /* between blocks, tracks --read-fs */
+  --read-h1: 27px;
+  --read-h2: 21px;
+  --read-h3: 17.5px;
+  --read-h4: 15px;
 
   /* ── motion ─────────────────────────────────────────────────────────────── */
   --dur-fast: 120ms;   /* hover, colour */

--- a/apps/portal-next/web/src/pages/files/Editor.tsx
+++ b/apps/portal-next/web/src/pages/files/Editor.tsx
@@ -39,7 +39,7 @@ import {
   Save, Search, Undo2, X,
 } from 'lucide-react';
 import {
-  fmtBytes, langFor, looksBinary, signInUrl,
+  fmtBytes, langFor, looksBinary, rawUrl, signInUrl,
   type DiffResult, type FileRead, type WriteConflict,
 } from '../../lib/files';
 import { ErrState, Skeleton } from '../../components/states';
@@ -382,7 +382,7 @@ function DocBody({
       // page's own root. The `#fragment` is dropped: this is the editor, where a
       // document arrives at the top and a scroll would fight the caret - the
       // reader is the surface that honours it.
-      links={{ dir: dirName(path), open: (p) => onOpenPath(root, p) }}
+      links={{ dir: dirName(path), open: (p) => onOpenPath(root, p), src: (p) => rawUrl(root, p) }}
     />
   );
 }

--- a/apps/portal-next/web/src/pages/files/FileView.tsx
+++ b/apps/portal-next/web/src/pages/files/FileView.tsx
@@ -178,7 +178,7 @@ export function FileView({
         // Nothing on this surface reports a degraded image; the frame it falls
         // back to labels itself.
         onFallback={() => {}}
-        links={onOpen ? { dir, open: onOpen, resolveWiki } : undefined}
+        links={onOpen ? { dir, open: onOpen, resolveWiki, src: (p) => rawUrl(root, p) } : undefined}
       />
     </div>
   );

--- a/apps/portal-next/web/src/pages/files/editor.css
+++ b/apps/portal-next/web/src/pages/files/editor.css
@@ -593,6 +593,35 @@
 .bothy-files .md .md-h3 { font-size: var(--read-h3); }
 .bothy-files .md .md-h4, .bothy-files .md .md-h5, .bothy-files .md .md-h6 { font-size: var(--read-h4); color: var(--fg-muted); }
 .bothy-files .md .md-p { margin: 0 0 var(--read-gap); }
+/* An image in a document, rendered from the sandbox origin (see mdImage in
+   md.tsx for why only repo-relative paths get here).
+
+   `max-width: 100%` is the load-bearing line. README.md's screenshots are
+   1280px wide and the measure is ~660px, so without it the first image blows
+   the column out and every paragraph after it reflows to the image's width -
+   measured exactly that way before this rule existed.
+
+   `height: auto` with the intrinsic size preserved stops the reflow when a slow
+   image finally arrives. The border is there because a screenshot of a dark UI
+   on a dark page has no edge of its own. */
+/* A remote image cannot be shown - the CSP's img-src does not reach third
+   parties, deliberately (see mdImage). This says one was there without pasting
+   its URL into the sentence. */
+.bothy-files .md .md-img-remote {
+  display: inline-block; padding: 0 6px; border-radius: var(--r-sm);
+  border: 1px dashed var(--line-strong); background: var(--surface-2);
+  color: var(--fg-subtle); font-size: 0.85em; line-height: 1.6;
+  vertical-align: baseline; cursor: help;
+}
+.bothy-files .md .md-img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: var(--read-gap) 0;
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+}
 .bothy-files .md .md-list { margin: 0 0 var(--read-gap); padding-left: 22px; }
 .bothy-files .md .md-list li { margin: 3px 0; }
 .bothy-files .md .md-list .md-list { margin-bottom: 0; }

--- a/apps/portal-next/web/src/pages/files/md.tsx
+++ b/apps/portal-next/web/src/pages/files/md.tsx
@@ -33,6 +33,18 @@ export interface MdLinks {
   /** Open a root-relative path in the same root. `frag` is the `#heading` the
    *  link carried, or `''`; the caller decides whether it can honour it. */
   open: (path: string, frag: string) => void;
+  /** Turn a ROOT-RELATIVE path into a URL the browser may load as an image.
+   *
+   *  Supplied by the caller, and for the same reason `resolveWiki` is: answering
+   *  it needs the ROOT, and knowing which root a document came from is exactly
+   *  the knowledge this module is built not to have. Absent, images render inert
+   *  the way an unresolvable link does.
+   *
+   *  The URL it returns points at the SANDBOX ORIGIN (:8100), which is where raw
+   *  bytes live and what the CSP's `img-src` already allows. That is not a
+   *  detail - it is why an image in a document cannot become a script in this
+   *  one. */
+  src?: (path: string) => string | null;
   /** Resolve a WIKILINK target - `[[dns]]`, `[[network/dns]]`, `[[dns#ttl]]` -
    *  to a real path, or null.
    *
@@ -55,6 +67,55 @@ const RE_WEB = /^(https?:\/\/|#|mailto:)/i;
 // opens a file named `javascript:alert(1)`. A scheme this page does not know is
 // not a path; `//host/x` is not one either.
 const RE_SCHEME = /^([a-z][a-z0-9+.-]*:|\/\/)/i;
+
+/**
+ * `![alt](path)`.
+ *
+ * ONLY A REPO-RELATIVE PATH BECOMES AN <img>. Anything carrying a scheme -
+ * `https:`, `data:`, `//` - renders inert with its target visible, and that is a
+ * decision rather than an omission:
+ *
+ *   · The CSP is `img-src 'self' data: blob: http://$host:8100`. A remote image
+ *     is BLOCKED at load, so allowing one here buys a broken-image icon.
+ *   · Widening the CSP to permit it would let any document in any root make the
+ *     reader's browser talk to a third party. On a box reached over a tailnet,
+ *     an <img> is an IP-address beacon.
+ *
+ * The inert form is deliberately the same one an unresolvable link gets: the
+ * text, with the target beside it, because a reader wants to know what was meant
+ * even when it cannot be shown.
+ */
+function mdImage(
+  href: string, alt: string, key: string, links?: MdLinks,
+): ReactNode {
+  // A REMOTE image gets a compact chip, not the inert link treatment. The
+  // difference matters on README.md, which opens with three shields.io badges:
+  // rendering each as "alt" followed by a 90-character URL turns the first
+  // screen of the most-read document into a wall of query strings. The chip says
+  // an image was there and what it was; the URL is in `title` for anyone who
+  // wants it.
+  if (RE_SCHEME.test(href)) {
+    return (
+      <span className="md-img-remote" key={key} title={href}>{alt || 'image'}</span>
+    );
+  }
+  const inert = (
+    <span className="md-reflink" key={key}>{alt || href}<span className="md-reftarget">{href}</span></span>
+  );
+  if (!links || !links.src) return inert;
+  // Relative to the DOCUMENT, not to the page URL - the same rule links follow.
+  const hit = resolveRelative(links.dir, href);
+  if (!hit) return inert;
+  const url = links.src(hit.path);
+  if (!url) return inert;
+  // `alt` is the author's text and lands in an attribute React escapes. loading
+  // and decoding are here because a doc with a dozen screenshots should not
+  // block the render of the prose around them.
+  return (
+    <img className="md-img" key={key} src={url} alt={alt}
+         loading="lazy" decoding="async" />
+  );
+}
 
 function refLink(
   href: string, label: string, key: string, links?: MdLinks, wiki = false,
@@ -107,7 +168,7 @@ function refLink(
 // The wiki alternative comes FIRST and that is load-bearing: `[[dns]]` would
 // otherwise be matched by the inline-link arm as `[` followed by `[dns]`, and
 // the reader would print a stray bracket beside a broken link.
-const INLINE_RE = /(\[\[[^\]\n]+\]\])|(`[^`\n]+`)|(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)|(_[^_\n]+_)|(\[[^\]\n]*\]\([^)\s]+\))/g;
+const INLINE_RE = /(\[!\[[^\]\n]*\]\([^)\s]+\)\]\([^)\s]+\))|(!\[[^\]\n]*\]\([^)\s]+\))|(\[\[[^\]\n]+\]\])|(`[^`\n]+`)|(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)|(_[^_\n]+_)|(\[[^\]\n]*\]\([^)\s]+\))/g;
 
 function inlineMd(text: string, k: string, links?: MdLinks): ReactNode[] {
   const out: ReactNode[] = [];
@@ -122,7 +183,24 @@ function inlineMd(text: string, k: string, links?: MdLinks): ReactNode[] {
     // containing a link or a `code span` swallows it whole and prints the
     // markdown source - measured on docs/kb/access.md, whose second line is
     // exactly that shape. Code is terminal by definition: it is literal.
-    if (tok.startsWith('[[')) {
+    if (tok.startsWith('[![')) {
+      // `[![alt](image)](target)` - a badge. Semantically it is a LINK labelled
+      // by the image's alt text, so that is what it renders as: the label, and
+      // the target treated exactly like any other link. Rendering the image
+      // instead would put a remote chip where a link belongs and lose the target
+      // entirely.
+      const shut = tok.indexOf(')](');
+      const alt = tok.slice(3, tok.indexOf(']('));
+      const target = tok.slice(shut + 3, -1);
+      out.push(RE_WEB.test(target)
+        ? <a className="md-link" href={target} target="_blank" rel="noreferrer" key={key}>{alt || target}</a>
+        : refLink(target, alt || target, key, links));
+    } else if (tok.startsWith('![')) {
+      // Before the `[[` and `[` arms: the link pattern would match from the
+      // bracket and leave a stray `!` in the prose.
+      const cut = tok.indexOf('](');
+      out.push(mdImage(tok.slice(cut + 2, -1), tok.slice(2, cut), key, links));
+    } else if (tok.startsWith('[[')) {
       // `[[target]]` or `[[target|label]]`. It resolves through refLink, the
       // SAME path a relative markdown link takes - so a wikilink inherits the
       // property that file records at length: it never becomes an <a href>, and


### PR DESCRIPTION
Part of #103. Mermaid is deliberately **not** here — see the end.

## Images render

`![alt](screenshot.png)` used to come out as its own markdown source. README.md carries two screenshots and showed neither — in the app whose reason for existing is reading the files on this box.

Mostly **joining things that already existed**: the CSP already allows `img-src … http://$host:8100`, `resolveRelative()` already maps a target against the document's own directory, and `rawUrl()` already builds the sandbox-origin URL. What was missing was a `src` resolver on `MdLinks` — **supplied by the caller**, for the same reason `resolveWiki` is: answering it needs to know which root a document came from, and that is exactly the knowledge `md.tsx` is built not to have.

**Only repo-relative paths become an `<img>`**, and that's a decision, not an omission:

- The CSP doesn't reach third parties, so a remote image is blocked at load — allowing one buys a broken-image icon.
- Widening the CSP would let any document in any root make the reader's browser talk to a stranger. On a tailnet-only box, an `<img>` is an IP beacon.

Remote images render as a compact chip naming the alt text, URL in `title`.

### That chip is not cosmetic

README.md opens with **six shields.io badges**. The first version rendered each as alt text followed by a 90-character URL — turning the first screen of the most-read document on the box into a wall of query strings. I caught it in a screenshot before fixing it.

**Linked images are parsed too** — `[![alt](img)](target)`. Without a pattern for the whole shape, the tokenizer matched the inner image and left `](LICENSE)` sitting in the prose. A badge is semantically *a link labelled by its alt text*, so that's what it renders as — which also keeps the target, where rendering the image would have thrown it away.

## 16px body — and a correction

**I was wrong about half of this in #103.** The reader already had a proper measure: `--read-measure: 72ch`, with the reasoning written down, rendering at *exactly* 72 characters — verified in the browser rather than assumed. The 1320px I cited is the page shell, not the reader.

What was actually wrong is the **size**: the body was set at the app's UI size, and a document is not a dashboard. Because the measure is in `ch`, raising the size keeps 72 characters and widens the column, which is the intended relationship.

`max-width: 100%` on images is load-bearing: the screenshots are 1280px against a ~660px measure, and before the rule the image rendered at 1280px and every paragraph after it reflowed to that width.

## Verified in a browser, on the real box

| | |
|---|---|
| body | 16px |
| line | 68 characters |
| images | both constrained to the measure, no horizontal page scroll |
| badges | 6 chips, no `img.shields.io` anywhere in the rendered text |
| stray `](LICENSE)` | gone |

Plus: portal harness 0 FAIL, stray-colour clean, `just verify` 23/23, `files-check` clean.

## Not done here: mermaid

The repo ships **7 mermaid diagrams** (1 README, 6 ARCHITECTURE) and they still render as code fences. It needs a *security decision* rather than a patch — mermaid emits SVG and wants `innerHTML`, which is the one property this renderer refuses to give up, and which is why file content can't become markup today. Left open in #103 rather than smuggled in here.