### PR TITLE
docs(monitoring): record what the cAdvisor flags actually did

### DIFF
--- a/monitoring/compose.yml
+++ b/monitoring/compose.yml
@@ -139,6 +139,17 @@ services:
     # dashboard, alert rule or portal query reads. cadvisor is also the closest
     # container on this box to its own limit, 213.5 MiB of a 256 MiB cap.
     #
+    # MEASURED AFTER, on the same box, so the claim above is not left as a
+    # prediction: 4147 series -> 1036, and 213.5 MiB -> 25.8 MiB (83% of the cap
+    # to 10%). The three biggest producers went to zero - container_tasks_state
+    # 360, container_blkio_device_usage_total 124, container_fs_reads_total 113.
+    # Everything queried survived intact, and the query SystemDialog.tsx actually
+    # runs still returns its six series grouped by compose project.
+    #
+    # 1036 rather than the ~407 that is "reachable": container_memory_failures_total
+    # keeps 84 series because it is gated by MemoryUsageMetrics, so dropping it
+    # would take container_memory_working_set_bytes with it. That is the floor.
+    #
     # THE LABEL WHITELIST IS LOAD-BEARING, and this is the line to be careful
     # with. `--store_container_labels=false` on its own drops
     # container_label_com_docker_compose_project, which SystemDialog.tsx selects


### PR DESCRIPTION
#114 shipped the cAdvisor flags with the result stated as a prediction — they had been validated against `gcr.io/cadvisor/cadvisor:v0.55.1` itself, but never run on a box. They have now been applied to the dev box and measured.

| | before | after |
|---|---|---|
| series emitted | 4147 | **1036** |
| memory | 213.5 MiB (83% of a 256m cap) | **25.8 MiB (10%)** |

The three biggest producers went to zero: `container_tasks_state` 360→0, `container_blkio_device_usage_total` 124→0, `container_fs_reads_total` 113→0.

**Nothing that is queried was lost.** The three whitelisted compose labels survived, verified by running the exact PromQL `SystemDialog.tsx` builds:

```
sum by (name) (container_memory_working_set_bytes{container_label_com_docker_compose_project="monitoring"})
→ 6 series, grouped correctly
```

`container_cpu_usage_seconds_total`, `container_memory_working_set_bytes`, `container_network_receive_bytes_total` and `container_start_time_seconds` are all still emitted.

**Why 1036 and not the ~407 the comment calls "reachable":** `container_memory_failures_total` keeps 84 series because it is gated by `MemoryUsageMetrics` — dropping it would take `container_memory_working_set_bytes` with it. That is the floor, and it is worth writing down so nobody spends an afternoon chasing the last 600.

Also confirmed live: the `docker-daemon` target is gone (five targets, all up) and `just doctor strict` exits 0 on this box.

Comment only — no behaviour change.