### PR TITLE
fix(settings): say that a theme you wrote is a file, not a browser key

### DIFF
--- a/apps/portal-next/web/src/pages/Settings.css
+++ b/apps/portal-next/web/src/pages/Settings.css
@@ -122,11 +122,6 @@
      never truncated to one line - the row heights vary and that is correct. */
 }
 
-/* The swatch row carries the theme's OWN tokens (the element sets
-   data-bothy-theme), so these rules must not paint any colour themselves. */
-
-
-
 /* A theme that came from the box rather than from the bundle. Quiet: it answers
    "where did this come from" for someone who is looking, and says nothing to
    anyone who is not. */

--- a/apps/portal-next/web/src/pages/Settings.tsx
+++ b/apps/portal-next/web/src/pages/Settings.tsx
@@ -335,6 +335,15 @@ const STORES = [
       + 'they are used - the theme button in the topbar, the panes themselves - rather than here.',
   },
   {
+    what: 'A theme you wrote yourself',
+    where: 'The box, as a file',
+    store: THEME_DIR_HOST,
+    why: 'The row above is the CHOICE - one key naming a theme, per browser. The theme itself is a '
+      + '.css file on disk, shared by every browser that reaches this box, and it outlives that '
+      + 'choice: clearing this browser forgets which theme you picked, not the file you wrote. It is '
+      + 'also the only thing on this page you change with an editor rather than with the page.',
+  },
+  {
     what: 'Your username, email, subject id and roles',
     where: 'Your account',
     store: 'Keycloak',


### PR DESCRIPTION
The smallest independent piece of #95, and the one factual gap in its "say where each setting lives" ask.

`Settings.tsx`'s `Storage` panel exists to answer *where does each setting live*. Its first row says **theme → localStorage**, and nothing in the table said that a **custom** theme is a `.css` file on the box. That only appeared as prose inside the Appearance lede — the one place a reader looking for "what is stored where" wouldn't look.

The new row states the distinction rather than just adding the path:

- the localStorage key is the **choice**, per browser
- the file is the **theme**, shared by every browser that reaches this box, and it outlives the choice

Clearing this browser forgets which theme you picked, not the file you wrote. It's also the only thing on that page you change with an editor rather than with the page — which fits how the rest of the panel is written.

Also removes a stranded comment in `Settings.css` and the three blank lines after it: it described swatch rules that moved to `themes/picker.css`, which carries the reasoning in full, including why they had to leave (they broke `stray-colour.mjs`).

Verified: `npm run typecheck`, `npm run build`, and `stray-colour.mjs` (123 files scanned, pass).

Part of #95; does not close it — the design pass is still open.