### PR TITLE
feat(installer): scripts/bothy.sh - clone at a pinned release, verify the commit, stop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # fetch-depth: 0 for the TAGS, which the default shallow checkout does not
+      # fetch. Two checks in this job compare something in the tree against a
+      # release tag - version.sh and installer-pin.sh - and with no tags present
+      # both take their "nothing to compare against" branch and pass on a repo
+      # that has already released. A check that cannot see the thing it checks
+      # is the silent pass this repo has a whole file (mutants.sh) about.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v7
         with:
@@ -147,6 +155,14 @@ jobs:
         if: always()
         run: bash scripts/checks/version.sh
 
+      # scripts/bothy.sh is what `curl … | sh` runs, and it verifies the clone
+      # against a commit id written into itself. That is a third copy of what
+      # VERSION and the tag already say: left behind, it installs an old release
+      # and every install still succeeds, which is drift nothing else notices.
+      - name: The installer serves this release
+        if: always()
+        run: bash scripts/checks/installer-pin.sh
+
   # ── the checks must be able to fail ─────────────────────────────────────────
   #
   # Everything above answers "is the tree healthy". This answers the question
@@ -166,7 +182,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # Tags, for the same reason as the tree job: the installer-pin row plants a
+      # broken commit id, and without tags the check would catch it on the SHAPE
+      # rule alone - the row would pass while the comparison it is really about
+      # never ran.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -407,3 +407,162 @@ jobs:
           name: install-failure-logs
           path: /tmp/logs
           retention-days: 7
