### PR TITLE
docs(security): what a browser shell would cost, before one exists

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,8 @@ like style and are actually the security boundary - a well-meaning
 leak or a remote root shell. Those are listed under
 [Load-bearing design rules](#load-bearing-design-rules). Read that section before
 touching `edge/dynamic/portal-api.yml`, `edge/dynamic/portal-prom.yml`,
-`apps/bothy/socket-proxy.yml`, `edge/dynamic/auth.yml` or `auth/`.
+`apps/bothy/socket-proxy.yml`, `apps/bothy-control/compose.yml`,
+`edge/dynamic/auth.yml` or `auth/`.
 
 ---
 
@@ -25,11 +26,12 @@ Traefik on `:80` serves the portal and its read-only data plane.
 2026-08-12). the name layer went dormant on 2026-08-08 when the split-DNS route
 was removed, and its configuration was **deleted on 2026-08-12**: Traefik holds
 zero `Host()` rules, and the Traefik dashboard router was deleted with them.
-Identity was rebuilt on Keycloak + oauth2-proxy and **now enforces on the tier
-that can change things**: three routers carry a role requirement (`viewer` to read
-a file, `editor` to write one). Everything else is still reached without passing
-an edge auth boundary, so "SSO is running" must not be read as "everything is
-behind SSO".
+Identity was rebuilt on Keycloak + oauth2-proxy and **now enforces on the tiers
+that can change things**: nine routers across three files carry a role
+requirement - `viewer` to read a file or a config field, `editor` to write one,
+`operator` to restart, stop or start a service. Everything else is still reached
+without passing an edge auth boundary, so "SSO is running" must not be read as
+"everything is behind SSO".
 
 **Who can reach it.** Only devices on that tailnet. The tailnet is WireGuard, so
 the transport is encrypted even though every URL is plain `http://`. A device not
@@ -44,7 +46,7 @@ device and the box, and edge auth covers only the last of them:
 |---|---|
 | The tailnet itself | Everything. It is the outer perimeter and, today, very nearly the only one |
 | Each service's own login, using the shared `DEV_LOGIN_*` credential | Grafana, Prometheus |
-| Keycloak roles at the edge (`forwardAuth`) | The editor tier: `viewer` to read a file, `editor` to write one. The only place a role is enforced today |
+| Keycloak roles at the edge (`forwardAuth`) | The tiers that change things: `viewer`/`editor` on the file and config tiers (`edge/dynamic/portal-files.yml`, `bothy-config.yml`), `operator` on the control tier (`bothy-control.yml`). The only places a role is enforced today. `shell` is defined and gated on nothing |
 | The exact `Path()` rules in `edge/dynamic/portal-api.yml` and `portal-prom.yml` | The portal's data plane - the only reachable slice of the Docker socket, Loki, Prometheus and the Traefik API |
 
 The portal itself has **no** login for browsing its own pages. That is accepted,
@@ -119,10 +121,14 @@ very much wanted.
 Every rule here has a reason written next to it in the source. Changing one is a
 security change, and should be reviewed as one.
 
-### 1. SSO enforces on the editor tier, and nowhere else yet
+### 1. SSO enforces on the tiers that change things, and nowhere else yet
 
