### PR TITLE
fix(installer): the curl-path job's two first-run findings

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -455,6 +455,14 @@ jobs:
           mkdir -p "$fake"
           echo "FAKE_HOME=$fake" >> "$GITHUB_ENV"
           echo "SRC=$GITHUB_WORKSPACE/workspace" >> "$GITHUB_ENV"
+          # THE RUNNER IMAGE SETS $XDG_CONFIG_HOME, and the installer honours it
+          # for the CLI's config file - deliberately, because scripts/bothy READS
+          # that same variable, and a writer and reader that disagree produce "No
+          # Bothy checkout found" with the file sitting right there. Left alone,
+          # the config would land in the runner's real home while HOME says
+          # otherwise, which is a confusing way to learn this. Pinned here so the
+          # job tests one defined behaviour instead of the image's environment.
+          echo "XDG_CONFIG_HOME=$fake/.config" >> "$GITHUB_ENV"
 
       - name: A dry run touches nothing
         run: |
@@ -471,9 +479,14 @@ jobs:
       - name: A commit that is not the pinned one is refused
         run: |
           set -uo pipefail
+          # `&& rc=0 || rc=$?`, not `; rc=$?`. GitHub runs every step under
+          # `bash -e`, and `set -uo pipefail` does not turn that off - so a plain
+          # capture of a command EXPECTED to fail kills the step before the next
+          # line runs, and the step reports "exit code 1" with no output at all.
+          # It looked exactly like the installer crashing.
           out=$(HOME="$FAKE_HOME" BOTHY_REPO_URL="$SRC" \
                 BOTHY_SHA=0000000000000000000000000000000000000000 \
-                sh workspace/scripts/bothy.sh 2>&1); rc=$?
+                sh workspace/scripts/bothy.sh 2>&1) && rc=0 || rc=$?
           echo "$out" | tail -8
           [ "$rc" != 0 ] || { echo "FAIL  a wrong sha installed anyway"; exit 1; }
           echo "$out" | grep -q 'VERIFICATION FAILED' \
@@ -520,13 +533,16 @@ jobs:
             || { echo "FAIL  the checkout has a detached HEAD - bothy upgrade would fail"; fail=1; }
 
           want="BOTHY_HOME=$FAKE_HOME/bothy"
-          got_cfg=$(cat "$FAKE_HOME/.config/bothy/config")
-          [ "$got_cfg" = "$want" ] && echo "ok    ~/.config/bothy/config points at the checkout" \
+          # `|| true` on both reads below: a missing file or a CLI that will not
+          # run is a FAIL line worth printing, not a step that dies under `-e`
+          # with no indication of which assertion was being made.
+          got_cfg=$(cat "$XDG_CONFIG_HOME/bothy/config" 2>/dev/null || true)
+          [ "$got_cfg" = "$want" ] && echo "ok    the CLI config points at the checkout" \
             || { echo "FAIL  config says '$got_cfg', wanted '$want'"; fail=1; }
 
           # The CLI has to work from a directory that is not the checkout - that
           # is what the config file is for.
-          v=$(cd /tmp && HOME="$FAKE_HOME" "$FAKE_HOME/.local/bin/bothy" version)
+          v=$(cd /tmp && HOME="$FAKE_HOME" "$FAKE_HOME/.local/bin/bothy" version || true)
           echo "$v" | sed 's/^/      | /'
           echo "$v" | grep -q "${pin_v#v}" \
             && echo "ok    bothy version reports ${pin_v#v} from outside the checkout" \
@@ -562,7 +578,7 @@ jobs:
           [ -z "$unexpected" ] && echo "ok    only .local, .config and bothy exist in the fake HOME" \
             || { echo "FAIL  unexpected in the fake HOME: $unexpected"; fail=1; }
 