+
+  # ── the OTHER way in ────────────────────────────────────────────────────────
+  #
+  # The job above proves `git clone && cp .env.example .env && just up`. That is
+  # the path for somebody who already knows this repository exists and already
+  # has `just`. scripts/bothy.sh is the path for somebody who has only a URL, and
+  # until now nothing executed it at all - which for a file whose entire purpose
+  # is to be piped into a shell is the least acceptable place to have no
+  # coverage.
+  #
+  # NO DAEMON, NO CONTAINERS, ABOUT A MINUTE. That is not a gap in the test: the
+  # installer deliberately STOPS before `bothy init`, so "it started nothing" is
+  # one of the things worth asserting rather than something this job fails to
+  # reach. `just up` is proven above; what was unproven is the clone, the commit
+  # verification, and the blast radius.
+  #
+  # IT IGNORES `inputs.dir`. The awkward-path matrix in elsewhere.yml varies
+  # where the STACK is installed; the curl path has one directory shape by
+  # design ($HOME/bothy), and the property that matters here - a path with a
+  # space in it - is exercised unconditionally by the fake HOME below, on every
+  # PR rather than nightly.
+  installer:
+    name: curl | sh - clone, verify, and stop
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # fetch-depth: 0 because the installer resolves a TAG in whatever it
+      # clones, and a shallow checkout has none - the installer would fail with
+      # "is not a tag", which reads like a broken installer rather than a
+      # workspace missing its tags.
+      - uses: actions/checkout@v7
+        with:
+          path: workspace
+          fetch-depth: 0
+
+      # A HOME THE INSTALLER MUST STAY INSIDE, with a space in its path. The
+      # installer writes three paths, all derived from $HOME, and an unquoted
+      # one of them splits into two arguments the first time somebody's home
+      # directory has a space in it - which on macOS is not exotic. Pointing
+      # HOME at a temp directory also makes "did it write outside $HOME"
+      # answerable, by looking at the runner's real home afterwards.
+      - name: A home that is not the runner's, with a space in it
+        run: |
+          set -euo pipefail
+          fake="$RUNNER_TEMP/home with a space"
+          mkdir -p "$fake"
+          echo "FAKE_HOME=$fake" >> "$GITHUB_ENV"
+          echo "SRC=$GITHUB_WORKSPACE/workspace" >> "$GITHUB_ENV"
+
+      - name: A dry run touches nothing
+        run: |
+          set -euo pipefail
+          HOME="$FAKE_HOME" BOTHY_REPO_URL="$SRC" sh workspace/scripts/bothy.sh --dry-run
+          n=$(find "$FAKE_HOME" -mindepth 1 | wc -l)
+          [ "$n" = 0 ] && echo "ok  a dry run wrote nothing" \
+            || { echo "FAIL  a dry run left $n path(s) behind"; find "$FAKE_HOME" -mindepth 1; exit 1; }
+
+      # THE VERIFICATION MUST BE ABLE TO FAIL. Same argument as
+      # scripts/checks/mutants.sh: a verify step that cannot refuse is
+      # indistinguishable from one that always passes, and it is the only thing
+      # standing between a `curl | sh` and a tree nobody pinned.
+      - name: A commit that is not the pinned one is refused
+        run: |
+          set -uo pipefail
+          out=$(HOME="$FAKE_HOME" BOTHY_REPO_URL="$SRC" \
+                BOTHY_SHA=0000000000000000000000000000000000000000 \
+                sh workspace/scripts/bothy.sh 2>&1); rc=$?
+          echo "$out" | tail -8
+          [ "$rc" != 0 ] || { echo "FAIL  a wrong sha installed anyway"; exit 1; }
+          echo "$out" | grep -q 'VERIFICATION FAILED' \
+            || { echo "FAIL  it exited non-zero without saying why"; exit 1; }
+          # The clone it made is untrusted, so it must not survive the refusal.
+          n=$(find "$FAKE_HOME" -mindepth 1 -maxdepth 1 | wc -l)
+          [ "$n" = 0 ] && echo "ok  refused, and left nothing behind" \
+            || { echo "FAIL  $n path(s) survived a failed verification"; exit 1; }
+
+      - name: sh bothy.sh
+        run: |
+          set -euo pipefail
+          HOME="$FAKE_HOME" BOTHY_REPO_URL="$SRC" sh workspace/scripts/bothy.sh
+
+      - name: It installed exactly what it said
+        run: |
+          set -euo pipefail
+          fail=0
+          pin_v=$(sed -n 's/^BOTHY_PIN_VERSION="\(.*\)"$/\1/p' workspace/scripts/bothy.sh)
+          pin_sha=$(sed -n 's/^BOTHY_PIN_SHA="\(.*\)"$/\1/p' workspace/scripts/bothy.sh)
+          echo "pin: $pin_v $pin_sha"
+
+          [ -x "$FAKE_HOME/.local/bin/bothy" ] && echo "ok    ~/.local/bin/bothy is executable" \
+            || { echo "FAIL  no executable CLI at ~/.local/bin/bothy"; fail=1; }
+
+          # BYTE-IDENTICAL TO THE RELEASE, not merely present. A copy step that
+          # truncated, or that copied the wrong file, would pass every other
+          # assertion here.
+          if git -C workspace show "$pin_v:scripts/bothy" | cmp -s - "$FAKE_HOME/.local/bin/bothy"; then
+            echo "ok    the CLI is scripts/bothy from $pin_v, byte for byte"
+          else
+            echo "FAIL  ~/.local/bin/bothy is not scripts/bothy at $pin_v"; fail=1
+          fi
+
+          got=$(git -C "$FAKE_HOME/bothy" rev-parse HEAD)
+          [ "$got" = "$pin_sha" ] && echo "ok    the checkout is at $pin_sha" \
+            || { echo "FAIL  the checkout is at $got, not the pinned $pin_sha"; fail=1; }
+
+          # On a branch, not detached: `bothy upgrade` runs `git pull --ff-only`,
+          # which on a detached HEAD fails with a message about local changes
+          # that names the wrong cause entirely.
+          br=$(git -C "$FAKE_HOME/bothy" symbolic-ref --quiet --short HEAD || true)
+          [ -n "$br" ] && echo "ok    the checkout is on a branch ($br), not detached" \
+            || { echo "FAIL  the checkout has a detached HEAD - bothy upgrade would fail"; fail=1; }
+
+          want="BOTHY_HOME=$FAKE_HOME/bothy"
+          got_cfg=$(cat "$FAKE_HOME/.config/bothy/config")
+          [ "$got_cfg" = "$want" ] && echo "ok    ~/.config/bothy/config points at the checkout" \
+            || { echo "FAIL  config says '$got_cfg', wanted '$want'"; fail=1; }
+
+          # The CLI has to work from a directory that is not the checkout - that
+          # is what the config file is for.
+          v=$(cd /tmp && HOME="$FAKE_HOME" "$FAKE_HOME/.local/bin/bothy" version)
+          echo "$v" | sed 's/^/      | /'
+          echo "$v" | grep -q "${pin_v#v}" \
+            && echo "ok    bothy version reports ${pin_v#v} from outside the checkout" \
+            || { echo "FAIL  bothy version did not report ${pin_v#v}"; fail=1; }
+          exit $fail
+
+      # ── the blast radius it claims ────────────────────────────────────────
+      #
+      # SECURITY.md's whole argument for this repo is what a thing can reach.
+      # The installer's claim is: three paths under $HOME, no sudo, nothing
+      # started. Every one of those is checkable, and none of them stays true by
+      # itself once somebody "simplifies" the script six months from now.
+      - name: It stayed inside HOME, and started nothing
+        run: |
+          set -euo pipefail
+          fail=0
+          n=$(docker ps -aq | wc -l)
+          [ "$n" = 0 ] && echo "ok    no container was created" \
+            || { echo "FAIL  $n container(s) exist - the installer started the box"; fail=1; }
+
+          [ -e "$FAKE_HOME/bothy/.env" ] \
+            && { echo "FAIL  it wrote a .env - that is bootstrap's job, on purpose"; fail=1; } \
+            || echo "ok    no .env was generated"
+
+          [ -e "$FAKE_HOME/.local/bin/just" ] \
+            && { echo "FAIL  it installed just - bothy init does that, deliberately later"; fail=1; } \
+            || echo "ok    it did not install just"
+
+          # $HOME/.local/bin, $HOME/.config/bothy and $HOME/bothy, and nothing
+          # else. Anything new at the top level of the fake home is a path this
+          # script's own header does not admit to writing.
+          unexpected=$(cd "$FAKE_HOME" && ls -A | grep -vxE '\.local|\.config|bothy' || true)
+          [ -z "$unexpected" ] && echo "ok    only .local, .config and bothy exist in the fake HOME" \
+            || { echo "FAIL  unexpected in the fake HOME: $unexpected"; fail=1; }
+
+          [ -e "$HOME/.local/bin/bothy" ] \
+            && { echo "FAIL  it wrote into the runner's real home, not the fake one"; fail=1; } \
+            || echo "ok    the runner's own home was untouched"
+          exit $fail

