### PR TITLE
ci: stop installing shellcheck that is already on the runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,21 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+          # shellcheck ships ON the GitHub ubuntu images. Installing it anyway cost
+          # a 15-minute hang on 2026-08-18: apt-get stalled, the job sat there
+          # until its timeout, and GitHub reported the result as "cancelled" -
+          # which reads like somebody pressed a button rather than an
+          # infrastructure stall, and sent me looking at the wrong thing.
+          #
+          # So: use what is there, and only reach for apt when it genuinely is
+          # not - under a timeout, so the failure is a failure rather than a
+          # fifteen-minute wait.
+          if ! command -v shellcheck >/dev/null 2>&1; then
+            echo "shellcheck is not on this runner image - installing"
+            timeout 120 sudo apt-get update -qq || { echo "apt-get update stalled"; exit 1; }
+            timeout 120 sudo apt-get install -y -qq shellcheck || { echo "apt-get install stalled"; exit 1; }
+          fi
+          shellcheck --version | sed -n '2p'
           # -x follows `. scripts/lib/env.sh` so sourced definitions are known.
           #
           # WARNINGS ARE FATAL, not just errors. The expected move here was to
@@ -141,8 +155,27 @@ jobs:
       # One row plants an unguarded `cd` and requires shellcheck to catch it.
       # Without the tool that row SKIPS - out loud, but it still skips, and this
       # is the job whose whole purpose is that nothing quietly stops running.
+      # One mutation plants an unguarded `cd` and requires shellcheck to catch
+      # it. Same guard as the tree job - and this is the job the apt-get hang
+      # actually killed.
       - name: shellcheck (one mutation needs it)
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+        run: |
+          set -euo pipefail
+          # shellcheck ships ON the GitHub ubuntu images. Installing it anyway cost
+          # a 15-minute hang on 2026-08-18: apt-get stalled, the job sat there
+          # until its timeout, and GitHub reported the result as "cancelled" -
+          # which reads like somebody pressed a button rather than an
+          # infrastructure stall, and sent me looking at the wrong thing.
+          #
+          # So: use what is there, and only reach for apt when it genuinely is
+          # not - under a timeout, so the failure is a failure rather than a
+          # fifteen-minute wait.
+          if ! command -v shellcheck >/dev/null 2>&1; then
+            echo "shellcheck is not on this runner image - installing"
+            timeout 120 sudo apt-get update -qq || { echo "apt-get update stalled"; exit 1; }
+            timeout 120 sudo apt-get install -y -qq shellcheck || { echo "apt-get install stalled"; exit 1; }
+          fi
+          shellcheck --version | sed -n '2p'
 
       # `npm ci` leaves the tree clean, but a cache restore or a generated file
       # would not, and mutants.sh refuses to run dirty. Failing HERE names the


### PR DESCRIPTION
The `mutants` job hung for **fifteen minutes** on

```
sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
```

then hit its `timeout-minutes: 15`. GitHub reports a timeout as **CANCELLED**, which reads like somebody pressed a button rather than an infrastructure stall — and sent me reading the mutation harness before the log showed one step spanning `19:20:40 → 19:35:45`.

**shellcheck ships on the GitHub ubuntu images.** The install was never needed. It was a fifteen-minute hang risk on every run of two jobs, for a binary already on the box.

## The fix

- Use what's on the runner.
- Fall back to apt only when it genuinely isn't there.
- `timeout 120` on both apt calls, so a stall is a *failure* rather than a wait.
- Print the version, so a runner image that ever drops shellcheck says so in one line instead of being diagnosed from timestamps.

Applied to both jobs — `tree` makes the identical call and got lucky that run.

## Why it's its own PR

It was originally committed onto the docs-reader branch by mistake, which put an unrelated CI change inside that PR. Split out here so it can merge on its own and unblock #106, which is currently red for exactly this flake and nothing else — every other check on it passed, including the full install job.