### PR TITLE
fix(files): the IDE opened on the one root that aliases every other

### DIFF
--- a/apps/portal-next/checks/redirect-table.mjs
+++ b/apps/portal-next/checks/redirect-table.mjs
@@ -17,7 +17,7 @@
 // the old name.
 
 import { LEGACY_PATHS, LIVE_PATHS, legacyTarget } from './redirects.mjs';
-import { EDIT_PATH, READ_PATH, filesHref, filesMode, filesTarget } from './files-routes.mjs';
+import { EDIT_PATH, READ_PATH, defaultRoot, filesHref, filesMode, filesTarget } from './files-routes.mjs';
 
 let bad = 0;
 const check = (label, got, want) => {
@@ -166,6 +166,70 @@ check('a bare /files parses', filesTarget('/files'), { mode: 'read', root: '', p
 // button is a link to the page it is already on.
 check('the two modes differ',
   filesHref('read', 'stacks', 'a.md') !== filesHref('edit', 'stacks', 'a.md'), true);
+
+console.log('\n── a link with no root lands somewhere worth reading ───');
+
+// THE SAME DEFECT ONE MORE TIME: a page that answers 200 and renders a
+// plausible listing that is not the one anybody wanted. `/files` and
+// `/files/edit` both have to choose a root when the URL names none (or names one
+// that no longer exists), and for a year the IDE chose `r.roots[0]`.
+//
+// That is not a neutral choice. The service returns roots ALPHABETICALLY, and on
+// this box `/roots` answers home, notes, projects, stacks - so roots[0] is
+// `home`, the one root that is read-only, holds ~4,000 entries, and carries
+// `aliases = true` in apps/portal-files/policy.toml. Opening the IDE meant
+// seeing every document twice, and the second copy under a root that refuses
+// writes. Nothing on screen says "you are in the aliasing root".
+//
+// Expectations are written longhand and NOT derived from the module.
+
+// The shape this box really returns, verified against the live service. `notes`
+// is the answer: first root that is not read-only, not first root.
+const REAL_ROOTS = [
+  { key: 'home', readOnly: true },
+  { key: 'notes', readOnly: false },
+  { key: 'projects', readOnly: true },
+  { key: 'stacks', readOnly: false },
+];
+check('this box: home,notes,projects,stacks -> notes', defaultRoot(REAL_ROOTS), 'notes');
+// Stated separately, because it is the whole bug: the answer must not be the
+// alphabetically-first root just because the list arrives sorted.
+check('the alphabetically first root is not the answer',
+  defaultRoot(REAL_ROOTS) !== REAL_ROOTS[0].key, true);
+
+// ABSENT `readOnly` MEANS WRITABLE. The field is optional in FileRoot and the
+// service sends it explicitly on every root today - but the declared type and
+// the wire shape have already drifted apart once (`label` and `writableSuffixes`
+// are declared and never sent). If a root ever arrives without the field, it has
+// to read as writable: the alternative spelling would call every root read-only
+// and drop the whole box back on `home`, which is precisely the bug.
+check('a root with no readOnly field is writable',
+  defaultRoot([{ key: 'home', readOnly: true }, { key: 'notes' }]), 'notes');
+check('all fields absent -> the first is fine',
+  defaultRoot([{ key: 'notes' }, { key: 'stacks' }]), 'notes');
+
+// Nothing writable anywhere - a viewer-only mount, or policy.toml with every
+// `writable = false`. A read-only listing beats an empty page, so it falls back
+// to the first root rather than returning undefined and rendering `?root=`
+// with the string "undefined" in it.
+check('every root read-only -> the first one',
+  defaultRoot([{ key: 'home', readOnly: true }, { key: 'projects', readOnly: true }]), 'home');
+
+// One root, and it is writable: no fallback logic gets a say.
+check('a single writable root', defaultRoot([{ key: 'notes', readOnly: false }]), 'notes');
+
+// THE CONTRACT FOR NOTHING AT ALL. `/roots` can answer `{"roots":[]}` - a
+// misconfigured policy.toml, or a mount that is not there yet - and this runs
+// inside a `.then()` whose rejection path is the sign-in card. Throwing would
+// tell a signed-in visitor to sign in, so it returns '' and filesHref renders a
+// bare `/files`, which is the honest empty state.
+check('no roots at all returns the empty string', defaultRoot([]), '');
+check('no roots at all does not throw', (() => {
+  try { defaultRoot([]); return 'no throw'; } catch { return 'threw'; }
+})(), 'no throw');
+// And that empty string has to survive the URL builder as "no root named",
+// rather than becoming `?root=`.
+check('the empty root builds a bare /files', filesHref('read', defaultRoot([])), '/files');
 
 console.log('\n── the router and the redirect table agree ─────────────');
 

--- a/apps/portal-next/web/src/pages/files/Files.tsx
+++ b/apps/portal-next/web/src/pages/files/Files.tsx
@@ -75,7 +75,7 @@ import { SignInCard } from './SignInCard';
 import { SourceControl } from './SourceControl';
 import { decorate, NO_DECORATIONS, type Change } from './gitdeco';
 import { usePanes } from './panes';
-import { filesHref } from './routes';
+import { defaultRoot, filesHref } from './routes';
 import { ancestorsOf, baseName, buildTree, defaultMessage, type Node } from './tree';
 
 import './shell.css';
@@ -338,8 +338,9 @@ export function Files() {
     setRaised((prev) => (prev.some((x) => x.id === p.id) ? prev : [p, ...prev].slice(0, 50)));
   }, []);
 
-  // Roots. The first one is the default, so the page does not hard-code a root
-  // name it may not have any more.
+  // Roots. `defaultRoot` picks the landing root, so the page does not hard-code
+  // a root name it may not have any more - and does not land on `home`, which is
+  // what taking the first of an alphabetical list used to mean here.
   useEffect(() => {
     const ac = new AbortController();
     listRoots(ac.signal)
@@ -348,14 +349,18 @@ export function Files() {
         setNeedsAuth(false);
         if (!r.roots.length) return;
         // No root, or a root that no longer exists (the set widened once and can
-        // widen again, and people bookmark these URLs): fall back to the first
-        // one rather than letting a stale link render a 400 as if the service
-        // were broken. `replace`, so Back does not bounce off the dead URL.
+        // widen again, and people bookmark these URLs): fall back to
+        // `defaultRoot` rather than letting a stale link render a 400 as if the
+        // service were broken. `replace`, so Back does not bounce off the dead
+        // URL. The rule itself - and why it is not `r.roots[0]`, which is what
+        // this was and which opened the IDE on the one root that aliases every
+        // other - is documented with the function in routes.ts.
         if (!urlRoot || !r.roots.some((x) => x.key === urlRoot)) {
+          const pick = defaultRoot(r.roots);
           const nextParams = new URLSearchParams();
-          nextParams.set('root', r.roots[0].key);
+          nextParams.set('root', pick);
           setParams(nextParams, { replace: true });
-          setBrowseRoot(r.roots[0].key);
+          setBrowseRoot(pick);
         }
       })
       .catch((e: unknown) => {

--- a/apps/portal-next/web/src/pages/files/Reader.tsx
+++ b/apps/portal-next/web/src/pages/files/Reader.tsx
@@ -39,7 +39,7 @@ import { FileView } from './FileView';
 import { SearchView } from './Search';
 import { SignInCard } from './SignInCard';
 import { Toc, useHeadings } from './Toc';
-import { filesHref } from './routes';
+import { defaultRoot, filesHref } from './routes';
 import { baseName, dirName, resolveWikiIn } from './tree';
 import { fetchLinks, type LinkIndex } from '../../lib/files';
 
@@ -111,9 +111,10 @@ export function Reader() {
 
   // ── the roots ──────────────────────────────────────────────────────────────
   //
-  // Same fallback as the editor's: a `?root=` naming a root that no longer
-  // exists lands on the first one rather than rendering a 400 as if the service
-  // were broken. `replace`, so Back does not bounce off the dead URL.
+  // Same fallback as the editor's, and now literally the same function: a
+  // `?root=` naming a root that no longer exists lands on `defaultRoot(...)`
+  // rather than rendering a 400 as if the service were broken. `replace`, so
+  // Back does not bounce off the dead URL.
   useEffect(() => {
     const ac = new AbortController();
     listRoots(ac.signal)
@@ -123,18 +124,10 @@ export function Reader() {
         setRootsErr(null);
         if (!r.roots.length) return;
         const known = r.roots.some((x) => x.key === urlRoot);
-        // NOT roots[0]. The service returns them alphabetically, which put
-        // `home` first - the one root that is read-only, holds ~4,000 entries,
-        // and ALIASES every other root, so everything worth reading appeared
-        // twice under a name that cannot be written to. Landing there was an
-        // accident of sort order, and it made the reader open on the worst
-        // possible listing.
-        //
-        // A writable root is the one somebody keeps documents in; `readOnly`
-        // already travels with each root, so this needs nothing new from the
-        // service. Falls back to whatever exists if every root is read-only.
-        const best = r.roots.find((x) => !x.readOnly) ?? r.roots[0];
-        const pick = known ? urlRoot : best.key;
+        // Why this is not roots[0], and why absent `readOnly` means writable,
+        // live with the rule in routes.ts - the reader is one of two callers and
+        // the reasoning is not the reader's.
+        const pick = known ? urlRoot : defaultRoot(r.roots);
         if (!known) {
           const next = new URLSearchParams();
           next.set('root', pick);

--- a/apps/portal-next/web/src/pages/files/routes.ts
+++ b/apps/portal-next/web/src/pages/files/routes.ts
@@ -69,3 +69,47 @@ export function filesTarget(
   const q = new URLSearchParams(search.replace(/^\?/, ''));
   return { mode, root: q.get('root') ?? '', path: q.get('path') ?? '' };
 }
+
+/** The minimum a root has to look like to be chosen between. Written out here
+ *  rather than imported from lib/files.ts because THIS MODULE IMPORTS NOTHING
+ *  (see the header): that is what lets checks/run.sh compile it with a bare
+ *  `npx tsc` and run a truth table over it with no bundler and no test runner.
+ *  `FileRoot` carries more fields, and every one of them is irrelevant here. */
+export interface RootChoice {
+  key: string;
+  readOnly?: boolean;
+}
+
+/**
+ * Which root a Files URL with no usable `?root=` should land on. It sets
+ * `?root=`, so it is a URL decision, so it lives beside the other two.
+ *
+ * NOT roots[0]. The service returns them alphabetically, which put `home`
+ * first - the one root that is read-only, holds ~4,000 entries, and ALIASES
+ * every other root (`aliases = true` in apps/portal-files/policy.toml), so
+ * everything worth reading appeared twice under a name that cannot be written
+ * to. Landing there was an accident of sort order, and it opened the reader -
+ * and, until this function existed, the IDE - on the worst possible listing.
+ *
+ * A writable root is the one somebody keeps documents in; `readOnly` already
+ * travels with each root, so this needs nothing new from the service.
+ *
+ * ABSENT `readOnly` MEANS WRITABLE. The field is optional in the type and the
+ * service sends it on every root today, so the two agree - but the gap is real
+ * (`label` and `writableSuffixes` are declared and never sent), and the inverse
+ * spelling, `roots.find((x) => x.writable)`, would read a field the service
+ * stopped sending as "read-only everywhere" and send every visitor back to
+ * `home`. `!x.readOnly` fails the safe way round.
+ *
+ * Falls back to the first root when every root is read-only - a listing of
+ * something beats an empty page - and to `''` when the list is empty, which
+ * `filesHref` already renders as a bare `/files`. It never throws and never
+ * returns undefined: both callers run it inside a `.then()` whose rejection
+ * path is the sign-in-required branch, so a throw here would tell somebody
+ * already signed in to sign in.
+ */
+export function defaultRoot(roots: RootChoice[]): string {
+  if (!roots.length) return '';
+  const best = roots.find((x) => !x.readOnly) ?? roots[0];
+  return best.key;
+}


### PR DESCRIPTION
Fixes the bug described in #94. The "Your files" landing-root **feature** from that issue is deliberately **not** here — this is the bug half only, and #94 stays open for the feature.

## What was wrong

`/files/edit` (the IDE) picked its landing root with `r.roots[0].key`, in two places, whenever the URL named no root or named one that no longer exists.

The file service returns roots **alphabetically**. On this box `GET /roots` answers:

```json
{"roots":[{"key":"home","readOnly":true},
          {"key":"notes","readOnly":false},
          {"key":"projects","readOnly":true},
          {"key":"stacks","readOnly":false}]}
```

so `roots[0]` is `home` — and `home` is the one root that must not be the default:

- it is **read-only** (`writable = false` in `apps/portal-files/policy.toml`, and mounted `:ro` besides),
- it holds roughly **4,000 entries**,
- and it carries **`aliases = true`**, meaning it overlaps every other root.

Concretely: a user opening the IDE saw every document **twice** — once at `notes/network/dns.md` and once at `home/claude-notes/network/dns.md` — and the copy they landed on was under a root that refuses writes. Clicking through from the tree opened a read-only view of a file that is perfectly editable thirty characters away under another name. Nothing on screen says "you are in the aliasing root"; it just looks like the box has twice as many files as it does and none of them can be saved.

`/files` (the reader) already got this right, and carried a comment calling `roots[0]` "the worst possible listing". The IDE did it anyway. Two components, one decision, one of them correct.

## The fix

One shared function, `defaultRoot(roots)`, in `pages/files/routes.ts`:

```ts
export function defaultRoot(roots: RootChoice[]): string {
  if (!roots.length) return '';
  const best = roots.find((x) => !x.readOnly) ?? roots[0];
  return best.key;
}
```

**Why `routes.ts` and not `lib/files.ts`.** Choosing a default root *is* a URL decision — it sets `?root=` — and that module's header states the policy: one URL decision, one module, one truth table over it. Both callers already import from it, and `checks/run.sh` already compiles it with a bare `npx tsc` to `files-routes.mjs`, so the truth table cost nothing new. `routes.ts` stays import-free, so `defaultRoot` takes the minimal structural type (`{ key: string; readOnly?: boolean }`) rather than importing `FileRoot`.

Reader.tsx's comment **moved into the function** — it is the reasoning for the rule, not for one of two callers. Three stale comments are corrected along the way: `Reader.tsx` said a bad root "lands on the first one" while the code three lines below did the opposite, and `Files.tsx` said "The first one is the default" twice.

## Absent `readOnly` means writable

The service sends `readOnly` explicitly on every root today, but the type declares it optional — and the declared type and the wire shape have already drifted (`label` and `writableSuffixes` are declared and never sent). `!x.readOnly` fails the safe way round; the inverse spelling `x.writable === true` would read a field the service stopped sending as "read-only everywhere" and send every visitor straight back to `home`. That is a named case in the truth table with the reason attached, not just an entry.

## The check

Nine cases added to `checks/redirect-table.mjs`, in a new section — the real shape this box returns, the alphabetical-first root explicitly *not* being the answer, absent `readOnly`, every root read-only (falls back to the first — a read-only listing beats an empty page), a single writable root, and the empty list (returns `''`, does not throw; it runs inside a `.then()` whose rejection path is the sign-in card, so a throw would tell a signed-in visitor to sign in).

**Proved it can fail.** Reverting `defaultRoot` to `return roots[0].key` turns three of the nine red and `run.sh` exits 1:

```
FAIL  this box: home,notes,projects,stacks -> notes        want="notes" got="home"
FAIL  the alphabetically first root is not the answer      want=true got=false
FAIL  a root with no readOnly field is writable            want="notes" got="home"
```

## Verified

- `npm run typecheck` — clean
- `npm run build` — clean
- `bash apps/portal-next/checks/run.sh --offline` — all pass, exit 0
