### PR TITLE
fix(overview): the disk panel said "no volumes" when it meant "I could not tell"

### DIFF
--- a/apps/portal-next/web/src/lib/api.ts
+++ b/apps/portal-next/web/src/lib/api.ts
@@ -42,6 +42,25 @@ export const POLL_OK = 10_000;
 export const POLL_FAIL = 60_000;
 export const MAX_BACKOFF = 3;
 const FETCH_TIMEOUT = 5000;
+// /system/df GETS ITS OWN, LONGER BUDGET, and it is the only call that needs
+// one. Measured on this box: containers/json answers in 85ms, /system/df in
+// 1.7s - twenty times slower, because it walks every image layer, container and
+// volume rather than reading a list. That cost grows with the box and spikes
+// while an image is building, and all five requests used to share one 5s
+// AbortController - so the most expensive call was policed by a budget sized
+// for the cheap ones, and lost the race first.
+//
+// Its failure is nearly silent by design (see loadAll), which is what let this
+// go unnoticed: the page kept working and the disk panel just stopped knowing
+// anything.
+//
+// 8s, NOT something generous. allSettled waits for all five, and `data` starts
+// empty, so this call gates FIRST PAINT - a long budget here would mean the
+// whole page waits on the one request the comment below calls least critical.
+// 8s is ~4.7x the measured cost and still under POLL_OK, so a slow df can never
+// become the thing you are waiting for. If it does time out the panel now says
+// so in words instead of claiming the box has no volumes.
+const DF_TIMEOUT = 8000;
 
 export interface LoadError {
   src: string;
@@ -112,6 +131,8 @@ export interface LoadResult {
 export async function loadAll(): Promise<LoadResult> {
   const ac = new AbortController();
   const t = setTimeout(() => ac.abort(), FETCH_TIMEOUT);
+  const dfAc = new AbortController();
+  const dfT = setTimeout(() => dfAc.abort(), DF_TIMEOUT);
   try {
     // allSettled, not all: partial results are first-class. Traefik is the
     // skeleton, docker is enrichment - either can die alone. df is the LEAST
@@ -133,7 +154,7 @@ export async function loadAll(): Promise<LoadResult> {
       // The socket proxy's CONTAINERS=1 already covers this endpoint, and POST=0
       // still blocks every mutating call.
       getJSON<Container[]>('/-/api/docker/containers/json?all=1', ac.signal),
-      getJSON<SystemDf>('/-/api/docker/system/df', ac.signal),
+      getJSON<SystemDf>('/-/api/docker/system/df', dfAc.signal),
       // Static file written by the host-side collector and bind-mounted into
       // this container - NOT an /-/api/* route, so it needs no edge config and
       // its absence (collector not installed yet) is a normal, silent no-op.
@@ -167,6 +188,7 @@ export async function loadAll(): Promise<LoadResult> {
     };
   } finally {
     clearTimeout(t);
+    clearTimeout(dfT);
   }
 }
 

--- a/apps/portal-next/web/src/pages/Overview.tsx
+++ b/apps/portal-next/web/src/pages/Overview.tsx
@@ -388,6 +388,13 @@ function DiskBody({ systems, df }: { systems: System[]; df: ReturnType<typeof us
     return { rows, orphanRows: orphans };
   }, [systems, df]);
 
+  // "None" and "could not read" are DIFFERENT ANSWERS and this said the first
+  // when it meant the second. diskVolumes() returns [] for a null df, so a
+  // timed-out /system/df rendered "No persistent volumes." on a box with
+  // fourteen of them holding 2.1 GB - a confident statement of something the
+  // page did not know. Observed: it happened while an image was building, which
+  // is exactly when df is slowest.
+  if (!df) return <p className="ov-uicol-empty">Volume sizes could not be read - the daemon did not answer in time.</p>;
   if (!rows.length && !orphanRows.length) return <p className="ov-uicol-empty">No persistent volumes.</p>;
   // one scale across BOTH sections, so an orphan bar is comparable to a system's
   const max = Math.max(1, ...rows.map((r) => r.value), ...orphanRows.map((r) => r.value));


### PR DESCRIPTION
Reported from the UI: **Data & disk** showed `no sizes` and `No persistent volumes.` on a box with **fourteen** of them holding **2.1 GB**.

Two separate bugs.

### The lie

`diskVolumes()` returns `[]` for a null `df`, and `DiskBody` could not tell that apart from a box that genuinely has no volumes — so it rendered **"No persistent volumes."**, a confident statement of something the page did not know. *None* and *could not read* are different answers, and only one of them was available.

### Why `df` was null

Measured on this box:

| call | time |
|---|---|
| `/-/api/docker/containers/json?all=1` | 0.085s |
| `/-/api/docker/system/df` | **1.7s** |

Twenty times slower, because it walks every image layer, container and volume rather than reading a list. All five requests in `loadAll` shared **one 5s `AbortController`** — so the most expensive call was policed by a budget sized for the cheap ones and lost the race first. Its cost grows with the box and spikes while an image is building, which is exactly when this was observed.

`df` now has its own budget. **8s, not something generous:** `allSettled` waits for all five and `data` starts empty, so this call gates **first paint** — a long budget would make the whole page wait on the one request `loadAll`'s own comment calls least critical. 8s is ~4.7× the measured cost and still under `POLL_OK`.

### Verified in a real browser, against the live box

With `/system/df` forced to reject on the next poll:

```
before:  Data & disk | 2.1 GB | Monitoring · Grafana | 4 vols | 1.9 GB | ...
after:   Data & disk | no sizes | Volume sizes could not be read - the daemon
         did not answer in time. | 0 volumes | sizes unavailable
```

and it recovers to `2.1 GB · 14 volumes` on the following poll.