--- a/scripts/bothy.sh
+++ b/scripts/bothy.sh
@@ -1,0 +1,372 @@
+#!/bin/sh
+# The Bothy installer - the half of the CLI you cannot get by having the repo.
+#
+#   curl -fsSL https://raw.githubusercontent.com/YehudaBriskman/Bothy/main/scripts/bothy.sh -o bothy.sh
+#   less bothy.sh          # it is short, and it names every path it writes
+#   sh bothy.sh
+#
+# The pipe works too - `curl -fsSL … | sh` - and it is the convenience, not the
+# documented path. That order is deliberate: this ends with a program that holds
+# a Docker socket, and SECURITY.md spends a section on exactly how large that
+# blast radius is.
+#
+# ── what it does, and pointedly what it does not ────────────────────────────
+#
+# scripts/bothy is the CLI. It is excellent at everything AFTER you have a
+# checkout, and unreachable before - which is the chicken-and-egg its own header
+# says it exists to break, and which it cannot break on its own because you have
+# to clone the repo to get it. This file is the missing first step and NOTHING
+# MORE:
+#
+#   clone at a pinned release  ->  verify the commit  ->  put `bothy` on PATH
+#
+# It does not start a container, generate a secret, install `just`, or write
+# outside $HOME. `bothy init` does all of that, and this script PRINTS that
+# command rather than running it. See "why it stops" below - that is the single
+# most consequential decision in this file.
+#
+# ── POSIX sh, and why `set -o pipefail` is missing ──────────────────────────
+#
+# The house pattern in scripts/ is `set -uo pipefail`, and it is wrong here.
+# `curl … | sh` runs this under whatever /bin/sh is, which on Debian and Ubuntu
+# is dash - and dash answers `set -o pipefail` with
+#
+#   set: Illegal option -o pipefail
+#
+# and exits 2 on LINE ONE. An installer that dies on its first line, with a
+# message about an option nobody typed, is the worst possible first contact.
+# So: `set -u` only, no bashisms at all, and every command whose failure matters
+# is checked explicitly rather than by a shell option. The same rule that makes
+# scripts/bothy avoid bash 4 syntax (macOS ships bash 3.2) applies here twice
+# over - shellcheck runs this file as `sh`, which is what keeps it honest.
+set -u
+
+# ── the pin ─────────────────────────────────────────────────────────────────
+#
+# THIS IS THE VERIFICATION. Two lines, and scripts/checks/installer-pin.sh
+# refuses to let them drift from VERSION and the tag.
+#
+# WHY A COMMIT SHA AND NOT A CHECKSUM, which is what the issue first asked for:
+#
+#   · The published release carries ZERO assets. There is no tarball of ours to
+#     checksum, so a SHA-256 line here would have to be computed over something
+#     GitHub generates.
+#   · GitHub's auto-generated source tarballs are NOT byte-stable. They are
+#     produced by `git archive` on demand, and its output has changed with git
+#     versions and with the default compression - projects that published a
+#     checksum for one have had it go wrong under them without a single commit
+#     landing. A checksum that changes by itself is worse than none: it trains
+#     everyone to skip the verification.
+#   · A git commit id IS a checksum, over the whole tree and its history, and
+#     git verifies it on every object it writes. `git rev-parse "$VER^{commit}"`
+#     against a value baked in here is therefore the same guarantee, computed by
+#     the tool rather than by us.
+#   · It costs no new dependency. `bothy init` already requires git, so cloning
+#     adds nothing to the prerequisite list.
+#
+# WHAT IT DOES AND DOES NOT PROVE. It proves the tree you are about to run is
+# the exact tree this file was published against - a substituted or rewritten
+# tag cannot match. It proves nothing about whether THIS FILE is genuine; that
+# is what reading it before running it is for.
+BOTHY_PIN_VERSION="v2026.8.1"
+BOTHY_PIN_SHA="25d6ef4fcdac878fcadd497097d30e2d7f75cab8"
+
+# ── settings ────────────────────────────────────────────────────────────────
+#
+# Every one of these is an override for an existing default, so the no-argument
+# path is the whole documented install.
+#
+#   BOTHY_VERSION   pin to another release, e.g. BOTHY_VERSION=v2026.8.1
+#   BOTHY_SHA       the commit to require for it (see resolve_version)
+#   BOTHY_DIR       where the checkout goes. Must be inside $HOME
+#   BOTHY_REPO_URL  the clone source. CI points this at a local path
+REPO_URL="${BOTHY_REPO_URL:-https://github.com/YehudaBriskman/Bothy.git}"
+DIR="${BOTHY_DIR:-$HOME/bothy}"
+BIN_DIR="$HOME/.local/bin"
+CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/bothy/config"
+
+DRY_RUN=0
+CREATED_DIR=0
+
+red() { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+say() { printf '%s\n' "$*"; }
+die() {
+  red "$*"
+  # A half-finished install is worth saying out loud: the clone is the only
+  # thing this script can leave behind, and a silent one is a directory the
+  # next run refuses to reuse for reasons nobody can see.
+  if [ "$CREATED_DIR" = 1 ] && [ -d "$DIR" ]; then
+    say "The checkout at $DIR was left in place. Remove it if you are starting over."
+  fi
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+bothy.sh - install the `bothy` CLI from a pinned release
+
+  sh bothy.sh              clone the pinned release into ~/bothy and put
+                           `bothy` in ~/.local/bin
+  sh bothy.sh --dry-run    say exactly what that would do, and touch nothing
+  sh bothy.sh --help       this
+
+It never uses sudo, never writes outside $HOME, and never starts anything -
+it prints the `bothy init` command instead of running it.
+
+  BOTHY_VERSION   install another release tag (the commit is then unverified
+                  unless BOTHY_SHA is given too)
+  BOTHY_SHA       the commit that tag must resolve to
+  BOTHY_DIR       where to put the checkout (default ~/bothy, must be in $HOME)
+  BOTHY_REPO_URL  clone from somewhere else
+EOF
+}
+
+# ── the prerequisites this script needs FOR ITSELF ──────────────────────────
+#
+# Three, not seven. The full list - docker with the compose plugin, git, curl,
+# python3, openssl - lives in check_prereqs() in scripts/bothy, and this script
+# DELEGATES to it (`bothy doctor --pre`) once the clone exists rather than
+# repeating it here.
+#
+# That is the whole reason to clone before checking: a second copy of the list
+# is the failure this repo has paid for repeatedly - four dead compose files,
+# dependabot entries for deleted directories - and a prerequisite list that
+# disagrees with itself sends people to install the wrong thing. The cost of the
+# order is one clone (~20 MB, in $HOME, removable) on a box that turns out to
+# have no docker, and the message says where it is.
+#
+# git, curl and bash are the exception because this script cannot do its own job
+# without them: git to clone, curl because that is how you got this file and how
+# `bothy init` fetches `just`, and bash because scripts/bothy is a bash script -
+# running it under dash to ask for the rest of the list would fail on its
+# `set -o pipefail` and report a prerequisite problem that is not one.
+need_min() {
+  missing=""
+  for c in git curl bash; do
+    command -v "$c" >/dev/null 2>&1 || missing="$missing $c"
+  done
+  [ -z "$missing" ] || die "missing:$missing - this installer needs git, curl and bash before it can fetch anything"
+}
+
+# ── which release ───────────────────────────────────────────────────────────
+#
+# THE DEFAULT IS THE PIN, NOT "whatever /releases/latest says today", and that
+# is not laziness about an API call. Resolving "latest" at run time means
+# installing a commit whose id this file cannot know, which is precisely the
+# thing the pin exists to check - the verification would have to be dropped for
+# the default path and kept only for the unusual one. So "latest" is baked in,
+# and scripts/checks/installer-pin.sh is what keeps it latest: the moment
+# VERSION names a release the pin does not, CI is red.
+#
+# An explicit BOTHY_VERSION is honoured for pinning to an older release. It is
+# UNVERIFIED unless BOTHY_SHA is given with it, and it says so loudly - the
+# alternative, silently skipping the check for any version but one, is a
+# verification that reads as present and is not.
+resolve_version() {
+  VER="${BOTHY_VERSION:-$BOTHY_PIN_VERSION}"
+  WANT_SHA="${BOTHY_SHA:-}"
+  if [ -z "$WANT_SHA" ] && [ "$VER" = "$BOTHY_PIN_VERSION" ]; then
+    WANT_SHA="$BOTHY_PIN_SHA"
+  fi
+}
+
+# ── nothing outside $HOME ───────────────────────────────────────────────────
+#
+# Not a style rule. This is a script people are invited to pipe into a shell,
+# and "what can it touch" has to be answerable by reading it: three paths, all
+# under $HOME, no sudo anywhere in the file. A BOTHY_DIR pointing at /opt or
+# /usr/local would need a privilege this script deliberately never asks for, and
+# would half-succeed - the clone as your user, then a permission error.
+inside_home() {
+  case "$1" in
+    "$HOME"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ── the download, and the check ─────────────────────────────────────────────
+fetch_and_verify() {
+  if [ -e "$DIR/.git" ]; then
+    # Reusing a checkout rather than refusing: re-running the installer is the
+    # documented way to refresh the CLI copy in ~/.local/bin, and the verify
+    # below still has to pass, so a tampered-with reuse is caught rather than
+    # trusted.
+    say "== reusing the checkout at $DIR =="
+    git -C "$DIR" fetch --quiet --tags origin || die "could not fetch from origin in $DIR"
+  elif [ -e "$DIR" ] && [ -n "$(ls -A "$DIR" 2>/dev/null)" ]; then
+    die "$DIR exists and is not empty, and is not a git checkout. Set BOTHY_DIR to somewhere else."
+  else
+    say "== cloning $REPO_URL =="
+    git clone --quiet "$REPO_URL" "$DIR" || die "clone failed"
+    CREATED_DIR=1
+  fi
+
+  # `^{commit}` and not the bare tag: an annotated tag is its own object with
+  # its own id, so comparing that id against a commit id fails for a tag that is
+  # perfectly correct. v2026.8.1 is annotated (`just release` uses `git tag -a`),
+  # which is exactly the case that would break.
+  got=$(git -C "$DIR" rev-parse "$VER^{commit}" 2>/dev/null) \
+    || die "$VER is not a tag in $REPO_URL - check BOTHY_VERSION"
+
+  if [ -n "$WANT_SHA" ]; then
+    if [ "$got" != "$WANT_SHA" ]; then
+      # The clone is untrusted from here on, so it goes - but only if THIS run
+      # created it. Deleting a directory the user already had, because a version
+      # they asked for did not match, would be a data loss bug in an installer.
+      if [ "$CREATED_DIR" = 1 ]; then
+        rm -rf "$DIR"
+        CREATED_DIR=0
+      fi
+      red "VERIFICATION FAILED"
+      say "  $VER should be $WANT_SHA"
+      say "  it is        $got"
+      say ""
+      say "Nothing was installed. Either this installer is out of date for the"
+      say "repository it fetched, or the tag has been moved - do not run the"
+      say "checkout until you know which."
+      exit 1
+    fi
+    say "  verified $VER = $got"
+  else
+    say "  $VER = $got  (UNVERIFIED - no BOTHY_SHA given for a non-default version)"
+  fi
+
+  # Land the working tree ON the release, and stay on a branch while doing it.
+  # `git checkout <tag>` would detach HEAD, and `bothy upgrade` then runs
+  # `git pull --ff-only` against a detached HEAD and fails with "the checkout
+  # has local changes or has diverged" - a message that names the wrong cause
+  # and sends whoever reads it looking for a change they did not make.
+  #
+  # `checkout -B` and not `reset --hard`: on a reused checkout a hard reset
+  # discards whatever the person had edited in it, silently, as a side effect of
+  # re-running an installer. checkout refuses instead, and the refusal is the
+  # correct outcome - it is their change, not ours to throw away.
+  branch=$(git -C "$DIR" symbolic-ref --quiet --short HEAD 2>/dev/null)
+  [ -n "$branch" ] || branch=main
+  git -C "$DIR" checkout --quiet -B "$branch" "$got" \
+    || die "could not put $DIR on $branch at $got - it may have uncommitted changes"
+}
+
+# ── the CLI ─────────────────────────────────────────────────────────────────
+install_cli() {
+  mkdir -p "$BIN_DIR" || die "cannot create $BIN_DIR"
+  # A COPY, not a symlink into the checkout. A symlink would silently break the
+  # `bothy` command the day somebody moves or deletes ~/bothy, and the error is
+  # "command not found" for a program they can see in their PATH. The cost is
+  # that `bothy upgrade` refreshes the checkout and not this copy; re-running
+  # this installer is what refreshes the copy, and the summary below says so.
+  cp "$DIR/scripts/bothy" "$BIN_DIR/bothy" || die "could not write $BIN_DIR/bothy"
+  chmod +x "$BIN_DIR/bothy" || die "could not make $BIN_DIR/bothy executable"
+
+  # The same warning ensure_just() prints in scripts/bothy, in the same words -
+  # two different wordings for one situation is how somebody concludes they are
+  # two different problems.
+  case ":${PATH:-}:" in
+    *":$BIN_DIR:"*) ;;
+    *) say "  installed. Add ~/.local/bin to your PATH to keep it." ;;
+  esac
+
+  # `init` writes this too, and writing it here means the CLI can find the
+  # checkout from any directory the moment it is installed. Without it,
+  # `bothy version` from anywhere but inside ~/bothy answers "no checkout found"
+  # one second after a successful install.
+  mkdir -p "$(dirname "$CONFIG")" || die "cannot create $(dirname "$CONFIG")"
+  printf 'BOTHY_HOME=%s\n' "$DIR" > "$CONFIG" || die "cannot write $CONFIG"
+}
+
+# ── why it stops here ───────────────────────────────────────────────────────
+#
+# IT PRINTS `bothy init`; IT DOES NOT RUN IT. The tempting version of this
+# script ends with a running box, and it is the wrong one:
+#
+#   · `bothy init` runs `just up`, which starts ~26 containers, one of which
+#     reaches a Docker socket - root-equivalent on the machine, as SECURITY.md
+#     says in the first line of its socket-proxy section. A pipe from a URL to
+#     `sh` should not be able to reach that in one step.
+#   · `init` also installs `just` by piping ANOTHER remote installer into bash.
+#     One curl|sh implying a second, unmentioned one is exactly the property
+#     that makes people distrust the pattern, and they are right.
+#   · `just up` writes .env, generates five secrets, and creates docker volumes.
+#     Undoing that is `just nuke`, which deletes data volumes. Everything this
+#     script does is undone by deleting two paths.
+#
+# The stopping point is chosen so the destructive half is a command a person
+# typed, on a machine where they can already read the code that will run - it is
+# in ~/bothy by then, at a verified commit. That is a materially different act
+# from a pipe, and it costs one line of typing.
+next_steps() {
+  say ""
+  say "== installed =="
+  say "  $BIN_DIR/bothy      the CLI"
+  say "  $DIR                the checkout, at $VER"
+  say "  $CONFIG"
+  say ""
+  say "Nothing is running yet, and nothing has been started for you. Next:"
+  say ""
+  say "  bothy init $DIR"
+  say ""
+  say "That installs \`just\`, writes .env, generates this box's secrets and"
+  say "brings the stack up. Read $DIR/scripts/bothy first if you would rather"
+  say "see what that means - it is now on disk, at a commit you have verified."
+  say ""
+  say "Re-run this installer to refresh $BIN_DIR/bothy after an upgrade."
+}
+
+main() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dry-run) DRY_RUN=1 ;;
+      -h|--help) usage; exit 0 ;;
+      *) red "unknown option: $1"; say ""; usage; exit 1 ;;
+    esac
+    shift
+  done
+
+  [ -n "${HOME:-}" ] || die "HOME is not set - this installer writes only inside it and cannot find it"
+  # `sudo sh bothy.sh` leaves root-owned files in the invoking user's
+  # ~/.local/bin, and the next ordinary `bothy` cannot overwrite them. Refused
+  # rather than warned: this script has no step that needs a privilege, so being
+  # run with one means a misunderstanding worth stopping for.
+  if [ "$(id -u)" = 0 ] && [ -n "${SUDO_USER:-}" ]; then
+    die "Do not run this with sudo. It writes only inside \$HOME and needs no privileges."
+  fi
+
+  need_min
+  resolve_version
+
+  inside_home "$DIR" || die "BOTHY_DIR must be inside \$HOME (got $DIR). This installer never writes elsewhere."
+
+  if [ "$DRY_RUN" = 1 ]; then
+    say "dry run - nothing will be written"
+    say "  version     $VER"
+    if [ -n "$WANT_SHA" ]; then say "  verify      $WANT_SHA"; else say "  verify      NO (no BOTHY_SHA for $VER)"; fi
+    say "  clone from  $REPO_URL"
+    say "  clone to    $DIR"
+    say "  cli         $BIN_DIR/bothy"
+    say "  config      $CONFIG"
+    say "  then        prints \`bothy init $DIR\` - never runs it"
+    exit 0
+  fi
+
+  fetch_and_verify
+
+  # The full prerequisite list, from its ONE definition. Run from the checkout
+  # rather than from the copy in ~/.local/bin because that copy does not exist
+  # yet - and because a prerequisite failure should not leave a `bothy` on PATH
+  # that cannot do anything.
+  say ""
+  say "== prerequisites =="
+  # `bash`, explicitly, and never `sh`: scripts/bothy opens with
+  # `set -uo pipefail`, which dash answers with "Illegal option -o pipefail" and
+  # exit 2 - so `sh scripts/bothy` would report a prerequisite failure on a box
+  # where every prerequisite is present.
+  bash "$DIR/scripts/bothy" doctor --pre \
+    || die "install what is missing above, then re-run this installer"
+
+  say ""
+  say "== the CLI =="
+  install_cli
+  next_steps
+}
+
+main "$@"

