### PR TITLE
feat(theme-editor): the raw-CSS pane types in the real code editor

### DIFF
--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -103,7 +103,7 @@ fi
 
 echo
 echo "── every theme keeps the palette's contract ────────────"
-# Reads index.css, shell.css and src/themes/*.css directly. Runs against the two
+# Reads index.css, hl.css and src/themes/*.css directly. Runs against the two
 # SHIPPED palettes as well as the named themes, on purpose: a rule that fails on
 # Bothy's own colours is a wrong rule, and this is where that gets found out.
 #

--- a/apps/portal-next/checks/stray-colour.mjs
+++ b/apps/portal-next/checks/stray-colour.mjs
@@ -42,9 +42,12 @@ const SRC = join(HERE, '..', 'web', 'src');
 const EXEMPT = new Map([
   ['index.css',
     'defines the tokens. This is the palette; it is where the literals live.'],
-  ['pages/files/shell.css',
+  ['hl.css',
     'defines the five --hl-* syntax tokens for both themes. Same job as '
-    + 'index.css, kept beside the editor it serves.'],
+    + 'index.css. Its own file rather than part of the Files shell because a '
+    + 'second surface - the theme editor CSS pane - renders code on a route '
+    + 'that must not load that shell, and the alternative was a second copy of '
+    + 'these eight hexes, which is the bug this check exists to catch.'],
   ['components/three/webgl.ts',
     'the ScenePalette and the STATUS_HEX mirror. The 3D scene paints with real '
     + 'materials and cannot resolve a CSS variable into a mesh colour, so its '

--- a/apps/portal-next/checks/theme-contract.mjs
+++ b/apps/portal-next/checks/theme-contract.mjs
@@ -103,7 +103,7 @@ function blocks(css) {
 }
 
 const indexCss = readFileSync(join(SRC, 'index.css'), 'utf8');
-const shellCss = readFileSync(join(SRC, 'pages', 'files', 'shell.css'), 'utf8');
+const hlCss = readFileSync(join(SRC, 'hl.css'), 'utf8');
 const idx = blocks(indexCss);
 
 const merge = (...sets) => Object.assign({}, ...sets);
@@ -112,11 +112,16 @@ const pick = (pred) => merge(...idx.filter((b) => pred(b.sel)).map((b) => b.toks
 const BASE = pick((s) => s === ':root');
 const LIGHT = pick((s) => /^:root\[data-theme=['"]?light/.test(s));
 
-// The syntax palette lives beside the editor it serves rather than in index.css.
-// A theme that restyles everything except code is not a theme, so it is part of
-// the contract - but as an OPTIONAL group, because a theme that omits it falls
-// back to a set that is already contrast-checked for its appearance.
-const hlBlocks = blocks(shellCss).filter((b) => b.sel.includes('bothy-files'));
+// The syntax palette has its own file rather than sitting in index.css: two
+// surfaces render code now - the Files window and the theme editor's CSS pane -
+// and only one of them loads the Files shell. A theme that restyles everything
+// except code is not a theme, so it is part of the contract - but as an OPTIONAL
+// group, because a theme that omits it falls back to a set that is already
+// contrast-checked for its appearance.
+//
+// Still filtered on `bothy-files`: a theme's own override names that scope, so
+// that is the selector this file has to agree with.
+const hlBlocks = blocks(hlCss).filter((b) => b.sel.includes('bothy-files'));
 
 // THE SYNTAX PALETTE IS THE `--hl-*` TOKENS, NOT THE WHOLE BLOCK. Those blocks
 // also carry the editor's LAYOUT - --rail-l, --rail-r, --panel-h, --code-fs,
@@ -125,7 +130,7 @@ const hlBlocks = blocks(shellCss).filter((b) => b.sel.includes('bothy-files'));
 // Tokyo Night declare a rail width, which it should never do.
 //
 // The prefix IS the group's definition here rather than a list to maintain: a
-// sixth --hl-* token added to shell.css becomes required of every theme
+// sixth --hl-* token added to hl.css becomes required of every theme
 // automatically, and a new structural token stays out without anyone deciding.
 const syntaxOnly = (t) => Object.fromEntries(
   Object.entries(t).filter(([k]) => k.startsWith('--hl-')));
@@ -161,7 +166,7 @@ const render = (f) => {
 function checkTheme(name, appearance, toks, hl) {
   console.log(`\n── ${name}  (${appearance}) ─────────────────────────────────`);
   // The set a theme inherits when it declares nothing, which is also the set it
-  // must declare in FULL once it declares any of it. Derived from shell.css so a
+  // must declare in FULL once it declares any of it. Derived from hl.css so a
   // sixth syntax token becomes required everywhere the moment it is added, with
   // nothing here to remember to update.
   const syntaxBase = appearance === 'light' ? merge(HL_DARK, HL_LIGHT) : HL_DARK;

--- a/apps/portal-next/web/src/components/CodeBoundary.tsx
+++ b/apps/portal-next/web/src/components/CodeBoundary.tsx
@@ -1,0 +1,29 @@
+// ── the guard around a lazily-loaded code surface ────────────────────────────
+//
+// CodeMirror arrives as its own 332 kB chunk, behind `lazy()`, on a link that
+// can fail: a deploy that replaced the assets under a long-lived tab, a captive
+// portal, a flaky tailnet hop. A failed chunk load is not an exception React can
+// recover from on its own, and the default is a blank pane - on a page that may
+// be holding unsaved work. This pins the session to the plain `<textarea>` and
+// SAYS which of the two the reader is looking at, because "my editor lost its
+// line numbers" with no explanation is a bug report.
+//
+// Lives out here rather than in pages/files/Editor.tsx because it has two
+// consumers now - that editor and the theme editor's raw-CSS pane - and
+// importing it from Editor.tsx would have pulled the whole Files window into the
+// Settings route's chunk to get at a nine-line class.
+
+import { Component } from 'react';
+
+export class CodeBoundary extends Component<
+  { children: React.ReactNode; fallback: React.ReactNode; onFail: () => void },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() { return { failed: true }; }
+
+  componentDidCatch() { this.props.onFail(); }
+
+  render() { return this.state.failed ? this.props.fallback : this.props.children; }
+}

--- a/apps/portal-next/web/src/hl.css
+++ b/apps/portal-next/web/src/hl.css
@@ -1,0 +1,54 @@
+/* ── the syntax palette ──────────────────────────────────────────────────────
+   Five token classes, which is all a viewer needs: comment, string, keyword,
+   number, key/variable.
+
+   WHY THIS IS ITS OWN FILE. It lived in pages/files/shell.css while the Files
+   window was the only place in the app that rendered code. The theme editor's
+   raw-CSS pane is the second, and it is on a route that must not load the Files
+   shell - so the choice was a second copy of these eight hexes or a file both
+   can import. A second copy is the exact bug stray-colour.mjs exists to catch:
+   two palettes that agree today and diverge the first time one is tuned.
+
+   Both consumers name themselves in the selectors below rather than the rules
+   being written twice, and `cmtheme.ts` maps CodeMirror's generated classes onto
+   the same five properties - so there is still exactly one place a code colour
+   is decided.
+
+   Chosen to stay OUT of the status hues. --st-up is green, --st-warn amber,
+   --st-down rose, and the standing rule is that those colours mean state and
+   nothing else - so a highlighter built on the usual red-keyword/green-string
+   scheme would put two status colours on every screen of code and spend the
+   page's alarm budget on a `const`. Violet, sky, pink and indigo are all outside
+   that set, and none of them appears anywhere else in the app as a
+   meaning-bearing colour.
+
+   Base values are the DARK ones, matching index.css's dark-first model
+   (`:root` is dark, `:root[data-theme='light']` overrides). lib/theme.tsx always
+   stamps a concrete data-theme, so both branches are always reachable, and no
+   colour here exists in only one of them. Every value clears 4.5:1 on the
+   surface it is painted on (--bg-2 in each theme).
+
+   The doubled `.bothy-files.bothy-files` is load-bearing and predates this file:
+   a theme overrides these under `:root[data-bothy-theme='x'] .bothy-files
+   .bothy-files`, and the base set has to lose that tie. `.theme-editor .fx-cm`
+   carries the same (0,2,0) weight and can never match inside the Files window,
+   so the two selectors cannot collide on one element. What a THEME's own syntax
+   colours do not reach is the theme editor's pane - those overrides name
+   `.bothy-files` and nothing else - so the pane paints code in the base set
+   above whichever theme is live. That is a wart, not a bug: it is the palette
+   the file you are editing cannot change. */
+.bothy-files.bothy-files,
+.theme-editor .fx-cm {
+  --hl-com: var(--fg-subtle);
+  --hl-kw:  #c4b5fd;   /* violet-300  ·  9.6 on #0b0b0d */
+  --hl-str: #7dd3fc;   /* sky-300     ·  11.1 */
+  --hl-num: #f9a8d4;   /* pink-300    ·  10.2 */
+  --hl-key: #a5b4fc;   /* indigo-300  ·  8.9  */
+}
+:root[data-theme='light'] .bothy-files.bothy-files,
+:root[data-theme='light'] .theme-editor .fx-cm {
+  --hl-kw:  #6d28d9;   /* violet-700  ·  7.9 on #f4f4f5 */
+  --hl-str: #0369a1;   /* sky-700     ·  6.4 */
+  --hl-num: #a21caf;   /* fuchsia-700 ·  6.6 */
+  --hl-key: #4338ca;   /* indigo-700  ·  8.0 */
+}

--- a/apps/portal-next/web/src/pages/ThemeEditor.css
+++ b/apps/portal-next/web/src/pages/ThemeEditor.css
@@ -97,14 +97,177 @@
 }
 .theme-editor .te-more:hover { text-decoration: underline; }
 
-/* ── the file ─────────────────────────────────────────────────────────────── */
+/* ── the file ────────────────────────────────────────────────────────────────
+   Two surfaces, one look. `.te-css` is the plain textarea, which is still what
+   renders while CodeMirror's chunk is in flight and what the page falls back to
+   for good if that chunk never arrives; `.te-code` is the frame around the real
+   editor. They are sized the same on purpose - the swap happens under a reader
+   who is already looking at the box, and a box that jumps 40px as it upgrades
+   reads as a bug. */
 .theme-editor .te-css {
   width: 100%; min-height: 320px; margin-top: 10px; padding: 10px 12px;
   font-size: 12.5px; line-height: 1.55;
-  color: var(--fg); background: var(--bg);
+  color: var(--fg); background: var(--bg-2);
   border: 1px solid var(--line); border-radius: var(--r-sm);
   resize: vertical; white-space: pre;
 }
+
+/* ── the code surface ────────────────────────────────────────────────────────
+   CodeMirror 6, styled from out here, exactly as pages/files/editor.css does it
+   and for the same two reasons: style-mod inserts CodeMirror's own <style> as
+   the FIRST child of <head>, so this sheet always comes later and wins every
+   specificity tie, and every rule below is `.theme-editor .cm-*` - (0,2,0)
+   against CodeMirror's own (0,2,0). Nothing here needs `!important`.
+
+   THIS IS NOT editor.css RE-IMPORTED, and must not become it. That file styles
+   an IDE: four regions, a flex column that fills the viewport, indent guides, a
+   hover band, a status strip. This is one pane in a form, with a fixed height
+   somebody can drag. The overlap is the parts CodeMirror insists on having an
+   opinion about - the gutter, the caret, the selection, the find panel - and
+   those are written against the same tokens, so a theme repaints both.
+
+   COLOURS. Every value is a token or a colour-mix of one, including the --hl-*
+   set imported by ThemeEditor.tsx. There is no second palette here. */
+.theme-editor .te-code {
+  margin-top: 10px; height: 420px; min-height: 180px;
+  /* `resize` needs a non-visible overflow to do anything, and the rounded
+     corners need it anyway or the gutter paints over them. */
+  overflow: hidden; resize: vertical;
+  /* --bg-2, not --bg, and it is not a taste call: the contract check asserts
+     every --hl-* value clears 4.5:1 ON --bg-2, because that is the ground the
+     Files editor paints code on. Painting this pane on anything else would put
+     the syntax palette on a surface nothing measured. */
+  background: var(--bg-2);
+  border: 1px solid var(--line); border-radius: var(--r-sm);
+}
+/* The Suspense fallback renders INSIDE this frame while the chunk is in flight,
+   so it drops its own frame and fills this one instead - otherwise there is a
+   border inside a border, and a box that visibly re-draws when the editor
+   arrives. (The permanent fallback, when the chunk never loads at all, is
+   rendered without this wrapper and keeps its own frame.) */
+.theme-editor .te-code > .te-css {
+  height: 100%; min-height: 0; margin: 0;
+  border: 0; border-radius: 0; resize: none;
+}
+
+/* The height has to be handed down explicitly: CodeMirror sizes itself to its
+   content unless something above it is definite, and an editor that grows with
+   the file would push the whole form off the page as you type. */
+.theme-editor .fx-cm, .theme-editor .fx-cm > .cm-editor { height: 100%; }
+.theme-editor .cm-editor {
+  background: var(--bg-2); color: var(--fg);
+  font-family: var(--mono); font-size: 12.5px;
+}
+/* NO focus ring, for the reason editor.css states at length: `.cm-focused` is
+   set on a plain mouse click, so a ring here draws a rectangle around the whole
+   pane the instant anyone clicks into it. `outline: none` rather than no rule at
+   all - CodeMirror's baseTheme ships `&.cm-focused { outline: 1px dotted
+   #212121 }`, so deleting this would swap our ring for a hardcoded grey one.
+   The caret and the active-line underline are the focus indicator. */
+.theme-editor .cm-editor.cm-focused { outline: none; }
+/* And the contenteditable inside it, which is the element that actually takes
+   focus and would otherwise pick up index.css's page-wide `*:focus-visible`
+   ring one box further in. */
+.theme-editor .cm-content:focus-visible { outline: none; }
+.theme-editor .cm-scroller { font-family: var(--mono); line-height: 1.55; overflow: auto; }
+.theme-editor .cm-content {
+  padding: 10px 0 22px; caret-color: var(--accent-fg);
+  /* Alignment is meaning in a token table: toCss() pads the value column so the
+     hexes line up, and wrapping would throw that away on the first long
+     shadow recipe. */
+  white-space: pre;
+}
+.theme-editor .cm-line { padding: 0 14px 0 6px; }
+
+.theme-editor .cm-gutters {
+  background: var(--bg-2); color: var(--fg-subtle);
+  border-right: 1px solid var(--line);
+  font-variant-numeric: tabular-nums;
+}
+.theme-editor .cm-lineNumbers .cm-gutterElement { padding: 0 8px 0 12px; opacity: .65; }
+.theme-editor .cm-gutters .cm-activeLineGutter {
+  background: transparent; color: var(--fg); opacity: 1; font-weight: 600;
+}
+
+/* The active line is an underline rather than a filled band, and an inset shadow
+   rather than a border: a border changes the line's height, so every line below
+   the caret would shift a pixel as you move and the file would jitter. */
+.theme-editor .cm-activeLine {
+  background: transparent;
+  box-shadow: inset 0 -1px 0 color-mix(in oklab, var(--accent) 55%, transparent);
+}
+.theme-editor .cm-editor.cm-focused .cm-activeLine { box-shadow: inset 0 -1px 0 var(--accent); }
+
+.theme-editor .cm-selectionBackground,
+.theme-editor .cm-content ::selection { background: color-mix(in oklab, var(--accent) 30%, transparent); }
+.theme-editor .cm-focused .cm-selectionBackground { background: color-mix(in oklab, var(--accent) 38%, transparent); }
+.theme-editor .cm-cursor, .theme-editor .cm-dropCursor {
+  border-left-color: var(--accent-fg); border-left-width: 2px;
+}
+/* Every other occurrence of the selection or the word under the caret - which on
+   this file is how you find the other three places a colour is used. Outlined
+   rather than filled: a fill at this frequency turns the pane into highlighter. */
+.theme-editor .cm-selectionMatch {
+  background: color-mix(in oklab, var(--hl-kw) 16%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--hl-kw) 45%, transparent);
+  border-radius: var(--r-xs);
+}
+.theme-editor .cm-matchingBracket, .theme-editor .cm-focused .cm-matchingBracket {
+  background: color-mix(in oklab, var(--hl-num) 22%, transparent);
+  outline: 1px solid color-mix(in oklab, var(--hl-num) 70%, transparent);
+  color: var(--fg);
+}
+.theme-editor .cm-nonmatchingBracket, .theme-editor .cm-focused .cm-nonmatchingBracket {
+  background: var(--st-down-bg); color: var(--st-down-fg);
+}
+.theme-editor .cm-searchMatch {
+  background: color-mix(in oklab, var(--hl-num) 22%, transparent); border-radius: var(--r-xs);
+}
+.theme-editor .cm-searchMatch-selected {
+  background: color-mix(in oklab, var(--hl-num) 55%, transparent);
+  outline: 1px solid var(--hl-num);
+}
+
+/* The find panel is CodeMirror's own, restyled onto the tokens. It arrives with
+   Ctrl-F because searchKeymap is installed in the surface, and it is the reason
+   this pane is worth having on a 60-line file: `--st-` finds every status token
+   in one keystroke. */
+.theme-editor .cm-panels {
+  background: var(--surface-2); color: var(--fg-muted);
+  border-bottom: 1px solid var(--line); font-size: 11.5px;
+}
+.theme-editor .cm-panels.cm-panels-bottom { border-top: 1px solid var(--line); border-bottom: 0; }
+.theme-editor .cm-panel.cm-search {
+  padding: 7px 12px; display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
+}
+.theme-editor .cm-panel.cm-search br { display: none; }
+.theme-editor .cm-panel.cm-search label {
+  display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: var(--fg-subtle);
+}
+.theme-editor .cm-panel.cm-search input.cm-textfield {
+  font-family: var(--mono); font-size: 11.5px; padding: 3px 7px; min-width: 160px;
+  background: var(--bg-2); color: var(--fg);
+  border: 1px solid var(--line); border-radius: var(--r-sm);
+}
+.theme-editor .cm-panel.cm-search input.cm-textfield:focus-visible {
+  outline: 2px solid var(--ring); outline-offset: -1px; border-color: var(--accent);
+}
+.theme-editor .cm-panel.cm-search button:not([name='close']) {
+  font: inherit; cursor: pointer; padding: 3px 9px;
+  background: var(--surface-1); color: var(--fg-muted);
+  border: 1px solid var(--line); border-radius: var(--r-sm);
+  background-image: none;
+}
+.theme-editor .cm-panel.cm-search button:not([name='close']):hover {
+  background: var(--surface-3); color: var(--fg);
+}
+.theme-editor .cm-panel.cm-search button[name='close'] {
+  position: absolute; top: 4px; right: 8px;
+  background: transparent; border: 0; cursor: pointer;
+  color: var(--fg-subtle); font-size: 16px; padding: 0 4px;
+}
+.theme-editor .cm-panel.cm-search button[name='close']:hover { color: var(--fg); }
+.theme-editor .cm-specialChar { color: var(--st-warn-fg); }
 
 /* The section notes. `.set-note` is scoped to `.settings-page` next door, so
    this page - which is a sibling route, not inside it - was rendering them at

--- a/apps/portal-next/web/src/pages/ThemeEditor.tsx
+++ b/apps/portal-next/web/src/pages/ThemeEditor.tsx
@@ -20,7 +20,7 @@
 // want to. The rules exist to stop you making a mistake by accident, not to
 // stop you making a decision.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AlertTriangle, ArrowLeft, Check, Code2, Save, Trash2 } from 'lucide-react';
 import { evaluateTheme, type Finding } from '../lib/contract';
@@ -33,10 +33,30 @@ import { deleteFile, isAuthError, readFile, writeFile } from '../lib/files';
 import { hasRole } from '../lib/me';
 import { useMe } from '../components/UserMenu';
 import { useTheme } from '../lib/theme';
+import { CodeBoundary } from '../components/CodeBoundary';
+import type { CodeHandle } from './files/CodeSurface';
+// The five --hl-* syntax tokens, which used to live in the Files shell. The pane
+// below is the second surface in the app that renders code, and it is on a route
+// that must not load that shell - see src/hl.css.
+import '../hl.css';
 import './ThemeEditor.css';
 
 const ROOT = 'stacks';
 const dirOf = (id: string) => `${THEME_DIR_HOST}${id}.css`;
+
+// The same CodeMirror surface the Files editor mounts, behind the same one line.
+// This page is imported EAGERLY by App.tsx - it is a Settings route, not a lazy
+// one - so a static import here would put 332 kB of editor in the entry chunk
+// and charge it to everyone who opens the portal. `npm run build` printing
+// CodeSurface-*.js as its own chunk is the check that it stayed out.
+const CodeSurface = lazy(() => import('./files/CodeSurface'));
+
+// The surface computes a cursor/selection stat on every transaction because the
+// Files editor's status strip reads one. There is no strip here and no room for
+// one beside the form, so this is where that fact is dropped. A module-level
+// no-op rather than an inline arrow: the surface holds callbacks in a ref, and
+// one that never changes identity is one less thing to reason about.
+const NO_STAT = () => {};
 
 export function ThemeEditor() {
   const { id: routeId } = useParams<{ id: string }>();
@@ -52,6 +72,41 @@ export function ThemeEditor() {
   const [notice, setNotice] = useState<{ tone: 'ok' | 'bad' | 'info'; text: string } | null>(null);
   const [showCss, setShowCss] = useState(false);
 
+  // ── the raw-CSS pane's text ───────────────────────────────────────────────
+  //
+  // Null means "show the file derived from the form". A string means somebody is
+  // typing in the pane and THAT text is what the pane shows, whatever toCss()
+  // would have produced from the draft it parsed into.
+  //
+  // WHY THAT IS NEEDED, and what breaks without it. `css` below is derived:
+  // toCss(draft). The pane parses what you type straight back into the draft, so
+  // one keystroke runs the whole loop -
+  //     keystroke -> fromCss -> setDraft -> toCss -> back into the pane
+  // - and `toCss(fromCss(x))` is not x. It re-aligns the value column, re-emits
+  // the group headings, drops any comment you wrote, and throws away a
+  // declaration that has no `;` yet, which is every declaration halfway through
+  // being typed.
+  //
+  // In a <textarea> that cost a caret jump to the end. In CodeMirror it is
+  // worse: the surface REPLACES its whole document whenever an incoming `value`
+  // differs from the last one it emitted (CodeSurface.tsx, the `[value]`
+  // effect), so the half-typed line would disappear and the caret would land at
+  // offset 0 - on every keystroke that normalises anything. That is an editor
+  // that eats what you type.
+  //
+  // So while the pane is being typed in it owns its own text, the surface only
+  // ever sees back exactly what it emitted, and its `[value]` effect stays
+  // asleep. The parse still runs, so the form fields and the live preview follow
+  // along keystroke by keystroke. This drops back to null - and the pane
+  // re-derives - the moment the draft changes from anywhere ELSE, which is a
+  // finite list: `set`, `setToken`, the load effect, and closing the pane. The
+  // reset is written at each of those rather than inferred from a diff, because
+  // "did this draft come from the pane" is not a question a diff can answer.
+  const [typedCss, setTypedCss] = useState<string | null>(null);
+  // A failed chunk load pins the pane to the plain textarea for the rest of the
+  // session rather than re-attempting the import on every render.
+  const [cssPlain, setCssPlain] = useState(false);
+
   const mayWrite = hasRole(me, 'editor');
 
   // ── load ──────────────────────────────────────────────────────────────────
@@ -61,6 +116,7 @@ export function ThemeEditor() {
       // A new theme starts from what is currently on screen. Seeding from a
       // fixed palette would put you on Bothy Dark while the page showed
       // something else, and the first thing you would do is undo that.
+      setTypedCss(null);
       setDraft({
         id: '', name: '', note: '', tokens: activeValues(names),
         appearance: document.documentElement.getAttribute('data-theme') === 'light'
@@ -71,6 +127,7 @@ export function ThemeEditor() {
     readFile(ROOT, dirOf(editing))
       .then((f) => {
         if (!alive) return;
+        setTypedCss(null);
         setDraft(fromCss(editing, f.content));
         // Carried so the save can send it back as baseMtime. Without it, two
         // tabs editing the same theme would silently overwrite each other -
@@ -126,12 +183,17 @@ export function ThemeEditor() {
     { ...draft, id: draft.id || slugify(draft.name) || 'untitled' }, names,
   ) : ''), [draft, names]);
 
+  // Both of these are "the draft changed from the FORM", which is precisely the
+  // case the CSS pane must re-derive for: what it is showing no longer describes
+  // the theme. See `typedCss` above.
   const set = useCallback((patch: Partial<Draft>) => {
     setDraft((d) => (d ? { ...d, ...patch } : d));
+    setTypedCss(null);
     setNotice(null);
   }, []);
   const setToken = useCallback((k: string, v: string) => {
     setDraft((d) => (d ? { ...d, tokens: { ...d.tokens, [k]: v } } : d));
+    setTypedCss(null);
     setNotice(null);
   }, []);
 
@@ -229,7 +291,14 @@ export function ThemeEditor() {
           </p>
         </div>
         <div className="te-actions">
-          <button type="button" className="btn" onClick={() => setShowCss((v) => !v)}>
+          {/* Closing the pane drops what was typed in it, so reopening starts from
+              the canonical file again. The buffer exists to stop the surface
+              fighting a caret mid-word; it is not a second draft. */}
+          <button
+            type="button"
+            className="btn"
+            onClick={() => { setShowCss((v) => !v); setTypedCss(null); }}
+          >
             <Code2 size={15} aria-hidden="true" /> {showCss ? 'Hide' : 'Show'} CSS
           </button>
           {editing && (
@@ -321,13 +390,21 @@ export function ThemeEditor() {
               This is exactly what gets written. Editing it here re-reads the tokens,
               so the form and the file cannot disagree.
             </p>
-            <textarea
-              className="te-css mono"
-              value={css}
-              spellCheck={false}
-              onChange={(e) => {
-                const next = fromCss(id || 'untitled', e.target.value);
-                setDraft((d) => (d ? { ...d, ...next, id: d.id } : d));
+            <CssPane
+              value={typedCss ?? css}
+              plain={cssPlain}
+              onFail={() => {
+                setCssPlain(true);
+                setNotice({
+                  tone: 'info',
+                  text: 'The code editor could not be loaded, so this is a plain text box. '
+                    + 'Everything else on the page is unaffected; a reload usually fixes it.',
+                });
+              }}
+              onChange={(next) => {
+                setTypedCss(next);
+                const parsed = fromCss(id || 'untitled', next);
+                setDraft((d) => (d ? { ...d, ...parsed, id: d.id } : d));
               }}
             />
           </div>
@@ -353,6 +430,70 @@ export function ThemeEditor() {
           </div>
         </section>
       ))}
+    </div>
+  );
+}
+
+// ── the raw file, in the editor the Files window uses ────────────────────────
+//
+// The one place in this app where somebody types CODE rather than a value, and
+// it was the only code-shaped input still on a bare <textarea>. What it gains is
+// behaviour, not decoration: line numbers, a caret model that can hold more than
+// one range, an undo stack, bracket matching and a find panel over a file whose
+// interesting lines all look alike (`--st-up-fg: #4ade80;` forty times).
+//
+// `lang="css"` is a real answer, not a placeholder: cmlang.ts builds its
+// language out of the RULES table in highlight.tsx, which has a `css` entry, so
+// property names, hex values, at-rules and comments are all tagged. The colours
+// those tags resolve to are the five --hl-* properties, imported at the top of
+// this file.
+function CssPane({ value, plain, onChange, onFail }: {
+  value: string;
+  plain: boolean;
+  onChange: (next: string) => void;
+  onFail: () => void;
+}) {
+  // The surface publishes focus/find/goto through this. Nothing on this page
+  // drives it - the find panel is opened from inside the editor by its own
+  // keymap - but the prop has no default, and a ref that is never read is
+  // cheaper than a component that has to explain a missing one.
+  const handle = useRef<CodeHandle | null>(null);
+
+  // Also the Suspense fallback, so the chunk arriving swaps a working text box
+  // for a working editor rather than a spinner for anything.
+  const fallback = (
+    <>
+      <label className="sr-only" htmlFor="te-css">The theme file, as CSS</label>
+      <textarea
+        id="te-css"
+        className="te-css mono"
+        value={value}
+        spellCheck={false}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </>
+  );
+
+  if (plain) return fallback;
+
+  return (
+    <div className="te-code">
+      <CodeBoundary fallback={fallback} onFail={onFail}>
+        <Suspense fallback={fallback}>
+          <CodeSurface
+            value={value}
+            lang="css"
+            editable
+            onChange={onChange}
+            onStat={NO_STAT}
+            handleRef={handle}
+            // Read by EditorView.contentAttributes as the aria-label on the
+            // contenteditable, which is the only name a screen reader gets for
+            // it - the <h2> above is not associated with it by anything.
+            label="The theme file, as CSS - editable"
+          />
+        </Suspense>
+      </CodeBoundary>
     </div>
   );
 }

--- a/apps/portal-next/web/src/pages/files/Editor.tsx
+++ b/apps/portal-next/web/src/pages/files/Editor.tsx
@@ -32,7 +32,7 @@
 // same reason: it used to `return` before the surfaces were rendered, so opening
 // a diff over a file mid-edit and closing it again cost you your undo stack.
 
-import { Component, lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AlertTriangle, CircleCheck, Code2, Columns2, Crosshair, Download, Eye, FileArchive,
   GitCommitVertical, Info, Keyboard, LoaderCircle, Lock, LogIn, Pencil,
@@ -42,6 +42,7 @@ import {
   fmtBytes, langFor, looksBinary, rawUrl, signInUrl,
   type DiffResult, type FileRead, type WriteConflict,
 } from '../../lib/files';
+import { CodeBoundary } from '../../components/CodeBoundary';
 import { ErrState, Skeleton } from '../../components/states';
 import { Tooltip } from '../../components/Tooltip';
 import { BothyMark } from '../../components/Brand';
@@ -244,24 +245,6 @@ function PlainSurface(p: {
   return p.editing
     ? <EditSurface draft={p.draft} setDraft={p.setDraft} handleRef={p.handleRef} id={p.id} />
     : <Source src={p.src} lang={p.lang} />;
-}
-
-// A failed chunk load is not an exception React can recover from on its own, and
-// the default is a blank centre column - on a page that may be holding unsaved
-// work. This pins the session to the plain surfaces and SAYS which of the two
-// the reader is looking at, because "my editor lost its line highlight" with no
-// explanation is a bug report.
-class CodeBoundary extends Component<
-  { children: React.ReactNode; fallback: React.ReactNode; onFail: () => void },
-  { failed: boolean }
-> {
-  state = { failed: false };
-
-  static getDerivedStateFromError() { return { failed: true }; }
-
-  componentDidCatch() { this.props.onFail(); }
-
-  render() { return this.state.failed ? this.props.fallback : this.props.children; }
 }
 
 /** True when THIS document's code surface is on screen. Three things in the

--- a/apps/portal-next/web/src/pages/files/Files.tsx
+++ b/apps/portal-next/web/src/pages/files/Files.tsx
@@ -78,6 +78,10 @@ import { usePanes } from './panes';
 import { filesHref } from './routes';
 import { ancestorsOf, baseName, buildTree, defaultMessage, type Node } from './tree';
 
+// The syntax palette the five .hl-* classes in shell.css read, and the one
+// cmtheme.ts hands to CodeMirror. Its own file since the theme editor's CSS
+// pane started rendering code too - see src/hl.css.
+import '../../hl.css';
 import './shell.css';
 import './explorer.css';
 import './editor.css';

--- a/apps/portal-next/web/src/pages/files/Reader.tsx
+++ b/apps/portal-next/web/src/pages/files/Reader.tsx
@@ -48,6 +48,10 @@ import { fetchLinks, type LinkIndex } from '../../lib/files';
 // and every `.md-*` rule - both of which belong to the RENDERED DOCUMENT rather
 // than to the editor, which is why the reader gets them by importing rather than
 // by copying. explorer.css is here for `.fx-filter`, the search box's frame.
+// The syntax palette the five .hl-* classes in shell.css read, and the one
+// cmtheme.ts hands to CodeMirror. Its own file since the theme editor's CSS
+// pane started rendering code too - see src/hl.css.
+import '../../hl.css';
 import './shell.css';
 import './editor.css';
 import './explorer.css';

--- a/apps/portal-next/web/src/pages/files/shell.css
+++ b/apps/portal-next/web/src/pages/files/shell.css
@@ -96,36 +96,12 @@
 .bothy-files .fx-seg button:focus-visible { border-radius: var(--r-xs); }
 
 /* ── syntax palette ──────────────────────────────────────────────────────────
-   Five token classes, which is all a viewer needs: comment, string, keyword,
-   number, key/variable. Lives here rather than in editor.css because the JSON
-   tree in the centre and the code in a markdown fence both use it.
-
-   Chosen to stay OUT of the status hues. --st-up is green, --st-warn amber,
-   --st-down rose, and the standing rule is that those colours mean state and
-   nothing else - so a highlighter built on the usual red-keyword/green-string
-   scheme would put two status colours on every screen of code and spend the
-   page's alarm budget on a `const`. Violet, sky, pink and indigo are all outside
-   that set, and none of them appears anywhere else in the app as a
-   meaning-bearing colour.
-
-   Base values are the DARK ones, matching index.css's dark-first model
-   (`:root` is dark, `:root[data-theme='light']` overrides). lib/theme.tsx always
-   stamps a concrete data-theme, so both branches are always reachable, and no
-   colour here exists in only one of them. Every value clears 4.5:1 on the
-   surface it is painted on (--bg-2 in each theme). */
-.bothy-files.bothy-files {
-  --hl-com: var(--fg-subtle);
-  --hl-kw:  #c4b5fd;   /* violet-300  ·  9.6 on #0b0b0d */
-  --hl-str: #7dd3fc;   /* sky-300     ·  11.1 */
-  --hl-num: #f9a8d4;   /* pink-300    ·  10.2 */
-  --hl-key: #a5b4fc;   /* indigo-300  ·  8.9  */
-}
-:root[data-theme='light'] .bothy-files.bothy-files {
-  --hl-kw:  #6d28d9;   /* violet-700  ·  7.9 on #f4f4f5 */
-  --hl-str: #0369a1;   /* sky-700     ·  6.4 */
-  --hl-num: #a21caf;   /* fuchsia-700 ·  6.6 */
-  --hl-key: #4338ca;   /* indigo-700  ·  8.0 */
-}
+   The five --hl-* properties MOVED to src/hl.css, and the classes that read
+   them stayed here. The split is not tidiness: the theme editor's raw-CSS pane
+   is a second surface that renders code, on a route that must not pull in this
+   shell, so the values had to become importable without it. The JSON tree in
+   the centre and the code in a markdown fence still use these classes, which is
+   why they live here rather than in editor.css. */
 .bothy-files .hl-com { color: var(--hl-com); font-style: italic; }
 .bothy-files .hl-kw  { color: var(--hl-kw); }
 .bothy-files .hl-str { color: var(--hl-str); }


### PR DESCRIPTION
Closes #89.

## The issue was mis-scoped

It reads as "build an edit-file component (neovim/vsc-style)". That component already exists and has since the Files IDE landed: `web/src/pages/files/CodeSurface.tsx` is a clean, controlled CodeMirror 6 surface with a caret model, multiple selections, an undo stack, bracket matching, a find panel and ARIA on a contenteditable. It had exactly one consumer.

The real gap the issue is pointing at is the second half of its own sentence — *"usable in the theme creator/editor"*. `pages/ThemeEditor.tsx` rendered a bare `<textarea className="te-css mono">` for the raw CSS of the theme you are writing: the one place in the product where somebody types code, and the only code-shaped input that did not get the code editor. That is what this PR does.

**Vim mode stays declined.** `CodeSurface.tsx` names it in its "NOT taken, and why" list — *"modal editing was considered and declined; this editor types like every other text box on the box"*. Overturning a decision that was written down with a reason needs a fresh argument, and "the issue title said neovim-style" is not one. Nothing here re-opens it.

**`CodeSurface.tsx` did not move.** `Reader.tsx` asserts as a design invariant that nothing in the reader's import graph reaches `writeFile`, `CodeSurface` or `Editor.tsx` — that comment is there, and it still holds: the new import is from `pages/ThemeEditor.tsx`, a different page.

## The hard part: the lossy round trip

The pane's text is derived — `toCss(draft)` — and its `onChange` parses back through `fromCss` into the draft. So one keystroke runs the whole loop:

```
keystroke -> fromCss -> setDraft -> toCss -> back into the pane
```

`toCss(fromCss(x))` is not `x`. It re-aligns the value column, re-emits the group headings, drops any comment you wrote, and throws away a declaration that has no `;` yet — which is every declaration halfway through being typed.

Against a `<textarea>` that cost a caret jump. Against CodeMirror it is worse: `CodeSurface` replaces its **whole document** when an incoming `value` differs from the last one it emitted, so the half-typed line disappears and the caret lands at offset 0.

**The fix** is the second option from the two on the table: a local buffer of exactly what was typed. `typedCss` is `null` when the pane should show the derived file, and a string while somebody is typing in it. The parse still feeds `setDraft`, so the form fields and the live preview follow along keystroke by keystroke; the surface only ever sees back the string it emitted, so its `[value]` effect never fires. The buffer drops back to `null` — and the pane re-derives — the moment the draft changes from anywhere else, which is a finite list written at each site rather than inferred from a diff: `set`, `setToken`, the load effect, and closing the pane.

Relying on `CodeSurface`'s own `emitted` comparison alone is **not** sufficient, and that is worth stating because it is the tempting answer: `emitted` stops the surface echoing its own text back, but the value arriving is not the echo — it is `toCss` of the parse, a *different* string, which is precisely the case that effect exists to apply.

### How it was verified

Real Chromium (Playwright) against `vite dev`, on `#/settings/theme/new`, with the pane open.

**Counterfactual first.** With the guard removed (`value={css}`), one `Backspace` deleting the `;` from `--bg-glow` — the last declaration of its group, so the swallowed value crosses a comment that `fromCss` strips — moved the caret to line 1, column 0, and rewrote the document around it:

```
caretLine: "/* bothy-theme"   col: 0
around:    ["  --bg-glow:   #dfe5f5", "", "  ", "  --fg:        #09090b;", ...]
```

**The same keystroke, guarded:**

```
caretLine: "  --bg-glow:   #dfe5f5"   col: 22
around:    ["  --surface-4: #ffffff;", "  --bg-glow:   #dfe5f5", "",
            "  /* ── text ─── */", "  --fg:        #09090b;"]
```

Caret on the same line, at the same column, document otherwise untouched. Typing the `;` back restored both the file and the form fields (`--bg-glow` and `--fg` back to their values).

**Typing a token value slowly**, six characters one at a time into `--bg`'s value, reading the line text and the caret column after each:

```
1 -> "  --bg:        #ffffff1;"       col 23
2 -> "  --bg:        #ffffff12;"      col 24
3 -> "  --bg:        #ffffff123;"     col 25
4 -> "  --bg:        #ffffff1234;"    col 26
5 -> "  --bg:        #ffffff12345;"   col 27
6 -> "  --bg:        #ffffff123456;"  col 28
```

Monotonic, in order, nothing dropped or reordered.

Also checked live: editing the **Name** field re-derives the pane (`name: Deep Ocean` appears in the header comment, selector lines become `deep-ocean`); `Ctrl-F` opens the find panel and it is themed; the aria-label on the contenteditable reads `The theme file, as CSS - editable`.

## CSS highlighting: yes, it exists

`lang="css"` is a real answer, not a silent no-op. `cmlang.ts` builds its language from the `RULES` table in `highlight.tsx`, which has a `css` entry (comments, strings, at-rules, property names, hex/number) plus a multi-line `/* */` block rule — so the pane is tokenised by the same hand-written highlighter the read-only Source view uses. `@codemirror/lang-css` is still not taken, for the +112 kB reason already documented.

What did **not** work out of the box was the colour those tags resolve to. The five `--hl-*` properties were declared only under `.bothy-files`, so on a Settings route every tag resolved to nothing and the pane rendered flat. They now live in **`src/hl.css`**, imported by both the Files pages and this one, with the base selector extended to `.theme-editor .fx-cm`. That is a move, not a copy — the alternative was a second set of the same eight hexes, which is the exact bug `stray-colour.mjs` was written to catch. `checks/theme-contract.mjs` reads the palette from the new file (it still filters on `bothy-files`, which is the scope a theme's own override names), and the `stray-colour.mjs` exemption moved with it.

One honest wart, written into `hl.css`: a **theme's own** syntax colours (`themes/*.css`, and any user theme on disk) scope their `--hl-*` override to `.bothy-files`, so they do not reach this pane — it paints code in the base set. Widening that would mean editing every shipped theme and could never reach a theme somebody dropped into `data/themes` by hand.

## Loading and styling

- `lazy(() => import('./files/CodeSurface'))`, wrapped in `CodeBoundary` + `Suspense` with the plain `<textarea>` as the fallback for both — the same pattern as `Editor.tsx:61`. This page is imported **eagerly** by `App.tsx`, so a static import would have put CodeMirror in the entry chunk.
- `CodeBoundary` moved from `Editor.tsx` to `components/CodeBoundary.tsx`. It is a nine-line generic error boundary, nothing files-specific in it — but importing it from `Editor.tsx` would have pulled the whole Files window into the Settings route's chunk.
- `editor.css` is **not** imported. The `.cm-*` chrome the theme editor needs is written under `.theme-editor` in `ThemeEditor.css`, using the same tokens and the same style-mod-ordering argument. It is a fixed-height, drag-resizable pane in a form, not an IDE column, so the geometry is genuinely different; the overlap is only the parts CodeMirror insists on having an opinion about.
- The pane paints on `--bg-2`, not `--bg`, because that is the ground the contract check measures every `--hl-*` value against.
- `node checks/stray-colour.mjs` passes: every colour is a token or a `color-mix` of one.

## Chunk sizes

`npm run build`, before and after:

| chunk | before | after |
|---|---|---|
| `CodeSurface-*.js` | 332.30 kB · **107.56 kB gzip** | 332.30 kB · **107.56 kB gzip** |
| `index-*.js` (entry) | 717.35 kB · 224.27 kB gzip | 718.24 kB · 224.54 kB gzip |
| `index-*.css` | 158.58 kB · 26.96 kB gzip | 162.70 kB · 27.33 kB gzip |

CodeMirror is still its own chunk and did not move: `+0.89 kB` on the entry (`+0.27 kB` gzip) is the pane, the boundary and the lazy stub. Mechanically confirmed rather than eyeballed — `grep -c "cm-content\|cm-scroller"` finds **0** hits in the entry chunk and hits only in `CodeSurface-*.js`, and the entry references `CodeSurface-*.js` by name as a dynamic import.

## Checks

- `npm run typecheck` — clean
- `npm run build` — clean
- `bash checks/run.sh --offline` — exit 0, 473 PASS, 0 FAIL
- `node checks/stray-colour.mjs` — PASS
