### PR TITLE
chore(socket-proxy): rename portal-socket-proxy to bothy-socket-proxy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,10 +213,15 @@ Then rebuild and check it in a real browser:
 docker compose -f apps/portal-next/compose.yml up -d --build
 ```
 
-**Do not `docker compose down` `apps/portal`.** That compose file still owns
-`portal-socket-proxy`, which the new portal needs for `/-/api/docker`. The old
-pure-HTML nginx in there is retired via `traefik.enable=false`, kept as a
-one-line rollback.
+**Do not `docker compose down` the `bothy` project to restart the portal.** That
+project also owns `bothy-socket-proxy`, the read-only Docker socket the portal
+needs for `/-/api/docker`; take it down and the Overview enrichment goes blank
+even after portal-next comes back. Act on the one service, as above.
+
+(This paragraph used to warn about `apps/portal/`. That directory existed only
+to hold the socket proxy and was deleted on 2026-08-18 - the fragment now lives
+in `apps/bothy/socket-proxy.yml`. The retired pure-HTML nginx portal it also
+described went on 2026-08-17.)
 
 **A headless DOM cannot review a page.** jsdom has no layout, so "blank" and
 "perfect" look identical to it. This repo has shipped a near-blank portal twice

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Then open **`http://<this-node's-tailnet-IP>/`** - `just urls` prints every addr
 | `monitoring/` | Prometheus, Grafana, Loki + Promtail, cAdvisor, node-exporter. `provisioning/` wires datasources, dashboards and email alert rules; `dashboards/` holds four provisioned dashboards; `rules/` is for Prometheus rules. |
 | `data/postgres/` | Postgres 17 plus `postgres-exporter`. Binds **loopback only**. In active use - the dev database and Keycloak both live here. |
 | `apps/portal-next/` | The live portal on `:80` - React 19 + Vite + TypeScript, built by a multi-stage image and served static by nginx. Owns `portal-next-fallback`, the catch-all. Pages: Overview, Services, Ports, Routes, Topology (a lazy-loaded react-three-fiber 3D rack view). |
-| `apps/bothy/` | The one compose project over Bothy's three tiers, via `include:`. Also **owns `portal-socket-proxy`** - the read-only Docker socket the portal's `/-/api/docker` data plane goes through. It moved here on 2026-08-18 when `apps/portal/`, which existed only to hold it, was deleted. |
+| `apps/bothy/` | The one compose project over Bothy's three tiers, via `include:`. Also **owns `bothy-socket-proxy`** - the read-only Docker socket the portal's `/-/api/docker` data plane goes through. It moved here on 2026-08-18 when `apps/portal/`, which existed only to hold it, was deleted. |
 | `apps/portal-files/` | The editor tier behind Bothy Files - the read/write file API over the stacks repo, `~/claude-notes` and `~/projects`, with full-text search. No published port; reached only through the edge. |
 | `host/` | Copies of the host configuration git cannot see: dnsmasq, `daemon.json`, `wsl.conf`, the systemd units, and the Windows keepalive task. Required to rebuild the box. See [`host/README.md`](host/README.md). |
 | `scripts/` | `backup.sh` and `doctor.sh`. |
@@ -270,7 +270,7 @@ thing worth protecting:
   discovery to it (`--providers.docker.network=devnet`) so it can never pick the
   wrong container IP from a project-local network.
 - **`socketnet`** - holds exactly two containers, Traefik and
-  `portal-socket-proxy`. The proxy has no authentication, so keeping the blast
+  `bothy-socket-proxy`. The proxy has no authentication, so keeping the blast
   radius at two members is the control.
 - **`filesnet`** - holds exactly two, Traefik and `portal-files`. That service has
   read-write handles on two git repositories and no auth of its own, so the same

--- a/apps/bothy-control/checks/test_guard.py
+++ b/apps/bothy-control/checks/test_guard.py
@@ -149,7 +149,19 @@ for name in sorted(guard.SEVERING):
 # The containers the UI warns about but the service deliberately does NOT refuse.
 # Stopping any of these degrades the interface; the action still completes and
 # reports its own outcome truthfully, which is the line this service draws.