--- a/scripts/checks/installer-pin.sh
+++ b/scripts/checks/installer-pin.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# The installer's pinned release must be THIS release.
+#
+# scripts/bothy.sh is a `curl … | sh` installer, and its whole verification
+# story is two lines near the top:
+#
+#   BOTHY_PIN_VERSION="v2026.8.1"
+#   BOTHY_PIN_SHA="25d6ef4…"
+#
+# It clones, resolves that tag to a commit, and refuses to install anything if
+# the commit is not that one. Which makes those two lines a THIRD copy of a fact
+# already written down twice - in VERSION and in the git tag - and
+# scripts/checks/version.sh exists because two copies can disagree. Three can
+# disagree in more ways, and every one of them is silent:
+#
+#   · The SHA is stale or mistyped. Every install fails at the verify step, for
+#     everybody, and the failure blames the repository ("the tag has been
+#     moved") rather than this file. Nothing in the tree looks wrong.
+#   · A release is cut and the pin is not updated. `curl | sh` keeps installing
+#     the OLD release, indefinitely and silently - the install succeeds, verifies
+#     and is simply not what the project ships. This is the drift that matters,
+#     because nothing anywhere fails.
+#   · The pin is bumped ahead of VERSION. The installer distributes a release the
+#     tree does not claim to be.
+#
+# WHY IT IS A SIBLING OF cli-commands.sh AND NOT PART OF IT. That check skips
+# itself, out loud, when `just` is absent, because it cannot resolve recipes
+# without it. This one needs nothing but git and must never be skipped for a
+# reason that has nothing to do with what it guards.
+#
+# THE ORDER THIS ASSUMES, which is the release procedure with one step added:
+#   1. edit VERSION, commit          (version.sh: "a release is pending")
+#   2. `just release` tags it        (version.sh: they now match)
+#   3. update the pin here, commit   (this check: they now match)
+# Between 2 and 3 this check is RED on purpose - that is the window in which the
+# installer serves the wrong release, and it is meant to be short and loud.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1
+
+INSTALLER=scripts/bothy.sh
+fails=0
+check() { if [ "$2" = ok ]; then printf 'PASS  %s\n' "$1"; else printf 'FAIL  %s  %s\n' "$1" "$3"; fails=$((fails+1)); fi; }
+
+[ -f "$INSTALLER" ] || { echo "FAIL  $INSTALLER is missing"; exit 1; }
+[ -f VERSION ]      || { echo "FAIL  no VERSION file at the repo root"; exit 1; }
+
+v=$(tr -d '[:space:]' < VERSION)
+pin_version=$(sed -n 's/^BOTHY_PIN_VERSION="\(.*\)"$/\1/p' "$INSTALLER" | head -1)
+pin_sha=$(sed -n 's/^BOTHY_PIN_SHA="\(.*\)"$/\1/p' "$INSTALLER" | head -1)
+
+# READ, NOT SOURCED. `.` on the installer would run it - it ends in `main "$@"`,
+# which clones a repository into $HOME. A check must not be able to install
+# anything.
+if [ -z "$pin_version" ] || [ -z "$pin_sha" ]; then
+  echo "FAIL  could not read BOTHY_PIN_VERSION / BOTHY_PIN_SHA out of $INSTALLER"
+  echo "      They must stay one plain assignment per line - this check parses them."
+  exit 1
+fi
+
+# Shape first. A malformed pin makes every comparison below confusing, and a
+# truncated SHA would compare unequal for a reason nobody would guess.
+case "$pin_version" in
+  v[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*) check "the pinned version is vYYYY.M.PATCH" ok ;;
+  *) check "the pinned version is vYYYY.M.PATCH" no "got '$pin_version'" ;;
+esac
+case "$pin_sha" in
+  # 40 hex, lower case: `git rev-parse` prints it that way, so an upper-case or
+  # abbreviated value would never match at run time however correct it looks.
+  [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) \
+    check "the pinned commit is a full 40-hex sha" ok ;;
+  *) check "the pinned commit is a full 40-hex sha" no "got '$pin_sha'" ;;
+esac
+
+# ── the pin against VERSION ─────────────────────────────────────────────────
+#
+# NOT EQUALITY, for the reason version.sh gives: VERSION is bumped in one commit
+# and tagged in the next, so requiring them equal would fail the very commit that
+# starts a release. AHEAD is the fault - a pin naming a release newer than the
+# tree claims to be means somebody edited this pin without bumping VERSION.
+top=$(printf '%s\n%s\n' "$pin_version" "v$v" | sort -V | tail -1)
+if [ "$top" = "v$v" ]; then
+  check "the pin is not ahead of VERSION ($v)" ok
+else
+  check "the pin is not ahead of VERSION ($v)" no "pin is $pin_version, VERSION is $v"
+fi
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo
+  echo "not a git checkout - the pin says $pin_version, and there is no tag to resolve it against."
+  exit $((fails > 0 ? 1 : 0))
+fi
+
+# ── the pin against the tags ────────────────────────────────────────────────
+tagged=$(git rev-parse --quiet --verify "$pin_version^{commit}" 2>/dev/null)
+if [ -z "$tagged" ]; then
+  if [ -z "$(git tag)" ]; then
+    # A checkout with no tags at all is a shallow clone, not a broken pin. Said
+    # out loud rather than passed silently: a check that quietly stops checking
+    # is the failure this repo has a whole file (mutants.sh) about.
+    echo "NOTE  no tags in this checkout - cannot resolve $pin_version. Fetch tags to check the sha."
+  else
+    check "$pin_version exists as a tag" no "the installer pins a tag this repo does not have"
+  fi
+else
+  if [ "$tagged" = "$pin_sha" ]; then
+    check "the pinned sha is the commit $pin_version names" ok
+  else
+    check "the pinned sha is the commit $pin_version names" no "$pin_version is $tagged, the pin says $pin_sha"
+  fi
+
+  # Has a release been cut that the installer does not serve? The tag for
+  # VERSION existing is what makes step 3 of the procedure overdue rather than
+  # pending - before that there is nothing to pin to.
+  if [ "$pin_version" != "v$v" ]; then
+    if git rev-parse --quiet --verify "v$v^{commit}" >/dev/null 2>&1; then
+      check "the pin serves the released VERSION" no "v$v is tagged but the installer still serves $pin_version"
+    else
+      echo "NOTE  VERSION is $v and the installer serves $pin_version - a release is pending;"
+      echo "      update the pin after \`just release\` tags v$v"
+    fi
+  else
+    check "the pin serves the released VERSION" ok
+  fi
+fi
+
+# ── the claim the installer's own header makes ──────────────────────────────
+#
+# "It never uses sudo" is in the usage text people read before piping this into
+# a shell, and it is the one property that cannot be walked back later without
+# somebody noticing. Matched at COMMAND position only - the word appears four
+# times in that file explaining why it is absent, and a check that cannot tell a
+# sentence about sudo from a call to it would be un-passable.
+if grep -nE '(^|[;&|(]|&&|\|\|)[[:space:]]*sudo[[:space:]]' "$INSTALLER" >/dev/null 2>&1; then
+  check "the installer calls no sudo" no "$(grep -nE '(^|[;&|(]|&&|\|\|)[[:space:]]*sudo[[:space:]]' "$INSTALLER" | head -1)"
+else
+  check "the installer calls no sudo" ok
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "ok - the installer serves $pin_version"
+else
+  echo "$fails problem(s). scripts/bothy.sh is what \`curl | sh\` runs; a stale pin"
+  echo "there installs the wrong release, or nothing at all, and says so to nobody."
+fi
+exit $((fails > 0 ? 1 : 0))