-> **Status: ENFORCED, narrowly.** `edge/dynamic/portal-files.yml` carries three
-> role-gated routers - `viewer` for reads and downloads, `editor` for writes.
+> **Status: ENFORCED, narrowly.** Nine role-gated routers, in three files:
+> `edge/dynamic/portal-files.yml` (`viewer` for reads and downloads, `editor`
+> for writes and deletes), `bothy-config.yml` (the same pair over config fields)
+> and `bothy-control.yml` (`operator`, one router per verb). The fourth role,
+> `shell`, is defined in the realm and referenced by no router at all - see
+> [A shell in the browser](#a-shell-in-the-browser-90-before-it-exists).
 > Every *other* service is still reachable from the tailnet without passing an
 > auth boundary; their control is each dashboard's native login with the shared
 > `DEV_LOGIN_*` credential, plus the tailnet itself. Do not widen that gap without
@@ -361,12 +367,13 @@ then rewrite history. Removing it in a follow-up commit is not a fix.
 These are decisions, not oversights. They are listed here so that a reader can
 judge them, and so nobody "fixes" one without understanding what it buys.
 
-- **No authentication at the edge, as of 2026-08-12.** SSO is defined and
-  attached to nothing while identity is rebuilt on Keycloak. The tailnet plus
-  each service's own `DEV_LOGIN_*` login are the controls; the portal, the docs
-  site and the `/-/api/*` data plane have neither. This is a *time-boxed* state,
-  not a permanent design - it is listed here so it is judged rather than
-  discovered, and the plan is in [rule 1](#1-sso-is-being-rebuilt-and-is-attached-to-nothing).
+- **No authentication at the edge for anything that only reads.** SSO is
+  attached to the file, config and control tiers and to nothing else. The
+  tailnet plus each service's own `DEV_LOGIN_*` login are the remaining
+  controls; the portal's own pages, the docs site and the read-only `/-/api/*`
+  data plane have neither. This is a *time-boxed* state, not a permanent design
+  - it is listed here so it is judged rather than discovered, and the rollout
+  order is in [rule 1](#1-sso-enforces-on-the-tiers-that-change-things-and-nowhere-else-yet).
 - **Plain HTTP everywhere.** TLS would mean a private CA installed on every
   device. The tailnet is already WireGuard, so the wire is encrypted regardless.
   Safe *only* because the tailnet is the transport - revisit the moment anything
@@ -398,6 +405,281 @@ Recorded 2026-08-12 so nobody re-files it and nobody reintroduces it.
 
 ---
 
+## A shell in the browser (#90), before it exists
+
+Issue #90 asks for a terminal in the portal. **None of it is built.** This
+section is written first, on its own, so that a change to the boundary can be
+read and argued with before any capability exists to point at as already done -
+the ordering `docs/plans/all-open-issues.md` §C3 asks for.
+
+### What the boundary is today
+
+Three socket proxies run here, not two, and none of them can exec:
+
+| Proxy | Grants | Refuses |
+|---|---|---|
+| `bothy-socket-proxy` (`apps/bothy/socket-proxy.yml:78`) | `CONTAINERS: 1` (`:82`), `SYSTEM: 1` (`:83`) | `POST: 0` (`:86`), `EXEC: 0` (`:87`), and every other family written out as `0` |
+| `bothy-control-socket-read` (`apps/bothy-control/compose.yml:196`) | `CONTAINERS: 1` (`:199`) | `POST: 0` (`:205`), `EXEC: 0` (`:206`) |
+| `bothy-control-socket-write` (`apps/bothy-control/compose.yml:266`) | `POST: 1` (`:269`), `ALLOW_RESTARTS`/`ALLOW_START`/`ALLOW_STOP` `1` (`:270-272`) | `CONTAINERS: 0` (`:276`), `EXEC: 0` (`:277`) |
+
+`EXEC: 0` appears on all three, stated rather than left to a default, and each
+line carries the same comment: *"container exec == root on this box"*.
+`apps/bothy-control/checks/grants.py:98-99` asserts both halves of that - that
+the variable is written down at all, and that its value is `0`.
+`apps/bothy-control/compose.yml:65-76` lists exec first under *"explicitly out
+of scope, and it stays out"*, and names the replacement: *"`docker exec` over
+Tailscale SSH"*. `just urls` prints the same sentence to whoever runs it
+(`justfile:405-407`).
+
+Above the proxies, the verb set is a three-element tuple:
+`apps/bothy-control/guard.py:39` - `VERBS = ("restart", "stop", "start")`.
+`kill` is absent, and `checks/grants.py:177-180` asserts it stays absent,
+because the write proxy's `ALLOW_RESTARTS` regex grants `kill` alongside `stop`
+and `restart` and no configuration can separate them. `guard.SEVERING`
+(`guard.py:133`) refuses those verbs by container *name* for the four containers
+on the request path - Traefik, `bothy-control`, and its two proxies - and
+`checks/grants.py:166-167` asserts `len(guard.SEVERING) == 4`, so that list
+cannot quietly grow or shrink.
+
+And the `shell` role, which is the thing #90 would spend:
+
+- it exists in the realm, non-composite, described as *"HIGH PRIVILEGE:
+  arbitrary terminal. Keep composite=false and never nest it in another role"* -
+  `auth/realm-devbox.json:37-39`;
+- the interface says the same: *"An arbitrary terminal. Granted to nobody, on
+  purpose."* (`apps/portal-next/web/src/lib/me.ts:29`), rendered as **Granted to
+  nobody** rather than as an ordinary "Not held"
+  (`apps/portal-next/web/src/pages/Settings.tsx:260`);
+- it is granted to nobody. The seeding step grants `viewer editor operator` and
+  says why it stops there - *"`shell` is DELIBERATELY NOT GRANTED"*,
+  `auth/compose.yml:428-434`;
+- **no router references it.** There are three `allowed_groups=` values in
+  `edge/dynamic/` and none is `shell`: `viewer` and `editor`
+  (`portal-files.yml:188,197`, referenced again by the config tier at
+  `bothy-config.yml:61,69`) and `operator` (`bothy-control.yml:169`). The only
+  occurrences of the word in that directory are two comments using it as the
+  negative control of an authorisation probe - `allowed_groups=shell -> 403
+  (nobody has it)` (`portal-files.yml:40`, `bothy-control.yml:49`) - which
+  `apps/portal-files/checks/authz_probe.py:84` re-runs against the live edge.
+
+So the role is a **name with no route and no holder**, and that is exactly what
+makes it a safe thing to gate a new route on: oauth2-proxy fails closed on a
+group nobody holds, so a route carrying `allowed_groups=shell` refuses everybody
+until somebody grants it on purpose. It fails in the safe direction while the
+feature is half-built.
+
+One consequence to know before the code PR: **the realm import is first-boot
+only** (`auth/compose.yml:213-215` - *"If the realm already exists the import is
+silently skipped, so editing that file and restarting does nothing"*). Anything
+the shell needs from Keycloak - a role grant, an authentication flow, a client
+attribute - must land in the `keycloak-init` one-shot, which re-runs on every
+`just up-auth` (`auth/compose.yml:386-392`), or it will be correct on new
+installs and silently absent on every existing one.
+
+### What a browser shell would actually require
+
+As a concrete diff, not as a capability in the abstract. Which rows apply
+depends on which of #90's three shapes lands:
+
+| Shape (#90's own ordering) | Proxy change | Route | Role | What it widens |
+|---|---|---|---|---|
+| 1 · allowlisted command generator | none | one new exact `` Path() `` under `/-/api/` | `operator` would do | the verb set, and whatever composes the commands. No socket grant moves |
+| 2 · PTY as an unprivileged user in a throwaway container | `EXEC: 1`, **or** `POST: 1` together with `CONTAINERS: 1` | new exact `` Path() ``, plus a websocket upgrade | `shell` | everything - see below |
+| 3 · PTY on the host as the operator's own account | none. It does not go through Docker at all | new exact `` Path() ``, plus a websocket, into a host-side process | `shell` | the edge becomes a way to run host commands. The socket boundary is untouched; the boundary that moves is "the portal cannot run code" |
+
+The row that must not be misread is **shape 2**, which sounds like the contained
+option and costs the most:
+
+- **`EXEC: 1` on any proxy is root.** The proxy gates by endpoint family; an
+  exec into a container that already holds a host mount - and all three proxies
+  hold `/var/run/docker.sock` - is a host root shell. Two compose files say so
+  on three lines, in the same six words.
+- **Creating the throwaway container instead is worse, not better.**
+  `apps/bothy-control/compose.yml:20-26` reads the haproxy rule text out of
+  `tecnativa/docker-socket-proxy:0.3.0`: the granular `ALLOW_*` lines are
+  `allow` rules, the broad `^/containers` line sits below them, and there is
+  **no deny in between** - so `POST=1` with `CONTAINERS=1` permits every POST
+  under `/containers`, `/containers/create` included, and *"`/containers/create`
+  with a bind mount of `/` is root on this box"*. `CONTAINERS: 0` on the write
+  proxy (`:276`) is the only thing refusing that today, and its own comment says
+  setting it to `1` *"would silently grant `/containers/create` … and nothing
+  would look different"*.
+
+Shape 2 therefore does not need one new grant; it needs precisely the pair that
+`apps/bothy-control/compose.yml` was split into two containers to avoid. Putting
+it on a **fourth, dedicated proxy** does not fix that, it relocates it: the
+dedicated proxy would itself be a create-a-privileged-container endpoint
+defended only by the Python in front of it, which is the design the split
+rejected - *"a total compromise of bothy-control still cannot create a
+privileged container"* (`:52-56`).
+
+Shape 3 is the honest one about what it gives away: everything the operator's
+own account can already do on the host, and no socket grant at all. Shape 1
+gives away the least and is the only one needing no new role.
+
+### The blast radius
+
+Docker socket access is root-equivalent on this box, and the path from a route
+to root is four steps. Take shape 2 with the grants it needs:
+
+1. A request reaches the shell route. Three things could produce one: a
+   signed-in holder of the role; **a mistake in the route rule** - a
+   `PathPrefix` where a `` Path() `` was meant, the failure
+   [rule 3](#3-the--api-routers-use-exact-path-never-pathprefix-this-is-the-control)
+   exists for and which has to be re-argued for every new route; or anything
+   that can reach the service directly, since these services have no auth of
+   their own and the network is the authorisation (`README.md:115-121`).
+2. The service asks its proxy to create a container.
+3. The create body carries `Binds: ["/:/host"]` and `Privileged: true`. **The
+   proxy gates by path, never by body.**
+4. The result is a root shell over the host filesystem: every `.env` on the box,
+   the Postgres and Grafana credentials, the Keycloak database that decides who
+   holds which role, the operator's SSH directory, and the tailnet key that
+   makes this node a member of the tailnet at all.
+
+Step 3 is the one to keep in view, because it generalises. Every control in this
+repository is a control over **which path** is reachable - exact `` Path() ``
+rules, endpoint families, container names. Not one of them reads a request body.
+A proxy that permits `/containers/create` permits the whole of it.
+
+The two-member networks are what keep that unreachable today, and a shell adds
+members. `socketnet` holds exactly Traefik and the socket proxy because *"the
+proxy has no authentication, so keeping the blast radius at two members is the
+control"* (`README.md:272-274`, `justfile:41-45`,
+`apps/bothy/socket-proxy.yml:47-48`). `controlsocknet` holds `bothy-control` and
+its two proxies, and Traefik is deliberately **not** on it: *"it never routes to
+one - but 'it is not configured to' is a weaker statement than 'it cannot', and
+the second one costs one `docker network create`"*
+(`apps/bothy-control/compose.yml:86-92`). A shell service needs its own pair on
+that precedent, never a seat on an existing one, and never `devnet`.
+
+One more thing the evidence forces, and #90 should hear it plainly.
+`guard.SEVERING` guarantees that the control tier cannot stop the container
+serving the page you are typing into. **A real PTY cannot inherit that
+guarantee.** A shell can `docker stop` from inside itself, or `kill -9` its own
+parent, and no name-keyed refusal list can see it - `SEVERING` is a property of
+*buttons*, not of a terminal. #90's requirement that "you must not be able to
+stop the container serving the page you are typing into" is therefore
+satisfiable by shape 1 and by nothing else. That is not an argument against the
+feature; it is a statement that the requirement has to be rewritten honestly as
+*"the shell can break its own session, and the recovery is Tailscale SSH"*.
+
+### The conditions under which it is acceptable
+
+The maintainer's position is explicit and it is right about the box it
+describes: this is real developer tooling for one person's workstation, it ships
+instructions and warnings, and somebody who edits a compose file and runs it
+owns the result.
+
+The stronger form of that argument, and the one this section is prepared to
+make, is narrower and better evidenced: **on this box the shell grants no new
+capability to the person it is for.** The operator already reaches the box over
+Tailscale SSH, and `docker exec -it <name> sh` is what the box itself tells them
+to use (`justfile:405-407`). Every credential in the blast radius above is
+already readable from that session. A browser shell is therefore not a new
+privilege; it is **a second front door onto a privilege that already exists**.
+The security question is not "should this power exist here" - it already does -
+but "is the new door as strong as the old one".
+
+It is not, and that is the whole of the risk. The old door is Tailscale SSH: one
+account, key material held by the tailnet rather than by anything a person types
+or a browser stores. The new door is a session cookie in a browser, on a
+plain-HTTP origin whose pages need no login to browse. Same capability, weaker
+credential.
+
+The argument holds exactly while all of the following are true, and each is a
+line at which it stops holding:
+
+| Condition | What breaks when it stops being true |
+|---|---|
+| **One operator** | A second person with a portal login has host root without ever having been handed SSH. The role gate becomes the only thing between them and it, and a role grant is one `kcadm add-roles` away, with no review and no record in this repository |
+| **A tailnet ACL admitting only that operator's devices** | Widening it for a colleague, a CI runner, or a device somebody else also uses silently widens the shell. Nothing in this repository can see that change |
+| **No published host port; reachable only through Traefik** | The moment a shell service publishes a port, the network stops being the authorisation and there is no second control behind it. That is the failure `socketnet` exists to prevent, at a higher stake |
+| **Nothing reachable off the tailnet** | Plain HTTP is accepted here *only* because the tailnet is WireGuard. A shell session cookie in cleartext off the tailnet is a root credential on the wire |
+| **The operator's browser is not shared, and not carrying hostile extensions** | An XSS or a malicious extension on the portal origin inherits the session |
+
+The last row is genuinely new and deserves its own sentence. The portal has no
+login for browsing its own pages - accepted, above - so anything executing on
+that origin is already inside the portal. Today the most it can reach is a
+role-gated API, where it gets a file write that leaves a diff or a restart that
+leaves an audit line. A shell route changes what an ambient session is worth
+from "an inconvenience with a paper trail" to "the box", and it does so at
+precisely the point where this repository has knowingly accepted its weakest
+control.
+
+### The mitigations that must ship with it
+
+A checklist a future PR can be held to. The ones marked **non-negotiable** are
+those without which the argument in the previous section does not hold.
+
+1. **Non-negotiable - no new socket grant.** `EXEC` stays `0` on every proxy,
+   and no proxy holds `POST: 1` and `CONTAINERS: 1` at once.
+   `apps/bothy-control/checks/grants.py` already asserts the first for two
+   proxies; extend it to assert both, for every proxy declared anywhere in the
+   repository, so a fourth one cannot be added without meeting the rule.
+2. **Non-negotiable - the route is an exact `` Path() ``, never `PathPrefix`,**
+   under [rule 3](#3-the--api-routers-use-exact-path-never-pathprefix-this-is-the-control).
+   A websocket upgrade is still a path.
+3. **Non-negotiable - gate it on `allowed_groups=shell`, and leave the role
+   ungranted.** `keycloak-init` keeps granting `viewer editor operator` and not
+   `shell` (`auth/compose.yml:432-434`), so installing Bothy never installs a
+   working terminal. Granting it stays a deliberate act by the box's owner, and
+   the fork checklist below says so.
+4. **Non-negotiable - its own network, holding exactly two.** Traefik and the
+   shell service; a second network for any privileged leg. Never `devnet`, where
+   about twenty containers including third-party images would inherit the reach.
+5. **Non-negotiable - an audit line per session, and per command where the shape
+   permits one.** `apps/bothy-control/app.py:145-161` is the model, and its
+   properties are the requirement: append-only, one tab-separated line, recording
+   what was *asked* rather than only what succeeded so refusals are logged too,
+   bind-mounted so it survives `up --build`, and swallowing its own errors so a
+   full disk cannot block a legitimate action. A log recording only that a
+   session opened is not an audit trail.
+6. **Non-negotiable - strip client-supplied `X-Auth-Request-*`.** Copy
+   `control-deidentify` (`edge/dynamic/bothy-control.yml:127-157`). Its own
+   reasoning applies with more force here: a forged name on a file write leaves a
+   diff somebody can read; a forged name on a shell session leaves a log that is
+   worse than none.
+7. **Step-up re-authentication - and this is the recommendation the issue does
+   not make.** It is already half-written. The realm carries
+   `acr.loa.map = {"standard":1,"stepup":2}` (`auth/realm-devbox.json:16`),
+   `realm-devbox.json:38` tells the reader to expect it, and
+   `auth/compose.yml:257-274` writes out the five remaining steps: copy the
+   built-in `browser` flow to `browser-stepup`; add a subflow conditioned on
+   `loa-condition-level=2` containing an OTP form; bind it as the realm's browser
+   flow; set the same map as a client attribute; and send `acr_values=stepup` on
+   the authorize request - *"which in practice means a SECOND oauth2-proxy
+   instance dedicated to that route, since `--acr-values` is per instance and
+   this one is shared by everything"*. Keycloak then stamps `acr=stepup` into the
+   id_token, so the guard verifies that a step-up happened instead of trusting
+   the role claim alone. **This is the mitigation that answers the actual risk**
+   named above - that the new door is a browser cookie while the old one is a
+   tailnet key. Without it, an ambient session is a root shell. It is real work
+   because of that second oauth2-proxy instance, and it belongs in the shell PR
+   rather than behind it.
+8. **A statement in the UI of what the session can do,** naming Tailscale SSH as
+   the equal-privilege alternative. The box already tells the truth about this in
+   `just urls` (`justfile:405-407`); if a shell ships, that text changes, and so
+   does this section.
+9. **An idle timeout and an explicit end-session.** A PTY held open under a
+   closed laptop lid is a credential with no expiry.
+10. **Recommended - build shape 1 first, and if that is not enough, jump to
+    shape 3.** #90's own ordering already puts the allowlisted generator first;
+    it is the only shape that keeps `guard.SEVERING`'s guarantee intact, needs no
+    new role, and moves no grant. If what is really wanted is a real terminal,
+    ship **shape 3** - a host PTY as the operator's own unprivileged account -
+    and not shape 2, because a container-creating proxy is the one thing on this
+    box that nothing is allowed to have.
+
+**What this section does not license.** It is an argument for a shell on a
+single-operator tailnet box, with the mitigations above. It is not an argument
+that `EXEC: 1` is ever acceptable here, that any proxy may hold `POST: 1` and
+`CONTAINERS: 1` together, or that rules 2, 3 or 4 may be relaxed to make a shell
+easier to build. If the shell needs one of those, it is the shell that is the
+wrong shape.
+
+---
+
 ## If you fork this
 
 Nothing in this repo is safe to run with the values it ships with. Before your
@@ -411,12 +693,14 @@ first `just up`:
 3. **Change the Grafana admin password** from the `admin`/`admin` sample, set
    your own `DEV_LOGIN_*` values, and set a real `WIKI_DB_PASSWORD` in place of
    `changeme`.
-4. **Assume nothing is authenticated until you attach it yourself.** As shipped
-   (2026-08-12) `sso@file` and `sso-errors@file` are defined and attached to no
-   router. Read
-   [rule 1](#1-sso-is-being-rebuilt-and-is-attached-to-nothing) before you
-   assume any dashboard here is behind a login, and attach the pair one router
-   at a time - starting with a router you do not need in order to fix a mistake.
+4. **Assume nothing is authenticated until you attach it yourself.** As shipped,
+   the role gates cover the file, config and control tiers and nothing else -
+   every dashboard and the read-only data plane are reached without passing an
+   auth boundary. Read
+   [rule 1](#1-sso-enforces-on-the-tiers-that-change-things-and-nowhere-else-yet)
+   before you assume any dashboard here is behind a login, and attach
+   `sso-errors@file,sso@file` one router at a time - starting with a router you
+   do not need in order to fix a mistake.
 5. **Generate `edge/dynamic/portal-prom.yml`, never commit it.** Run
    `just portal-prom-route`. It carries a credential; `git check-ignore -v
    edge/dynamic/portal-prom.yml` must print the rule.
@@ -433,3 +717,13 @@ first `just up`:
 8. **Do not commit real hostnames, tailnet IPs or account identifiers.** The
    `just urls` recipe reads them from `tailscale` at run time precisely so they
    never land in the repo. Keep it that way.
+9. **Leave the `shell` role ungranted, and do not grant it to a box that more
+   than one person reaches.** As shipped there is no terminal: `shell` is gated
+   on zero routes and `keycloak-init` grants `viewer editor operator` and stops.
+   If a browser shell ever exists here, granting that role hands its holder
+   everything an SSH session on the box would give them - which is the argument
+   *for* the feature on a one-operator box and the argument against it on any
+   other. Read
+   [A shell in the browser](#a-shell-in-the-browser-90-before-it-exists)
+   before granting it, and in particular the table of conditions under which the
+   argument stops holding.

--- a/docs/plans/all-open-issues.md
+++ b/docs/plans/all-open-issues.md
@@ -265,16 +265,39 @@ executor #90 needs.
 
 Last, and treated as a design decision rather than a feature. The pieces are
 already in place *and deliberately disconnected*: the `shell` role is defined,
-described in `ROLE_MEANING`, and gated on **zero routes**; `EXEC=0` on both
-socket proxies; `CONTAINERS=0` on the write proxy. Step-up auth is written but
-unbuilt.
+described in `ROLE_MEANING`, granted to nobody by `keycloak-init`, and gated on
+**zero routes**; `EXEC=0` on **all three** socket proxies, not two — the
+portal's read-only one plus `bothy-control`'s read/write pair; `CONTAINERS=0` on
+the write proxy. Step-up auth is written but unbuilt: the realm carries
+`acr.loa.map` and `auth/compose.yml:257-274` writes out the five steps that
+would enforce it, including the second oauth2-proxy instance it needs.
 
 A shell needs exactly the combination this architecture exists to prevent. That
 is not an argument against it — the user's position is explicit and stands: *"its
 a real devbox tooling, like arch linux — we give instructions and warnings."*
 It is an argument that the change is to the **threat model document first**, and
-the code second. `SECURITY.md` should gain the paragraph before anything gains
-the capability.
+the code second.
+
+**The document half has landed.** `SECURITY.md` now carries *A shell in the
+browser (#90), before it exists* — the current boundary with file:line, what
+each of #90's three shapes would cost, the four-step path from a widened proxy
+to host root, the conditions under which "it grants no new capability to the
+person it is for" is true, and a ten-item mitigation checklist the code PR is
+held to. Three findings from writing it that change the shape of the code work:
+
+- **`guard.SEVERING` cannot survive a real PTY.** #90's requirement that you
+  must not be able to stop the container serving the page you are typing into is
+  met by shape 1 (allowlisted commands) and by no other shape. State that in the
+  issue rather than discovering it in review.
+- **Shape 2 — "a PTY in a throwaway container" — is the most expensive, not the
+  safest.** Creating that container needs `POST=1` *with* `CONTAINERS=1`, which
+  is `/containers/create` with a bind mount of `/`. Prefer shape 1, and if a real
+  terminal is wanted, go straight to shape 3 (host PTY as the operator's own
+  account), which needs no socket grant at all.
+- **Step-up auth is the non-negotiable that the issue does not ask for.** The
+  honest argument for the feature is that the operator already has SSH; the gap
+  is that SSH is a tailnet key and the shell is a browser cookie. Step-up is what
+  closes that gap, and it is the only mitigation here that is real work.
 
 ---
 


### PR DESCRIPTION
The document-first half of #90. **No shell code, no route, no permission
change** — this PR touches two markdown files and nothing else.

#90 wants a terminal in the portal, and a browser shell needs exactly the
combination this architecture was built to prevent. The maintainer's position on
that is explicit and stands. What follows from it is an ordering, not a refusal:
the threat model changes **first**, on its own, so it can be read and argued
with while there is still nothing built to point at as already done. That is the
ordering `docs/plans/all-open-issues.md` §C3 already asks for.

## What is here

A new `SECURITY.md` section, *A shell in the browser (#90), before it exists*,
in five parts:

1. **The boundary as it is today**, with a `file:line` for every claim — three
   socket proxies (not two), `EXEC: 0` on all of them, `CONTAINERS: 0` on the
   write half, `VERBS` and `SEVERING` and the checks that assert them, and the
   `shell` role: defined in the realm, described in the UI, granted to nobody,
   referenced by zero routers.
2. **What each of #90's three shapes would actually require** — which permission
   on which proxy, which route, which role grant, and what each one widens. As a
   table, unsoftened.
3. **The blast radius**, as four steps from a widened proxy to a root shell over
   the host filesystem, and the observation that generalises it: every control in
   this repo gates a *path*, and not one of them reads a request body.
4. **The conditions under which it is acceptable.** The honest argument for the
   feature is that on a single-operator box it grants no new capability to the
   person it is for — that person already has Tailscale SSH, and everything in
   the blast radius is already readable from it. The section makes that argument
   properly, then says where it stops: a second person, a wider tailnet ACL, a
   published port, anything off the tailnet, a compromised browser origin.
5. **Ten mitigations as a checklist** the code PR can be held to, six marked
   non-negotiable.

Plus a ninth item in the fork checklist, and a §C3 update in
`docs/plans/all-open-issues.md`.

## What the research changed

Three things contradicted the framing this started with:

- **`guard.SEVERING` cannot survive a real PTY.** #90 requires that you must not
  be able to stop the container serving the page you are typing into. A shell can
  `docker stop` from inside itself or `kill -9` its parent, and a name-keyed
  refusal list cannot see it. That requirement is met by the allowlisted-command
  shape and by no other; it needs rewriting in the issue rather than discovering
  in review.
- **Shape 2 — "a PTY in a throwaway container" — is the most expensive option,
  not the safest.** Creating that container needs `POST=1` *with* `CONTAINERS=1`,
  which by the haproxy rule text quoted in `apps/bothy-control/compose.yml:20-26`
  is `/containers/create` with a bind mount of `/`. A dedicated fourth proxy does
  not fix that, it relocates it.
- **§C3 said "`EXEC=0` on both socket proxies". There are three.** Corrected.

**One mitigation I would call non-negotiable that #90 does not mention:
step-up re-auth.** It is the only one that answers the risk the argument for the
feature actually creates — the old door is a tailnet key, the new one is a
browser cookie on an origin whose pages need no login to browse. It is
half-written already (`acr.loa.map` in the realm, five remaining steps spelled
out in `auth/compose.yml:257-274`), and because it needs a second oauth2-proxy
instance it is real work that belongs *in* the shell PR rather than behind it.

## Also corrected

The new section would otherwise have contradicted the document around it:

- the threat model and rule 1 both still said the editor tier was the only place
  a role is enforced — untrue since the config and control tiers landed (nine
  role-gated routers across three files now);
- the first accepted-risk bullet still said SSO was "defined and attached to
  nothing";
- three links pointed at a rule-1 anchor that no longer exists.

## Deliberately not closing #90

The feature is not built. This PR owes nothing to the shell; the shell PR owes
this document its ten-item checklist, and owes the issue a rewritten
"cannot stop its own container" requirement.

## Verification

- `bash scripts/checks/portability.sh` — PASS, nothing newly tied to this
  machine (no home path, no tailnet IP, no person-email introduced).
- Every `file:line` in the new section was opened and read; the ones that were
  wrong on the first pass (`bothy-control.yml:127-160` → `:127-157`, "three
  compose files" → two files on three lines) are fixed.
- No `docker`, no `just`, no mutants run.

Refs #90.