-for name in ("portal-next", "portal-socket-proxy", "portal-files", "bothy-config",
+#
+# BOTH SOCKET-PROXY NAMES (#97). The proxy is being renamed portal-socket-proxy
+# -> bothy-socket-proxy. This is a NEGATIVE list - it asserts guard.severed()
+# stays None - so unlike actions.ts's SELF map nothing fails open here, and the
+# extra name costs nothing while the daemon may still be carrying either. It
+# does earn its place during the rename: it would catch somebody "helpfully"
+# adding the new name to guard.SEVERING, which would be a real regression (the
+# service would start refusing an action it can perform and report truthfully -
+# the exact line guard.py:102-110 draws). This list should mirror actions.ts's
+# SELF map, so drop 'portal-socket-proxy' here in the same change that drops the
+# legacy key there, and not before.
+for name in ("portal-next", "bothy-socket-proxy", "portal-socket-proxy",
+             "portal-files", "bothy-config",
              "keycloak", "oauth2-proxy", "grafana", "postgres"):
     for verb in guard.VERBS:
         ok(guard.severed(name, verb) is None,

--- a/apps/bothy-control/guard.py
+++ b/apps/bothy-control/guard.py
@@ -101,7 +101,7 @@ class Refused(Exception):
 #
 # WHY THIS IS NARROWER THAN THE UI'S WARNING LIST. `consequenceOf` in
 # apps/portal-next/web/src/lib/actions.ts warns about seven containers, and the
-# other three - portal-next, portal-socket-proxy, portal-files, bothy-config,
+# other six - portal-next, bothy-socket-proxy, portal-files, bothy-config,
 # keycloak, oauth2-proxy - are deliberately NOT refused here. Stopping any of
 # them degrades the interface, sometimes badly (stopping oauth2-proxy locks
 # every gated tier until somebody opens a terminal), but the action completes

--- a/apps/bothy/compose.yml
+++ b/apps/bothy/compose.yml
@@ -37,12 +37,27 @@
 # invitation to `compose down` the thing the live portal depends on - which is
 # exactly why README had to carry a "do not compose down this directory" note.
 #
-# THE CONTAINER IS STILL portal-socket-proxy, deliberately. That name is in
-# bothy-control's self-protection allowlist (guard.py, test_guard.py) and in the
-# SPA's foot-gun guard (lib/actions.ts) - the rule that stops you stopping the
-# container serving the page you are reading. Renaming it is a coordinated
-# change across a security guard and its tests, not a side effect of moving a
-# file.
+# THE CONTAINER IS bothy-socket-proxy as of 2026-08-19 (#97). It was
+# portal-socket-proxy - named after the nginx portal that was retired long
+# before the directory move, and the last reference in the repo to a service
+# that no longer exists.
+#
+# CORRECTING WHAT THIS COMMENT USED TO SAY: it claimed the name was in
+# bothy-control's self-protection allowlist, `guard.py`. It was not, and never
+# has been. guard.SEVERING holds exactly four names - traefik, bothy-control and
+# its two socket proxies - and checks/grants.py asserts that count, so the claim
+# was checkable and false. guard.py:102-110 explains at length WHY that list is
+# deliberately narrower than the UI's: stopping the socket proxy degrades the
+# interface but the action still completes and bothy-control reports it
+# truthfully, and a truthful report of a deliberate decision is not the
+# service's business to override. The only Python reference is a NEGATIVE
+# assertion in checks/test_guard.py listing what is deliberately not refused.
+#
+# What the name is actually load-bearing in: the SPA's foot-gun guard
+# (portal-next/web/src/lib/actions.ts, where a miss fails OPEN), the Traefik
+# service that dials it by Docker DNS (edge/dynamic/portal-api.yml), and
+# scripts/doctor.sh. socket-proxy.yml spells out the coupling next to the
+# `container_name:` line itself.
 
 name: bothy
 

--- a/apps/bothy/socket-proxy.yml
+++ b/apps/bothy/socket-proxy.yml
@@ -17,9 +17,12 @@
 #   · It held ten references to the dead namespace, in a file nobody
 #     read because nobody served it.
 #
-# The directory keeps its name because the container it still owns is called
-# `portal-socket-proxy`, and renaming that means recreating the one container
-# the live portal cannot render without.
+# The container was called `portal-socket-proxy` until 2026-08-19 - named after
+# that same dead nginx portal, and the last thing in the repo still pointing at
+# it. Renamed to `bothy-socket-proxy` in #97. `container_name` is IMMUTABLE on a
+# running container, so this file and the daemon disagree until somebody runs
+# `docker compose up -d --force-recreate socket-proxy` in project `bothy`; every
+# consumer of the name accepts both while that is true.
 
 
 services:
@@ -60,7 +63,19 @@ services:
   #    routed; nothing else under /system is reachable from the tailnet.
   socket-proxy:
     image: tecnativa/docker-socket-proxy:0.3.0   # pinned: never :latest for a socket holder
-    container_name: portal-socket-proxy
+    # THIS NAME IS AN API, not a label. Three things match on it by string and
+    # none of them can be discovered from here:
+    #   · edge/dynamic/portal-api.yml dials `http://bothy-socket-proxy:2375`
+    #     over socketnet by Docker DNS. Change one without the other and
+    #     /-/api/docker/containers/json 502s and every Overview enrichment goes
+    #     blank.
+    #   · apps/portal-next/web/src/lib/actions.ts's SELF map keys the foot-gun
+    #     warning on it, and a miss there fails OPEN - the warning vanishes
+    #     silently rather than erroring.
+    #   · scripts/doctor.sh checks it by name.
+    # It is NOT in bothy-control's guard.SEVERING and never was; see the comment
+    # in apps/bothy/compose.yml for why that list is deliberately narrower.
+    container_name: bothy-socket-proxy
     restart: unless-stopped
     environment:
       # The grants: container list (enrichment) + disk usage (Data & disk card).

--- a/apps/portal-next/web/src/lib/actions.ts
+++ b/apps/portal-next/web/src/lib/actions.ts
@@ -168,12 +168,29 @@ export interface Consequence {
 }
 
 // The portal is served THROUGH traefik, BY portal-next, and reads Docker through
-// portal-socket-proxy. Stopping any of those from a page they serve is a foot-gun
+// the socket proxy. Stopping any of those from a page they serve is a foot-gun
 // that deserves a sentence rather than a toast afterwards - you would lose the
 // interface that could put it back.
+//
+// THIS MAP FAILS OPEN. `consequenceOf` is an exact-match lookup on the LIVE
+// Docker container name, and a miss returns `{selfAffecting: false}` - no
+// warning, no error, just a missing sentence. So a key that stops matching does
+// not break loudly; it deletes the guard.
+//
+// WHY THE SOCKET PROXY HAS TWO KEYS (#97). It is being renamed
+// portal-socket-proxy -> bothy-socket-proxy, and this SPA is a BUILT ARTIFACT.
+// `container_name` is immutable on a running container, so the daemon carries
+// the old name until somebody force-recreates it, and a browser carries the
+// previously-built bundle until it reloads. Those two clocks are independent,
+// which means either single key leaves a window where the live name is not the
+// key and the warning silently vanishes - before the one action that blinds
+// every page in the product. Both keys cost a line and close the window in both
+// directions. Drop 'portal-socket-proxy' once a rebuilt portal-next image has
+// shipped AND the container has been recreated.
 const SELF: Record<string, string> = {
   traefik: 'Bothy is served through Traefik. Stopping it takes this page down, and the way back is a terminal.',
   'portal-next': 'This page is served by portal-next. Stopping it takes this page down.',
+  'bothy-socket-proxy': 'Bothy reads Docker through this. Stopping it blinds every page that shows what is running.',
   'portal-socket-proxy': 'Bothy reads Docker through this. Stopping it blinds every page that shows what is running.',
   'portal-files': 'Bothy Files reads and writes through this. Stopping it leaves the editor unable to load or save.',
   'bothy-config': 'Settings writes configuration through this.',

--- a/apps/portal-next/web/src/lib/discover.ts
+++ b/apps/portal-next/web/src/lib/discover.ts
@@ -1067,7 +1067,7 @@ export function merge(
   // That reasoning died with the name layer on 2026-08-12. With no routers left,
   // "route OR port" collapsed to "port", and TEN running containers went
   // invisible at once - promtail, postgres-exporter, oauth2-proxy,
-  // portal-socket-proxy, and `portal-next` ITSELF. The page could not see the
+  // bothy-socket-proxy, and `portal-next` ITSELF. The page could not see the
   // container serving it. It showed 16 services while 21 were running.
   //
   // The deeper mistake is conflating two different questions. "Can I open this?"

--- a/apps/portal-next/web/src/pages/Overview.tsx
+++ b/apps/portal-next/web/src/pages/Overview.tsx
@@ -481,7 +481,7 @@ export function Overview() {
   // inventory and goes in a line beneath it.
   //
   // The argument is not aesthetic. You are reading this page THROUGH portal-next,
-  // served BY traefik, enriched BY portal-socket-proxy - so for two of Bothy's
+  // served BY traefik, enriched BY bothy-socket-proxy - so for two of Bothy's
   // three containers the cell can only ever say `up`, because if they were not,
   // there would be no page to read the cell on. A card that cannot report a
   // problem is a card carrying no information, and by the footprint rule it

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,7 +64,7 @@ flowchart TB
 
         subgraph s_devnet["devnet - internal bridge network"]
             PNEXT["portal-next :80<br/>catch-all, priority 1"]
-            APIS["portal-socket-proxy · loki · prometheus<br/>· api@internal - reached only via exact Path()"]
+            APIS["bothy-socket-proxy · loki · prometheus<br/>· api@internal - reached only via exact Path()"]
         end
     end
 
@@ -134,7 +134,7 @@ browser reaches anything but the portal. What exists today:
 | `traefik` | `0.0.0.0:80` | **The front door for the portal and its data plane**, and nothing else. |
 | `grafana` `prometheus` `dozzle` `kafka-ui` `portainer` `loki` `cadvisor` `node-exporter` `keycloak` | `0.0.0.0:3000` `9090` `8080` `8081` `9000` `3100` `8082` `9100` `8090` | **The access path.** Not a legacy remnant and not a workaround - this is the model. Each is listed in `just urls`. |
 | `postgres` `redis` `kafka` | `127.0.0.1:5432` `6379` `9092` | **Loopback only, and non-negotiable.** Dropping the `127.0.0.1:` prefix hands the whole tailnet a database - Redis runs with no `requirepass` at all. Reached over an SSH tunnel, or by name over devnet from another container. |
-| `portal-next` `portal-files` `oauth2-proxy` `portal-socket-proxy` `promtail` and every exporter | none | Nothing needs to reach these except Traefik or Prometheus, over `devnet`. |
+| `portal-next` `portal-files` `oauth2-proxy` `bothy-socket-proxy` `promtail` and every exporter | none | Nothing needs to reach these except Traefik or Prometheus, over `devnet`. |
 
 The cost of the port model is real and worth stating: ports are a flat global
 namespace with no allocator, so every new service is a manual collision check
@@ -187,13 +187,13 @@ flowchart TB
     SOCKET[("/var/run/docker.sock<br/>root-equivalent")]
 
     subgraph s_socketnet["socketnet - exactly two members"]
-        PROXY["portal-socket-proxy<br/>CONTAINERS=1 SYSTEM=1 POST=0 EXEC=0<br/>no auth of any kind - no published port"]
+        PROXY["bothy-socket-proxy<br/>CONTAINERS=1 SYSTEM=1 POST=0 EXEC=0<br/>no auth of any kind - no published port"]
     end
 
     subgraph s_devnet["devnet - around two dozen containers"]
         OAUTH["oauth2-proxy"]
         OBS["monitoring - grafana, prometheus, loki,<br/>promtail, cadvisor, node-exporter"]
-        APPSG["apps - portal-next, portal-files, portal-socket-proxy"]
+        APPSG["apps - portal-next, portal-files, bothy-socket-proxy"]
         DATAG["data - postgres plus its exporter - not routed"]
         PROJ["project containers<br/>e.g. cvops-nginx, cvops-garage"]
     end
@@ -215,7 +215,7 @@ projects (and separate project repos under `~/projects`) share one edge.
 | Network | Members | Purpose |
 |---|---|---|
 | `devnet` | ~24 containers: the whole stack plus any project container that opts in | The shared bus. Traefik discovers here (`--providers.docker.network=devnet`), Prometheus scrapes here, containers resolve each other by service name here. |
-| `socketnet` | **Exactly two**: `traefik` and `portal-socket-proxy` | Isolation for the Docker socket proxy. |
+| `socketnet` | **Exactly two**: `traefik` and `bothy-socket-proxy` | Isolation for the Docker socket proxy. |
 
 ### Why `socketnet` exists
 
@@ -330,7 +330,7 @@ flowchart TB
 
     subgraph s_apps["apps/ - what the box itself serves"]
         PNEXT["portal-next - Vite + React built to<br/>static files, served by nginx.<br/>Owns the :80 catch-all"]
-        PSOCK["portal-socket-proxy<br/>still shipped by apps/portal"]
+        PSOCK["bothy-socket-proxy<br/>shipped by apps/bothy/socket-proxy.yml"]
         PFILES["portal-files - the editor tier.<br/>filesnet only, no published port,<br/>read/write over stacks, notes and projects"]
     end
 
@@ -358,7 +358,7 @@ numbers below are repeated here only so this table is readable on its own.
 | `auth/` | `auth` | `keycloak` `oauth2-proxy` | Keycloak `:8090`; oauth2-proxy only via `/oauth2/` on `:80` | n/a - it *is* the identity layer, and it guards nothing yet |
 | `monitoring/` | `monitoring` | `prometheus` `grafana` `loki` `promtail` `cadvisor` `node-exporter` | `:9090` `:3000` `:3100` - `:8082` `:9100` for the exporters | Grafana and Prometheus use the shared `DEV_LOGIN_*` credential. Prometheus runs `--web.enable-lifecycle`, so an unauthenticated `POST /-/quit` would stop it - its login is the only thing preventing that |
 | `data/postgres` | `postgres` | `postgres` `postgres-exporter` | `127.0.0.1:5432` | Postgres' own |
-| `apps/bothy` | `bothy` | `portal-socket-proxy` (the read-only Docker socket the portal's data plane goes through) | none - socketnet only | n/a |
+| `apps/bothy` | `bothy` | `bothy-socket-proxy` (the read-only Docker socket the portal's data plane goes through) | none - socketnet only | n/a |
 | `apps/portal-next` | `portal-next` | `portal-next` | the `:80` catch-all | **none** |
 | `apps/portal-files` | `bothy` | `portal-files` | none - filesnet only | `viewer` to read, `editor` to write, enforced at the edge |
 | `host/` | - | none | - | - |
@@ -369,10 +369,16 @@ authenticating. That is the current, accepted state, not an oversight - see
 
 Notes on `apps/`:
 
-- **`portal-next` is the portal.** The original pure-HTML `apps/portal` nginx is
-  retired but kept as a one-line rollback (`traefik.enable=true`).
-  **Do not `docker compose down apps/portal`** - that compose file still owns
-  `portal-socket-proxy`, which the live portal depends on for `/-/api/docker`.
+- **`portal-next` is the portal, and the only one.** The original pure-HTML
+  `apps/portal` nginx was retired behind `traefik.enable=false` and kept as a
+  one-line rollback until 2026-08-17, when it was deleted - the rollback was a
+  fiction, because the HTML it served linked to hostnames that stopped resolving
+  when the name layer was retired on 2026-08-12. `apps/portal/` itself went on
+  2026-08-18; the socket-proxy fragment that was its only remaining reason to
+  exist moved to `apps/bothy/socket-proxy.yml`.
+  **Do not `docker compose down` the `bothy` project to restart the portal** -
+  that project also owns `bothy-socket-proxy`, which the live portal depends on
+  for `/-/api/docker`. Act on the one service.
 - **Bothy Files replaced every markdown viewer this box has had.** It is a route
   in the portal (`/#/files`) backed by `apps/portal-files`, and it reads the real
   file from a bind mount rather than a mirror of it - so there is no sync lag, no
@@ -530,8 +536,8 @@ prefix on every vhost on this box.
 |---|---|---|
 | `/-/api/traefik/http/routers` | `api@internal` | Every route, including host processes (`@file`) - **the skeleton** |
 | `/-/api/traefik/http/services` | `api@internal` | Server targets, for the join |
-| `/-/api/docker/containers/json` | `portal-socket-proxy` | Ports, health, images, compose labels, `Mounts` - **the enrichment** |
-| `/-/api/docker/system/df` | `portal-socket-proxy` | Per-volume / image / container disk sizes |
+| `/-/api/docker/containers/json` | `bothy-socket-proxy` | Ports, health, images, compose labels, `Mounts` - **the enrichment** |
+| `/-/api/docker/system/df` | `bothy-socket-proxy` | Per-volume / image / container disk sizes |
 
 **Traefik is the skeleton; Docker is enrichment. Either can die and the page still
 renders** - the loader uses `Promise.allSettled`, never `all`, and partial results
@@ -788,7 +794,7 @@ Then, in order:
 
 Publish nothing. Join `devnet` and let other containers reach it by service
 name. This is still the correct default for exporters, sidecars and proxies -
-`portal-socket-proxy`, `oauth2-proxy`, `portal-files` and every `*-exporter` do it.
+`bothy-socket-proxy`, `oauth2-proxy`, `portal-files` and every `*-exporter` do it.
 
 ### A host process
 

--- a/docs/kb/architecture.md
+++ b/docs/kb/architecture.md
@@ -43,7 +43,7 @@ treat `auth/` as in flight rather than as the final shape.
 ## The portal
 
 Live-discovery page: polls the Traefik API + docker container list every 10s
-through `portal-socket-proxy` (tecnativa docker-socket-proxy, `CONTAINERS=1` +
+through `bothy-socket-proxy` (tecnativa docker-socket-proxy, `CONTAINERS=1` +
 `SYSTEM=1`, read-only socket, `POST=0`, no published port). Health display fixed in
 PR #11 (`container.Health?.Status` - Health is an object, not a string).
 

--- a/edge/compose.yml
+++ b/edge/compose.yml
@@ -156,7 +156,7 @@ services:
       resources:
         limits:
           memory: 128m
-    # socketnet: reaches portal-socket-proxy for the portal's read-only Docker
+    # socketnet: reaches bothy-socket-proxy for the portal's read-only Docker
     # API (see edge/dynamic/portal-api.yml). Traefik and the proxy are the only
     # two members - the proxy has no auth, so reachability is authorisation.
     # filesnet added 2026-08-12 with the editor tier: it holds exactly two

--- a/edge/dynamic/portal-api.yml
+++ b/edge/dynamic/portal-api.yml
@@ -72,7 +72,7 @@ http:
       # GET this. What it gets is bounded solely by the Path() rule above, which
       # is why the rule is the boundary and the comment is not decoration.
       middlewares: [portal-api-docker-rewrite]
-      service: portal-socket-proxy
+      service: bothy-socket-proxy
 
     # Loki reads, for the portal's per-service log view.
     #
@@ -145,10 +145,10 @@ http:
     # Reached by Docker DNS over socketnet. The docker provider can't see this
     # container (it's not on devnet, by design), which is exactly why it's
     # declared here in the file provider rather than via labels.
-    portal-socket-proxy:
+    bothy-socket-proxy:
       loadBalancer:
         servers:
-          - url: "http://portal-socket-proxy:2375"
+          - url: "http://bothy-socket-proxy:2375"
 
     # Loki is on devnet, so this could have been a label on the loki container -
     # but it is declared here to keep the whole /-/api/* surface readable in one

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ network:
     # another. Each holds exactly two members.
     -docker network create controlnet 2>/dev/null || true
     -docker network create controlsocknet 2>/dev/null || true
-    # socketnet holds exactly two containers: traefik + portal-socket-proxy.
+    # socketnet holds exactly two containers: traefik + bothy-socket-proxy.
     # docker-socket-proxy has NO auth, so network reachability IS authorisation -
     # on devnet, any of ~20 containers (incl. third-party wiki.js, kafka-ui) could
     # read the docker socket through it. Keep the blast radius at two.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -29,7 +29,7 @@ red()   { faults=$((faults + 1)); printf '  \033[31m✗\033[0m %s\n' "$*"; }
 dim()   { printf '  \033[2m·\033[0m %s\n' "$*"; }
 
 echo "== containers =="
-# traefik, oauth2-proxy and portal-socket-proxy are the front door and the login
+# traefik, oauth2-proxy and bothy-socket-proxy are the front door and the login
 # for everything else, and were missing from this list entirely.
 #
 # `wiki` was retired and replaced by Bothy Files - it sat here reporting a

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -44,18 +44,45 @@ echo "== containers =="
 # here, because a health check that does not know about a service you rely on is
 # worse than one that reports it missing. `portal-files` took its slot: it is
 # the editor tier, it has no published port, and a health sweep that cannot see
-# the one service that can WRITE to the repos is missing the thing worth watching. `portal-next` is the LIVE portal;
-# `portal` is the retired nginx one, kept only because its compose file also owns
-# portal-socket-proxy. Both run, so both are expected.
+# the one service that can WRITE to the repos is missing the thing worth watching. `portal-next` is the LIVE portal
+# and the only one - the retired nginx `portal` was deleted on 2026-08-17, and
+# the socket proxy it used to own moved to apps/bothy/ on 2026-08-18. The proxy
+# is not in this list at all; it is checked below, for the reason given there.
 # redis/redis-exporter/kafka/kafka-ui/kafka-exporter removed 2026-08-12 - retired
 # as idle. Leaving them here made `just doctor` report five phantom absences,
 # which is the fastest way to teach someone to ignore the health check.
 # keycloak/oauth2-proxy are the identity layer added the same day.
-expected="traefik oauth2-proxy keycloak portal-socket-proxy prometheus grafana loki promtail cadvisor node-exporter postgres postgres-exporter portal-next portal-files bothy-config bothy-control bothy-control-socket-read bothy-control-socket-write"
+expected="traefik oauth2-proxy keycloak prometheus grafana loki promtail cadvisor node-exporter postgres postgres-exporter portal-next portal-files bothy-config bothy-control bothy-control-socket-read bothy-control-socket-write"
 for c in $expected; do
   st=$(docker inspect -f '{{.State.Status}}' "$c" 2>/dev/null || echo missing)
   [ "$st" = running ] && green "$c" || red "$c ($st)"
 done
+
+# THE SOCKET PROXY IS CHECKED SEPARATELY, because it is mid-rename (#97) and the
+# loop above cannot express "either of these". That loop reds every name it is
+# given that is not running, so listing both names guarantees one permanent red
+# every sweep, and listing one guarantees a red on whichever side of the
+# recreate you happen to be standing. Neither is a health signal; both are the
+# cry-wolf failure this list has already been trimmed twice to avoid.
+#
+# The window is real rather than theoretical: `container_name` is IMMUTABLE on a
+# running container, so apps/bothy/socket-proxy.yml says bothy-socket-proxy from
+# the moment the rename merges while the daemon keeps answering to
+# portal-socket-proxy until `docker compose up -d --force-recreate socket-proxy`
+# runs. Accept EITHER and print which one answered, so the sweep reports where
+# the rename actually got to instead of hiding it behind a generic ✓.
+#
+# Delete the legacy name and fold this back into `expected` once the container
+# has been recreated.
+sock=""
+for c in bothy-socket-proxy portal-socket-proxy; do
+  if [ "$(docker inspect -f '{{.State.Status}}' "$c" 2>/dev/null)" = running ]; then
+    sock=$c
+    break
+  fi
+done
+[ -n "$sock" ] && green "$sock" \
+  || red "socket proxy (missing - neither bothy-socket-proxy nor portal-socket-proxy is running)"
 
 echo "== prometheus targets =="
 # Without this guard a missing jq piped its failure into a loop that never


### PR DESCRIPTION
Closes #97

Renames the socket proxy container `portal-socket-proxy` → `bothy-socket-proxy` — the last thing in the repo still named after `apps/portal`, retired 2026-08-17 and deleted 2026-08-18.

## The issue's premise is partly wrong

#97 says the rename touches "two safety allowlists", naming `guard.py` and `actions.ts`. **`guard.py` does not contain this name and never has.**

`guard.SEVERING` holds exactly four entries — `traefik`, `bothy-control`, `bothy-control-socket-read`, `bothy-control-socket-write` — and `checks/grants.py` asserts `len(guard.SEVERING) == 4`, so the claim was mechanically checkable and false. `guard.py:102-110` explains at length *why* that list is deliberately narrower than the UI's warning list: stopping the socket proxy degrades the interface, but the action completes and bothy-control reports it truthfully, and a truthful report of a deliberate operator decision is not the service's business to override.

So this rename touches **one** real safety mechanism plus a test's *negative* list:

| Where | Kind | Fails how |
|---|---|---|
| `actions.ts` `SELF` | exact-match lookup on the live Docker name | **open, silently** |
| `test_guard.py:152` | negative assertion (`severed()` stays `None`) | not a hazard |
| `guard.py` | **not present** | n/a |

The false claim originated in a comment in `apps/bothy/compose.yml`, which stated it outright. Fixing that comment is part of this PR — believing it would lead someone to add the name to `guard.SEVERING` and break the line `guard.py` draws.

## The fail-open hazard, and why the commit order exists

`consequenceOf()` returns `{selfAffecting: false}` for anything not in `SELF`. A key that stops matching does not raise; it **deletes the guard** — no warning, no error, just a missing sentence before the one action that blinds every page in the product.

Two clocks make that window unavoidable in a single commit:

- `container_name` is **immutable on a running container**. The compose file says the new name from the moment this merges; the daemon keeps answering to the old one until somebody force-recreates it.
- `actions.ts` ships inside a **built SPA bundle**. A browser holds the previously-built bundle until it reloads.

`scripts/doctor.sh` has the mirror-image window: the repo goes new-name at merge, the daemon is still old-name.

Hence:

**Commit 1 — double-accept. Nothing renames.** `SELF` carries both keys with the same message; `test_guard.py` lists both. `doctor.sh` could *not* simply list both: its loop reds every name it is given that is not running, so two names means one permanent red on every sweep — the cry-wolf failure that list has already been trimmed twice to avoid. The proxy comes out of `expected` and gets an either/or check that prints **which** name answered, so the sweep reports where the rename actually got to.

**Commit 2 — the flip.** `container_name`, the Traefik `url:` that dials it by Docker DNS, and the router `service:` / `services:` key, in one commit. They are two halves of one string match across a network boundary: split them and `/-/api/docker/containers/json` 502s in between, taking the entire Overview enrichment blank. Traefik's file provider watches `./dynamic`, so no restart — but the files must agree at every commit. Verified mechanically (below).

## Commit 3 is a deliberate follow-up, NOT in this PR

Dropping `'portal-socket-proxy'` from `actions.ts` and `test_guard.py` is left for the maintainer to apply **after a rebuilt `portal-next` image has shipped and the container has been recreated**. Landing it here would defeat the entire point of commit 1: the legacy key exists precisely to cover the interval between this merge and those two events. `doctor.sh` and both files carry a comment saying when the legacy name comes out.

## ⚠️ The container recreate is NOT done

`container_name` is immutable on a running container, so nothing has actually been renamed on the box yet. This needs, in project `bothy`:

```sh
docker compose up -d --force-recreate socket-proxy
```

Afterwards, confirm the blast radius held:

```sh
docker inspect bothy-socket-proxy
```

`socketnet` must hold **exactly two** members — `traefik` and the proxy. The proxy has no authentication of any kind, so reachability *is* authorisation, and that two-member membership is the only control on it.

Until that recreate runs, `just doctor` will report `✓ portal-socket-proxy` — which is the check working as intended, telling you the rename has not landed on the daemon yet.

## Also corrected — false before this rename, and would have stayed false after a find-and-replace

- **`CONTRIBUTING.md` ~217** and **`docs/ARCHITECTURE.md` ~372** both told the reader not to `docker compose down apps/portal` because it owns the proxy. That directory has not existed since 2026-08-18. ARCHITECTURE also still described the pure-HTML nginx portal as a live one-line rollback — deleted 2026-08-17, and a fiction anyway, since its HTML linked to hostnames that stopped resolving when the name layer went on 2026-08-12. Both now warn about the real hazard: downing the `bothy` **project**.
- **`guard.py:104`** said the UI warns about seven containers and "the other three", then listed six. Six is correct — `SELF` has seven entries and `traefik` is the only overlap with `SEVERING`.
- **`doctor.sh` ~49** claimed the retired `portal` was expected to be running and owned the proxy.
- **`ARCHITECTURE.md:333`** node label said the proxy was "still shipped by apps/portal".

## Should `socket-proxy` be the stable name long-term?

Worth considering, and my read is **no**. The compose **service** name is already plain `socket-proxy`, so that second Docker DNS alias is name-neutral and unaffected by this PR — `docker compose ... socket-proxy` already works today and will keep working.

But it is not a good `container_name`. Container names are flat and global on the daemon, and this box already runs `bothy-control-socket-read` and `bothy-control-socket-write`. An unprefixed `socket-proxy` sitting alongside them reads as "the" socket proxy when it is one of three, and the prefix is what tells a reader at a glance which project owns it and which blast radius it belongs to. The project prefix is the convention every other container here follows. Renaming to the service name would also be a *third* rename of the same container.

The durable fix is not the name but the coupling: `container_name` now carries an inline list of everything matching on it by string, since none of those consumers are discoverable from that file and one of them fails open. A `grants.py`-style assertion tying `SELF`'s keys to the compose `container_name` values — the way `grants.py` already ties `guard.SEVERING` to them — would make this class of drift impossible rather than merely documented. Happy to open that as a follow-up.

## Verification

| Check | Result |
|---|---|
| `npm ci && npm run typecheck` (`tsc -b --noEmit`) | pass |
| `npm run build` | pass, built in 579ms |
| `bash apps/portal-next/checks/run.sh --offline` | all pass (237 pass · 0 fail) |
| `bash apps/bothy-control/checks/run.sh --offline` | all API checks passed |
| `checks/test_guard.py` / `checks/grants.py` | all pass — `SEVERING` still exactly 4 |
| `bash apps/bothy-config/checks/run.sh` | all checks passed |
| `apps/portal-files` `checks/run.sh --offline` | all pass |
| `bash -n scripts/doctor.sh` | clean |
| `shellcheck -x -S warning scripts/doctor.sh` | clean |
| `bash32.sh` / `recipe-descriptions.sh` / `cli-commands.sh` / `version.sh` / `portability.sh` | all pass |
| `yaml.safe_load` on all 4 touched YAML files | all parse |
| Traefik ↔ compose cross-check | every router `service:` resolves; dialled URL host == `container_name` |

`scripts/checks/mutants.sh` was not run — it requires a clean tree and reverts with `git checkout --`.

Note: `npx tsc --noEmit` checks nothing here — `tsconfig.json` has `"files": []`. `npm run typecheck` (`tsc -b`) is the real gate.

## Every remaining `portal-socket-proxy` hit, and why it stayed

All 13 are deliberate:

- `actions.ts` ×3 — the legacy `SELF` key + its explanation. **Removed in the follow-up.**
- `test_guard.py` ×3 — the legacy negative-list entry + its explanation. **Removed in the follow-up.**
- `scripts/doctor.sh` ×3 — the either/or accept + its explanation. **Removed after the recreate.**
- `apps/bothy/socket-proxy.yml` ×1, `apps/bothy/compose.yml` ×1 — historical prose ("was called X until 2026-08-19"), deliberately naming the old name so the history is legible.
- `docs/plans/all-open-issues.md` ×2 — the planning record for this issue, including its title. It documents the pre-rename state; rewriting it would falsify the record.