--- a/scripts/checks/mutants.sh
+++ b/scripts/checks/mutants.sh
@@ -213,6 +213,29 @@ mutant_lower="${PATH'"$BASH4_SUFFIX"'}"' \
   -- bash scripts/checks/bash32.sh
 
 echo
+echo "── what \`curl | sh\` would actually install ─────────────────────────"
+# scripts/bothy.sh clones a release and refuses to go on unless the tag resolves
+# to a commit id written into the installer. That id is a THIRD copy of what
+# VERSION and the git tag already say, and the way it goes wrong is a stale or
+# mistyped constant that nothing in the tree looks wrong next to: every install
+# then fails at the verify step and blames the repository, or - worse - the pin
+# is left behind at an old release and every install silently succeeds with the
+# wrong code.
+#
+# ANCHORED ON THE ASSIGNMENT, NOT ON THE VALUE, and that is the whole reason
+# this row does not need editing at every release. A mutation whose anchor is
+# `…="25d6ef4…"` stops applying the day the pin is bumped, and `plant` then
+# reports "anchor not found" - which reads as the harness being broken rather
+# than as a row that has rotted. Prefixing a digit models the realistic slip
+# (one character in a forty-character constant) and applies to whatever the pin
+# happens to be.
+mutant "the installer's pinned sha drifts" \
+  scripts/bothy.sh \
+  'BOTHY_PIN_SHA="' \
+  'BOTHY_PIN_SHA="0' \
+  -- bash scripts/checks/installer-pin.sh
+
+echo
 echo "── the check harness itself ────────────────────────────────────────"
 # Three suites shipped `cd "$HERE/.."` with no `|| exit`, so a failed cd ran
 # every check below against the caller's directory. shellcheck at -S warning is


