### PR TITLE
fix(checks): shellcheck and the bash 3.2 rule skipped the CLI entirely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,10 @@ jobs:
           # silent and every check below then runs against whatever directory the
           # caller was in. Three real fixes is a cheaper price than a gate that
           # starts lenient, since a threshold nobody ever raises is the threshold.
-          find scripts apps/*/checks -name '*.sh' -print0 \
+          # Selected by SHEBANG, not by suffix - see scripts/checks/bash32.sh,
+          # which had the same hole. `scripts/bothy` has no extension, so the
+          # CLI itself was never linted here.
+          find scripts apps/*/checks -type f \( -name '*.sh' -o -exec sh -c 'head -1 "$1" | grep -qE "^#!.*(ba)?sh"' _ {} \; \) -print0 \
             | xargs -0 shellcheck -x -S warning
 
       - name: No bash 4 syntax (macOS ships bash 3.2)

--- a/scripts/checks/bash32.sh
+++ b/scripts/checks/bash32.sh
@@ -28,8 +28,29 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1
 # The second grep drops COMMENT lines. In a comment `${var,,}` is documentation;
 # only in code is it a parse error. Without this, the note above explaining the
 # rule would break the rule.
-hits=$(find scripts apps/*/checks -name '*.sh' -print0 \
-  | xargs -0 grep -HnE '\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?,,\}|\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?\^\^\}|^[^#]*\bdeclare -A|^[^#]*\breadarray\b|^[^#]*\bmapfile\b' \
+# A parameter name as bash accepts it before `,,` or `^^`: an identifier, a
+# POSITIONAL parameter, or $@/$*. The first version accepted only identifiers, so
+# `${1,,}` was invisible to it - and lowercasing an argument is the most likely
+# place anyone reaches for this in a CLI. Found by planting `${1,,}` to test
+# something else and watching the check stay green.
+VAR='([A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*])'
+# Assembled with SINGLE quotes around every literal part. Spelling it as one
+# double-quoted string looks tidier and is wrong: in double quotes bash turns
+# `\$` into a bare `$`, which grep -E then reads as end-of-line, and the two
+# case-conversion patterns silently stop matching anything. The check kept
+# printing "ok" with `${name,,}` sitting in the file - a check that cannot fail,
+# which is the one failure this whole directory exists to prevent.
+RE='\$\{'"$VAR"'(\[[^]]*\])?,,\}|\$\{'"$VAR"'(\[[^]]*\])?\^\^\}|^[^#]*\bdeclare -A|^[^#]*\breadarray\b|^[^#]*\bmapfile\b'
+
+# EVERY SHELL SCRIPT, not every file named *.sh. `scripts/bothy` is the CLI, it
+# is bash, and it had no extension - so this check and CI's shellcheck step both
+# walked straight past the one file where a bash 4 construct is worst. macOS
+# ships bash 3.2 and `${x,,}` is a PARSE error there, so the script does not run
+# at all and the message names a line that looks fine. A glob that decides what
+# to check by filename is a glob that stops checking the moment somebody drops an
+# extension, which is exactly what happened. Shebang, not suffix.
+hits=$(find scripts apps/*/checks -type f \( -name '*.sh' -o -exec sh -c 'head -1 "$1" | grep -qE "^#!.*(ba)?sh"' _ {} \; \) -print0 \
+  | xargs -0 grep -HnE "$RE" \
   | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' || true)
 
 if [ -n "$hits" ]; then

--- a/scripts/checks/mutants.sh
+++ b/scripts/checks/mutants.sh
@@ -212,6 +212,23 @@ mutant "bash 4 syntax creeps back in" \
 mutant_lower="${PATH'"$BASH4_SUFFIX"'}"' \
   -- bash scripts/checks/bash32.sh
 
+# THE SAME RULE, IN THE FILE THAT HAD NO EXTENSION. The row above plants in
+# scripts/doctor.sh, which is a *.sh file and was therefore always scanned - so
+# it passes whether the finder selects by suffix or by shebang, and it could not
+# have caught what was actually wrong: `find ... -name '*.sh'` walked straight
+# past scripts/bothy, the CLI, which is bash and is the file where a bash 4
+# construct hurts most (macOS ships 3.2, and ${x,,} is a PARSE error there, so
+# the script does not run at all and the message names a line that looks fine).
+#
+# This row is what stops that hole reopening: revert the finder to a suffix glob
+# and this goes red while the row above stays green.
+mutant "bash 4 syntax creeps into the extensionless CLI" \
+  scripts/bothy \
+  'set -uo pipefail' \
+  'set -uo pipefail
+mutant_lower="${PATH'"$BASH4_SUFFIX"'}"' \
+  -- bash scripts/checks/bash32.sh
+
 echo
 echo "── what \`curl | sh\` would actually install ─────────────────────────"
 # scripts/bothy.sh clones a release and refuses to go on unless the tag resolves


### PR DESCRIPTION
Found while reviewing the installer work, which noted in passing that `scripts/bothy` has no `.sh` extension.

Both scanners select files by **filename**:

```
find scripts apps/*/checks -name '*.sh' -print0
```

`scripts/bothy` has no extension. So the CLI — bash, run on macOS where bash is **3.2** and `${x,,}` is a *parse* error, meaning the script doesn't run at all and the error names a line that looks fine — has **never** been linted by shellcheck and **never** read by `bash32.sh`. Since the day each was written.

Selection is now by **shebang**. A rule that decides by suffix stops applying the moment someone drops an extension, which is precisely what happened.

### Two things found while proving it

**The pattern only matched identifiers.** `${1,,}` was invisible — and lowercasing an argument is the most likely place anyone reaches for this in a CLI. I found it by planting `${1,,}` to test something else and watching the check stay green.

**My first attempt at the fix silently broke the check.** Spelling the pattern as one double-quoted string turns `\$` into a bare `$`, which `grep -E` then reads as end-of-line, so both case-conversion patterns match nothing. It printed `ok` with `${name,,}` sitting in the file — a check that cannot fail, which is the exact failure this directory exists to prevent. Every literal part is single-quoted now and the comment says why.

### Evidence

| planted in `scripts/bothy` | before | after |
|---|---|---|
| `${1,,}` | not caught | **caught** |
| `${n^^}` | not caught | **caught** |
| `declare -A` | not caught | **caught** |
| `mapfile` | not caught | **caught** |

### The mutation row

The existing row plants in `scripts/doctor.sh` — a `*.sh` file that was always scanned, so it passes under either finder and could not have caught this. The new row plants in `scripts/bothy`: revert the finder to a suffix glob and it goes red while the old row stays green.

`10 mutation(s) planted, every one caught.`