-          [ -e "$HOME/.local/bin/bothy" ] \
+          [ -e "$HOME/.local/bin/bothy" ] || [ -e "$HOME/.config/bothy" ] \
             && { echo "FAIL  it wrote into the runner's real home, not the fake one"; fail=1; } \
             || echo "ok    the runner's own home was untouched"
           exit $fail

--- a/scripts/bothy.sh
+++ b/scripts/bothy.sh
@@ -83,6 +83,16 @@ BOTHY_PIN_SHA="25d6ef4fcdac878fcadd497097d30e2d7f75cab8"
 REPO_URL="${BOTHY_REPO_URL:-https://github.com/YehudaBriskman/Bothy.git}"
 DIR="${BOTHY_DIR:-$HOME/bothy}"
 BIN_DIR="$HOME/.local/bin"
+# THE SAME EXPRESSION scripts/bothy uses to READ this file, character for
+# character, and that matters more than tidiness: a writer and a reader that
+# disagree about where the config lives produce "No Bothy checkout found" one
+# second after a successful install, with the file sitting right there.
+#
+# It is also the one path here that $XDG_CONFIG_HOME can push outside $HOME -
+# which is somebody's own configuration saying where their config goes, not this
+# script choosing. The summary at the end prints the path it actually used, so
+# what was written is never a guess. (A GitHub runner sets this variable, which
+# is how it was noticed rather than shipped.)
 CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/bothy/config"
 
 DRY_RUN=0
@@ -110,8 +120,10 @@ bothy.sh - install the `bothy` CLI from a pinned release
   sh bothy.sh --dry-run    say exactly what that would do, and touch nothing
   sh bothy.sh --help       this
 
-It never uses sudo, never writes outside $HOME, and never starts anything -
-it prints the `bothy init` command instead of running it.
+It never uses sudo, never starts anything, and writes three paths only -
+~/.local/bin/bothy, ~/bothy, and the CLI's config file (under
+$XDG_CONFIG_HOME if you have set one, otherwise ~/.config). It prints the
+`bothy init` command rather than running it.
 
   BOTHY_VERSION   install another release tag (the commit is then unverified
                   unless BOTHY_SHA is given too)


### PR DESCRIPTION
Follow-up to #117, which auto-merged on the required checks one minute after it
opened — before its own new `installer` job had finished. That job is **red on
main right now**, for two reasons it found on its first run, which is exactly
what it was added to do.

**1. The refusal step could not pass.** GitHub runs every step as
`bash -e {0}`, and `set -uo pipefail` does not turn that off — so capturing the
output of an installer invocation that is *expected* to exit non-zero killed the
step before the line that reads `$?`. The step reported "exit code 1" with no
output at all, which reads as the installer crashing rather than as the test
being wrong. Captured with `… && rc=0 || rc=$?` instead.

**2. The runner image sets `$XDG_CONFIG_HOME`,** so the CLI's config file landed
in the runner's real home while `HOME` said otherwise. The installer honours
that variable deliberately — `scripts/bothy` *reads* the same expression, and a
writer and a reader that disagree produce "No Bothy checkout found" one second
after a successful install, with the file sitting right there. So the fix is not
to override it but to say so at the assignment, keep printing the path actually
used, pin the variable in the job so it tests one defined behaviour rather than
the image's environment, and stop claiming `$HOME` covers all three paths when
somebody's own XDG setting can move one of them.

Verified locally with the real daemon untouched (a stub `docker` first on
`PATH`, a fake `$HOME` whose path contains a space): the installer run with
`XDG_CONFIG_HOME` set and with it absent, and the refusal step re-run under
`bash -e` to prove the capture now survives. `bash -n`, `sh -n`, `bash32.sh`,
shellcheck `-x -S warning`, `installer-pin.sh`, `portability.sh` and YAML parsing
all green on this base.

As with #117: the end-to-end `bothy init` / `just up` path was **not** run
locally — this worktree sits on a live box whose real stack is running, and I am
forbidden from starting containers here. CI is the only place that path executes.

Refs #100.