### PR DESCRIPTION
`scripts/bothy` is the CLI and it is excellent at everything *after* you have a
checkout — and unreachable before, because you have to clone the repo to get it.
That is the chicken-and-egg its own header says it exists to break, and it
cannot break it alone. `scripts/bothy.sh` is the missing first step:

```
clone at a pinned release  ->  verify the commit  ->  put `bothy` on PATH
```

and nothing else. It never sudos, writes only `~/.local/bin/bothy`,
`~/.config/bothy/config` and `~/bothy`, and starts nothing.

## The verification, and why it is a commit id

Clone at the tag, then require `git rev-parse "$VER^{commit}"` to equal a SHA
baked into the installer. Not a checksum, for three reasons:

- the published release carries **zero assets**, so there is nothing of ours to
  checksum — a SHA-256 line would have to cover something GitHub generates;
- GitHub's auto-generated source tarballs are **not byte-stable** (`git archive`
  on demand; its output has moved with git versions), and a published checksum
  that changes by itself trains everybody to skip the verification;
- a git commit id **is** a checksum over the whole tree, recomputed by git on
  every object it writes, and `bothy init` already requires `git`, so cloning
  adds no dependency.

What it proves: the tree you are about to run is the exact tree this installer
was published against. What it does not: that this *file* is genuine — which is
why the documented path is `curl -o bothy.sh`, read it, `sh bothy.sh`, with the
pipe as the convenience.

`BOTHY_VERSION=v…` pins to another release; that path is **unverified unless
`BOTHY_SHA` is given too**, and it says so on the line where it happens rather
than silently skipping the check.

## Why it stops before `bothy init`

`SECURITY.md` argues its whole model in terms of what a thing can reach, so this
was decided rather than defaulted. `bothy init` runs `just up`: ~26 containers,
one of them holding a Docker socket (root-equivalent, per the socket-proxy
section), and it installs `just` by piping **another** remote installer into
bash. A pipe from a URL should not reach that in one step, and one curl|sh
implying a second unmentioned one is exactly the property that makes people
distrust the pattern.

So the installer prints the command. Everything it did is undone by deleting two
paths; the destructive half is a command a person types, on a box where the code
that will run is already on disk at a commit they have verified.

## The preflight

It checks `git`, `curl` and `bash` — the three it needs for its own job — then
clones and **delegates the real list to `bothy doctor --pre`**, which is
`check_prereqs()` in `scripts/bothy`. A second copy of the prerequisite list is
the duplication this repo has paid for over and over, and one that disagrees
with itself sends people to install the wrong thing. The cost of that order is
one clone in `$HOME` on a box that turns out to have no docker, and the message
says where it is.

## POSIX sh

`set -uo pipefail` — the house pattern — is deliberately absent. Piped to `sh`
on Debian/Ubuntu this runs under dash, which answers that with
`set: Illegal option -o pipefail` and exits **2 on line one**. shellcheck runs
the file as `sh`, which is what keeps it honest.

## The drift check

`scripts/checks/installer-pin.sh`, a sibling of `cli-commands.sh` rather than
part of it (that one skips itself when `just` is absent; this must never skip).
It asserts the pin's shape, that it is not ahead of `VERSION`, that the pinned
SHA is the commit the pinned tag names, that a tagged `VERSION` is the one being
served, and that the installer calls no `sudo` at command position. Shape and
"a release is pending" follow `version.sh`'s reasoning exactly.

**Proved able to fail, by hand** (tree restored after each):

| mutation | result |
|---|---|
| `BOTHY_PIN_SHA` one hex digit changed | `FAIL … v2026.8.1 is 25d6ef4…, the pin says 35d6ef4…`, exit 1 |
| `BOTHY_PIN_SHA` prefixed with `0` (the mutants row) | 2 FAILs (shape + comparison), exit 1 |
| `BOTHY_PIN_VERSION` bumped to an untagged `v2026.9.1` | 2 FAILs (ahead of VERSION, no such tag), exit 1 |
| a `sudo rm -rf /` line appended | `FAIL the installer calls no sudo`, exit 1 |

A `mutants.sh` row plants the prefixed-`0` mutation. Its anchor is the
**assignment**, not the value — a row anchored on `…="25d6ef4…"` stops applying
the day the pin is bumped and then reports "anchor not found", which reads as
the harness being broken rather than as a row that has rotted. `mutants.sh` was
**not** run here (dirty tree, and it is out of scope for this box); the row's
mutation was applied by hand and the check exited 1.

CI's `tree` and `mutants` jobs now check out with `fetch-depth: 0`. Without tags
both `version.sh` and this check take their "nothing to compare against" branch
and pass on a repo that has already released.

## CI

`install.yml` gains a second job, `installer`. It **ignores `inputs.dir`** —
`elsewhere.yml`'s matrix varies where the *stack* is installed; the curl path has
one directory shape by design, and the property that matters here (a path with a
space) is exercised unconditionally by a fake `HOME` on every PR. No daemon, no
containers, ~1 minute. It asserts:

- a dry run writes nothing;
- a wrong `BOTHY_SHA` **is refused**, says `VERIFICATION FAILED`, and leaves
  nothing behind (a verify step that cannot refuse is the same as one that
  always passes);
- the installed CLI is `scripts/bothy` at the pinned tag **byte for byte**, the
  checkout is at the pinned SHA and on a branch (a detached HEAD would make
  `bothy upgrade`'s `git pull --ff-only` fail with a message naming the wrong
  cause), the config file points at it, and `bothy version` works from another
  directory;
- the blast radius it claims: no container created, no `.env`, no `just`
  installed, nothing outside the fake `$HOME`.

The "Health sweep (gated)" step is untouched.

## What was NOT run locally, and cannot be

**The end-to-end install path was not executed on this box and I am forbidden to
execute it.** This worktree sits on a live dev box whose real stack is running,
and a throwaway clone once recreated its Traefik and Keycloak from `/tmp`. So no
`docker`, no `docker compose`, no `just up|down|nuke|bootstrap`, and no
`mutants.sh`.

What *was* run: the installer's full logic against a **local clone source**,
inside a fake `$HOME` whose path contains a space, with a **stub `docker`** first
on `PATH` so the real daemon was never contacted — help, dry-run, unknown option,
`BOTHY_DIR` outside `$HOME`, a wrong `BOTHY_SHA`, the real run, a second
idempotent run, a clone from a **detached-HEAD** source (the shape CI produces),
and the CI job's shell steps mirrored one for one minus the two docker
assertions. Plus `bash -n`, `sh -n`, `bash32.sh`, shellcheck `-x -S warning`,
`cli-commands.sh`, `version.sh`, `portability.sh`, `recipe-descriptions.sh` and
YAML parsing of all three workflows.

`just up` behind `bothy init` is covered only by the existing install job and by
CI.

## What the new job caught on its first run

Both of these are the reason it exists, and neither was visible from this box:

- **The refusal step could not pass.** GitHub runs every step as `bash -e {0}`,
  and `set -uo pipefail` does not turn that off — so capturing the output of an
  installer invocation *expected* to exit non-zero killed the step before the
  line that reads `$?`. It reported "exit code 1" with no output, which reads as
  the installer crashing rather than as the test being wrong. Now
  `… && rc=0 || rc=$?`.
- **The runner image sets `$XDG_CONFIG_HOME`**, so the CLI config landed in the
  runner's real home while `HOME` said otherwise. The installer honours that
  variable deliberately — `scripts/bothy` *reads* the same expression, and a
  writer and a reader that disagree produce "No Bothy checkout found" with the
  file sitting right there — so the fix is to say so at the assignment, print the
  path actually used, pin the variable in the job, and stop claiming `$HOME`
  covers all three paths when the user's own XDG setting can move one. Both
  environments (XDG set, XDG absent) are now exercised locally.

## Refs #100 — not `Closes`

This lands the installer half. Still open from that issue: `scripts/lib/ops.sh`
and the incremental extraction of recipe logic, `bothy download -a` /
`upgrade -a` flag parity, `bothy self-update`, and `README.md` (a separate
stream, #104, is rewriting it — deliberately untouched here, so the curl
one-liner is not yet documented anywhere a user will look).
