### PR TITLE
feat(discover): a system's identity, separated from where it is shown

### DIFF
--- a/apps/portal-next/checks/grouping.mjs
+++ b/apps/portal-next/checks/grouping.mjs
@@ -1,0 +1,225 @@
+// Identity vs display grouping.
+//
+// `group` used to be one field doing three jobs: the URL a person bookmarks
+// (`/control/systems/:name`), the seed the accent colour is hashed from, and the
+// panel a service is shown in. So the first user-facing regroup would have
+// 404'd every bookmark into the systems it touched and reshuffled the colours of
+// the ones it did not. This file is the guard on the split that fixes it:
+//
+//   * `system` is derived and no label can move it;
+//   * `group` is `system` unless `dev.portal.group` says otherwise;
+//   * with no label set, the two are equal - which is what makes this whole
+//     change invisible on a box nobody has configured, and is asserted here
+//     rather than asserted in a comment.
+//
+// It also pins the two rules whose failure is SILENT. A wrong accent seed is
+// only noticed when somebody cannot find a card by its colour any more, and a
+// wrong bookmark lookup is only noticed by whoever opens the bookmark.
+//
+// And it covers the disagreement this work was found through: makeNode() honoured
+// `dev.portal.group` and allPorts() did not, so the Ports section of a system
+// assembled with that label came back empty.
+//
+// Run from checks/run.sh, which compiles discover.ts next door.
+import { classify, merge, allPorts, primaryIdentity, findSystem } from './discover.mjs';
+
+// merge() builds a browsable node's URL from `location.hostname` - deliberately,
+// so a link works from whichever address the reader typed. Node has no
+// `location`, and this is the first check to call merge() rather than a leaf
+// function, so it supplies one. Grouping does not read it; without it the whole
+// section below dies on a ReferenceError before the first assertion.
+globalThis.location ??= { hostname: 'checks.invalid' };
+
+let fails = 0;
+const eq = (label, got, want) => {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  if (!ok) fails++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label.padEnd(58)} ${ok ? '' : `got ${JSON.stringify(got)} want ${JSON.stringify(want)}`}`);
+};
+
+// Not under /home. These are fixtures, not facts about anybody's machine, and
+// portability.sh flags a `/home/<name>/` path in a tracked file - correctly:
+// the one place this repo is allowed to spell one out is repo-roots.mjs, whose
+// subject IS the home directory that used to be hardcoded in discover.ts.
+const ROOT = '/srv/box/stacks/';
+// A container as /containers/json reports one, with only the labels that matter
+// here. `extra` is where a dev.portal.* override goes.
+const ctr = (proj, cfg, extra = {}, name = proj) => ({
+  Id: `id-${name}`,
+  Names: [`/${name}`],
+  Image: 'demo:latest',
+  State: 'running',
+  Status: 'Up 3 minutes',
+  Labels: {
+    'com.docker.compose.project': proj,
+    'com.docker.compose.project.config_files': cfg,
+    'com.docker.compose.service': name,
+    ...extra,
+  },
+  Ports: [{ IP: '0.0.0.0', PrivatePort: 5432, PublicPort: 5432, Type: 'tcp' }],
+});
+
+// ── identity is derived; only display grouping can be chosen ────────────────
+console.log('── a label moves where it is SHOWN, never what it IS ────────────────');
+
+const plain = classify(ctr('postgres', `${ROOT}data/postgres/compose.yml`), ROOT);
+eq('no label: identity and group are the same string',
+  [plain.system, plain.group], ['postgres', 'postgres']);
+
+const moved = classify(
+  ctr('postgres', `${ROOT}data/postgres/compose.yml`, { 'dev.portal.group': 'data' }),
+  ROOT,
+);
+eq('dev.portal.group moves the display group',   moved.group, 'data');
+eq('...and does NOT move the identity',          moved.system, 'postgres');
+eq('...and leaves the kind alone',               moved.groupKind, 'stack');
+
+const rekinded = classify(
+  ctr('postgres', `${ROOT}data/postgres/compose.yml`, { 'dev.portal.groupKind': 'project' }),
+  ROOT,
+);
+eq('dev.portal.groupKind still forces the panel', rekinded.groupKind, 'project');
+eq('...without touching identity either',        rekinded.system, 'postgres');
+
+// A route's hostname is a CLAIM ABOUT WHAT SOMETHING IS, made by whoever wrote
+// the route, so it beats config_files and lands in `system` - not merely in
+// `group`, which would make it a preference somebody could be talked out of.
+const nested = classify(ctr('monitoring', `${ROOT}monitoring/compose.yml`), ROOT, {
+  depth: 2, parent: 'cvops', leaf: 'grafana',
+});
+eq('nesting beats config_files, as identity',    [nested.system, nested.groupKind], ['cvops', 'project']);
+
+// The @file host process with no container at all. Its hostname's leaf IS its
+// system: falling through to the 'host' sentinel filed a project's own front-end
+// under a fabricated group, away from the api/auth routes beside it.
+eq('a depth-1 host process is its own system',
+  classify(null, ROOT, { depth: 1, parent: null, leaf: 'tals' }).system, 'tals');
+eq('a hostname that told us nothing -> host',
+  classify(null, ROOT, { depth: null, parent: null, leaf: null }).system, 'host');
+eq('a container with no compose labels',         classify({ Labels: {} }, ROOT).system, 'unmanaged');
+
+// ── infra is a place on disk, not a list of names ───────────────────────────
+//
+// It WAS a list of five names and the list had already gone stale: bothy-control
+// and bothy-config are Bothy, were split out of the `bothy` project after the set
+// was written, and rendered as two more "Stack" systems beside monitoring.
+//
+// A name list is also the wrong shape for the question. Compose project names are
+// global to the docker daemon and belong to whoever claimed them first, and this
+// box runs four unrelated projects out of ~/projects.
+console.log('\n── Bothy is what lives under <root>apps/, not what is named ─────────');
+
+const kindOf = (proj, cfg, root = ROOT) => classify(ctr(proj, cfg), root).groupKind;
+
+eq('bothy itself',            kindOf('bothy', `${ROOT}apps/bothy/compose.yml`), 'infra');
+eq('the action tier, unnamed anywhere',
+  kindOf('bothy-control', `${ROOT}apps/bothy-control/compose.yml`), 'infra');
+eq('the config tier, unnamed anywhere',
+  kindOf('bothy-config', `${ROOT}apps/bothy-config/compose.yml`), 'infra');
+eq('a tier that does not exist yet is covered too',
+  kindOf('bothy-tomorrow', `${ROOT}apps/bothy-tomorrow/compose.yml`), 'infra');
+eq('edge is infra by name - it is not under apps/',
+  kindOf('edge', `${ROOT}edge/compose.yml`), 'infra');
+eq('a shared stack service is stack, not infra',
+  kindOf('monitoring', `${ROOT}monitoring/compose.yml`), 'stack');
+
+// THE TRAP, and it is the reason the path test exists. `docker compose` project
+// names are unique per daemon but unqualified: they are simply the directory the
+// compose file sat in. A project checked out at ~/projects/portal is somebody
+// else's `portal`, and the old name set declared it part of Bothy.
+eq('a FOREIGN project named `portal` is not Bothy',
+  kindOf('portal', '/srv/box/projects/portal/compose.yml'), 'project');
+eq('a foreign project named `bothy` is not Bothy either',
+  kindOf('bothy', '/srv/box/projects/bothy/compose.yml'), 'project');
+eq('a sibling checkout of the repo is not the repo',
+  kindOf('bothy', '/srv/box/stacks-old/apps/bothy/compose.yml'), 'project');
+
+// With NO root known the path test has nothing to run against, so the name set
+// is all there is - and it must still fire, or the portal misfiles the page you
+// are reading under "Stack" while its own file tier is down. This is the case the
+// dead deployment names are kept for.
+eq('no root known: Bothy is still recognised',
+  kindOf('bothy', '/anywhere/apps/bothy/compose.yml', null), 'infra');
+eq('no root known: a retired tier name still lands right',
+  kindOf('portal-next', '/anywhere/apps/portal-next/compose.yml', null), 'infra');
+eq('no root known: everything else is stack, not project',
+  kindOf('cvops', '/srv/box/projects/cvops/compose.yml', null), 'stack');
+
+// ── one rule, applied in one place ──────────────────────────────────────────
+//
+// The bug this replaces: makeNode() re-applied `dev.portal.group` on top of
+// classify()'s answer and allPorts() printed the answer raw, so a service moved
+// into a system by label showed up in that system's service list and its ports
+// did not. `/control/systems/:name` filters ports on the group, so the Ports
+// section of the very page the label exists to build came back empty.
+console.log('\n── the node list and the ports table cannot disagree ────────────────');
+
+const BOX = [
+  ctr('postgres', `${ROOT}data/postgres/compose.yml`, { 'dev.portal.group': 'data' }, 'postgres'),
+  ctr('redis', `${ROOT}data/redis/compose.yml`, { 'dev.portal.group': 'data' }, 'redis'),
+];
+const nodes = merge([], [], BOX);
+const ports = allPorts(BOX);
+
+eq('both nodes are displayed under the label',
+  nodes.map((n) => n.group).sort(), ['data', 'data']);
+eq('both PORT ROWS are too',
+  ports.map((p) => p.group).sort(), ['data', 'data']);
+eq('and the port rows still know what they are',
+  ports.map((p) => p.system).sort(), ['postgres', 'redis']);
+eq('a node and its port row agree on the group',
+  nodes.every((n) => ports.some((p) => p.container === n.container.name && p.group === n.group)), true);
+
+// Same list with the labels taken off: nothing about it changes except the two
+// strings somebody chose. This is the zero-config promise, measured.
+const BARE = BOX.map((c) => ({ ...c, Labels: { ...c.Labels, 'dev.portal.group': undefined } }));
+eq('with no labels, group is identity everywhere',
+  merge([], [], BARE).every((n) => n.group === n.system), true);
+eq('...and the ports table says the same',
+  allPorts(BARE).every((p) => p.group === p.system), true);
+
+// ── the accent, and the bookmark ────────────────────────────────────────────
+//
+// Both are keyed off identity so that regrouping costs neither. Silent failures:
+// a card that changes colour is only noticed by someone hunting for it, and a
+// bookmark is only noticed by whoever opens it.
+console.log('\n── regrouping moves neither the colour nor the bookmark ─────────────');
+
+eq('unregrouped: the accent seed is the key itself',
+  primaryIdentity('postgres', ['postgres']), 'postgres');
+eq('merged: it keeps a MEMBER\'s seed, not the new name',
+  primaryIdentity('data', ['postgres', 'redis']), 'postgres');
+eq('...chosen by sort, so a reshuffled poll cannot repaint it',
+  primaryIdentity('data', ['redis', 'postgres']), 'redis');
+eq('a group whose key is also a member keeps its own',
+  primaryIdentity('postgres', ['postgres', 'redis']), 'postgres');
+eq('no identities at all -> the key, never undefined',
+  primaryIdentity('data', []), 'data');
+
+const GROUPS = [
+  { key: 'data', identities: ['postgres', 'redis'] },
+  { key: 'monitoring', identities: ['monitoring'] },
+];
+eq('an untouched system resolves by key',
+  findSystem(GROUPS, 'monitoring')?.key, 'monitoring');
+eq('A BOOKMARK FROM BEFORE THE REGROUP still opens',
+  findSystem(GROUPS, 'postgres')?.key, 'data');
+eq('the other member of the merge does too',
+  findSystem(GROUPS, 'redis')?.key, 'data');
+eq('a name nobody has ever used is still null',
+  findSystem(GROUPS, 'nonesuch'), null);
+
+// The ambiguous case, decided rather than left to array order: if a display group
+// is deliberately NAMED `postgres` while another still carries `postgres` as an
+// identity, the name somebody chose wins.
+eq('a deliberate name beats a leftover identity',
+  findSystem(
+    [{ key: 'x', identities: ['postgres'] }, { key: 'postgres', identities: ['pg'] }],
+    'postgres',
+  )?.key,
+  'postgres',
+);
+
+console.log();
+console.log(fails ? `${fails} check(s) FAILED` : 'all pass');
+process.exit(fails ? 1 : 0);

--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -57,7 +57,7 @@ mv "$OUT/customThemes.js" "$OUT/user-themes-mod.mjs"
 mv "$OUT/pages/files/tree.js" "$OUT/wikilinks-mod.mjs"
 cp "$HERE/status-classifier.mjs" "$HERE/relations.mjs" "$HERE/redirect-table.mjs" \
    "$HERE/titles-table.mjs" "$HERE/theme-contract.mjs" "$HERE/user-themes.mjs" \
-   "$HERE/wikilinks.mjs" "$HERE/repo-roots.mjs" "$OUT/"
+   "$HERE/wikilinks.mjs" "$HERE/repo-roots.mjs" "$HERE/grouping.mjs" "$OUT/"
 
 echo "── truth table ─────────────────────────────────────────"
 node "$OUT/status-classifier.mjs"
@@ -81,6 +81,12 @@ echo "── where this repo is, asked of docker not assumed ─────"
 # prefix of it, nothing mounted yet - which is precisely what could not be tested
 # while the value was a literal.
 node "$OUT/repo-roots.mjs"
+
+echo
+echo "── what a system IS vs where it is SHOWN ───────────────"
+# The split between derived identity and display grouping, and the two things
+# keyed off it whose failure is silent: the accent seed and the systems URL.
+node "$OUT/grouping.mjs"
 
 echo
 echo "── this box, right now ─────────────────────────────────"

--- a/apps/portal-next/web/src/lib/discover.ts
+++ b/apps/portal-next/web/src/lib/discover.ts
@@ -32,17 +32,38 @@
 // rule and would be true again the moment anyone wrote one. What is gone is the
 // assumption that a host belongs to one specific namespace.
 
-// 'bothy' is this app itself - web tier, editor tier and socket-proxy, all one
-// compose project since 2026-08-16. It was three ('portal', 'portal-next',
-// 'portal-files'), which made Bothy render as three separate cards in its own
-// Overview, since a system IS a compose project.
+// Bothy's own tiers are infra, not stack: filed under "Stack" they sit next to
+// the services they exist to describe, and the thing you are looking at reads as
+// one more workload on the box.
 //
-// Bothy is infra, not stack: leaving it out files the thing you are looking at
-// under "Stack", next to the services it is meant to be describing.
+// THIS USED TO BE A LIST OF FIVE PROJECT NAMES and the list had already gone
+// wrong. `bothy-control` and `bothy-config` are Bothy - the action tier and the
+// config tier, split out of the single `bothy` project after the set was written
+// - and because nobody remembered to add two strings they rendered as two
+// separate "Stack" systems beside monitoring and postgres.
 //
-// The old names stay listed. A container from a previous deployment keeps its
-// compose labels until it is recreated, and misfiling it for one poll is a
-// worse outcome than three dead strings.
+// A hand-maintained set of names is also the WRONG SHAPE for the question.
+// Compose project names are global to this docker daemon and belong to whoever
+// claimed them first; this box runs `cvops`, `thales`, `mpeg` and
+// `monorepo-inherited` from ~/projects. A project checked out at
+// ~/projects/portal would have been declared part of Bothy on the strength of
+// its directory name.
+//
+// So ask disk instead, exactly as the stack/project split already does: Bothy's
+// tiers are the compose files under `<stackRoot>apps/`. That is derived, it
+// cannot go stale, and a foreign project named `portal` fails it.
+const INFRA_SUBDIR = 'apps/';
+
+// The name test survives for the two cases the path test cannot answer:
+//
+//   * `edge` is Bothy's edge but lives at `<stackRoot>edge/`, not under apps/;
+//   * with NO stack root known (before the first `just up`, or with the file
+//     tier down) there is no path to test against, and the portal must still
+//     avoid misfiling ITSELF - see the null branch of classify().
+//
+// The dead deployment names stay listed for that second case only. A container
+// from a previous deployment keeps its compose labels until it is recreated, and
+// misfiling it for one poll is worse than three dead strings.
 const INFRA_PROJECTS = new Set(['edge', 'bothy', 'portal', 'portal-next', 'portal-files']);
 
 // ── Wire types (the raw API shapes) ─────────────────────────────────────────
@@ -278,6 +299,24 @@ export interface Nesting {
 }
 
 export interface Classification {
+  /**
+   * WHAT THIS IS, derived and never chosen. The compose project, or the
+   * hostname's own system for a container-less @file process. No label can move
+   * it.
+   *
+   * It exists because `group` was doing three jobs at once - the URL people
+   * bookmark (`/control/systems/:name`), the seed the accent colour is hashed
+   * from, and the panel a service is displayed in - so the moment anybody
+   * regrouped anything for DISPLAY, every bookmark into the systems they touched
+   * 404'd and every accent on the Overview reshuffled. A display preference must
+   * not be able to do that. Identity is the half that stays put.
+   */
+  system: string;
+  /**
+   * WHERE IT IS SHOWN. `system` unless `dev.portal.group` says otherwise. This
+   * is the only field a person is allowed to move, and moving it now costs
+   * nothing but the move.
+   */
   group: string;
   groupKind: string;
 }
@@ -293,6 +332,10 @@ export interface Port {
 export interface PortRow extends Port {
   container: string;
   image?: string;
+  /** Stable identity - see Classification.system. Carried on the row so the
+   *  system page can find its ports by what they ARE rather than by where they
+   *  are currently displayed. */
+  system: string;
   group: string;
   /** The group's display name, same contract as PortalNode.groupTitle - the
    *  Ports table is a third surface that was printing the raw slug. */
@@ -443,6 +486,13 @@ export interface PortalNode {
   path: string;
   url: string | null;
   browsable: boolean;
+  /**
+   * WHAT THIS SERVICE BELONGS TO, derived - see Classification.system. Equal to
+   * `group` unless somebody has set `dev.portal.group`, which is the point: the
+   * URL a person bookmarked and the colour they recognise a system by are keyed
+   * off this, so regrouping for display costs neither.
+   */
+  system: string;
   group: string;
   /** The group's DISPLAY name - what a human should ever see. Resolved here, in
    *  discovery, rather than at each render point, because the alternative is
@@ -684,25 +734,111 @@ export function repoRootsOf(
 // misfile ITSELF while its file tier is down; everything else falls to 'stack',
 // the answer that is right for every container on a box where this is the only
 // repo, and wrong only in the direction of under-claiming.
+//
+// `nesting` is the THIRD input and it is optional, because the two callers know
+// different amounts: merge() has resolved a router's hostname and allPorts() has
+// only a container. It is passed in rather than applied afterwards because
+// applying it afterwards is what shipped, and it is the whole reason
+// `dev.portal.group` worked on the Overview and was ignored by the Ports table -
+// makeNode() layered nesting and the label override on top of this function's
+// answer, and allPorts() printed the answer raw. One rule, one place; a caller
+// that knows less passes less.
 export function classify(
   container?: Container | null,
   stackRoot?: string | null,
+  nesting?: Nesting | null,
 ): Classification {
+  const labels = container?.Labels || {};
+  // Applied to whatever the derivation below lands on, so the override is
+  // honoured identically by every surface. Read once, here, and nowhere else.
+  const decide = (system: string, kind: string): Classification => ({
+    system,
+    group: labels['dev.portal.group'] ?? system,
+    groupKind: labels['dev.portal.groupKind'] ?? kind,
+  });
+
+  // Hostname nesting BEATS config_files: it's what puts cvops-tilt@file (no
+  // container at all) in the CVOps panel, which makes the DNS convention
+  // load-bearing. It is identity, not preference - the route says so - so it
+  // lands in `system` and not merely in `group`.
+  if (nesting?.parent) return decide(nesting.parent, 'project');
+
   // No container = an @file host process. It has no compose labels to classify,
-  // so the caller substitutes the hostname's own leaf as the group (see
-  // makeNode). 'host' survives only as the last resort for a route whose
-  // hostname told us nothing - it must never become a bucket of real services.
-  if (!container) return { group: 'host', groupKind: 'project' };
-  const labels = container.Labels || {};
+  // so its hostname's own leaf IS its system: a depth-1 host process
+  // (tals.<domain>) has no parent, and falling through to the 'host' sentinel
+  // filed Tals' own front-end under a fabricated system, separate from the
+  // api/auth/algo routes beside it. 'host' survives only as the last resort for
+  // a route whose hostname told us nothing - it must never become a bucket of
+  // real services.
+  if (!container) return decide(nesting?.leaf || 'host', 'project');
+
   const cfg = labels['com.docker.compose.project.config_files'];
   const proj = labels['com.docker.compose.project'];
   // minikube and anything else started outside compose has neither.
-  if (!cfg || !proj) return { group: 'unmanaged', groupKind: 'infra' };
-  const kind = INFRA_PROJECTS.has(proj) ? 'infra' : 'stack';
-  if (!stackRoot) return { group: proj, groupKind: kind };
+  if (!cfg || !proj) return decide('unmanaged', 'infra');
   const first = cfg.split(',')[0];
-  if (first.startsWith(stackRoot)) return { group: proj, groupKind: kind };
-  return { group: proj, groupKind: 'project' };
+
+  // No root known: the stack/project split cannot be made at all, so fall back
+  // to the name test for Bothy alone and call everything else 'stack' - wrong
+  // only in the direction of under-claiming. See the block comment above.
+  if (!stackRoot) return decide(proj, INFRA_PROJECTS.has(proj) ? 'infra' : 'stack');
+  if (!first.startsWith(stackRoot)) return decide(proj, 'project');
+  // In the repo. Bothy's own tiers live under `<stackRoot>apps/`; `edge` is the
+  // one that does not, and is named.
+  const own = first.startsWith(stackRoot + INFRA_SUBDIR) || INFRA_PROJECTS.has(proj);
+  return decide(proj, own ? 'infra' : 'stack');
+}
+
+// ── Pure: what a display group inherits from the identities inside it ───────
+//
+// Both of these take the structural minimum - a key and the identities folded
+// under it - rather than the full System from systems.ts. That module imports,
+// so it cannot be compiled by checks/run.sh's bare tsc, and these two rules are
+// precisely the ones a regression would be silent in: nobody notices a card's
+// colour moved until they cannot find it, and nobody notices a bookmark 404s
+// until they open it.
+
+/** A display group, as much of one as these functions need. */
+export interface GroupIdentity {
+  key: string;
+  identities: readonly string[];
+}
+
+/**
+ * Which identity a card's accent is hashed from.
+ *
+ * The key, when the key is itself one of the identities - which is every card on
+ * a box with no `dev.portal.group` labels, so the whole Overview keeps the exact
+ * colours it has today and this change is invisible until somebody asks for it.
+ *
+ * Otherwise the first identity alphabetically. A merged card has to pick one of
+ * its members' colours and cannot keep them all; it picks deterministically
+ * rather than by node order, which would repaint the card whenever docker
+ * returned its container list in a different order.
+ */
+export function primaryIdentity(key: string, identities: readonly string[]): string {
+  return identities.includes(key) ? key : identities[0] ?? key;
+}
+
+/**
+ * Resolve a `/control/systems/:name` param against the current display groups.
+ *
+ * Two lookups, and the second is the entire reason this is a function rather
+ * than a `.find()` at each call site: a URL that named a system before somebody
+ * regrouped it still names something real, and "No such system" is a bad answer
+ * to "the thing you bookmarked is now displayed one level up". Identity outlives
+ * display grouping, so a param that misses every key is tried against them.
+ *
+ * Key first, deliberately. If a display group is named `postgres` AND some other
+ * group still carries `postgres` among its identities, the group somebody
+ * deliberately named is the one they meant.
+ */
+export function findSystem<T extends GroupIdentity>(groups: readonly T[], name: string): T | null {
+  return (
+    groups.find((g) => g.key === name) ??
+    groups.find((g) => g.identities.includes(name)) ??
+    null
+  );
 }
 
 // Groups that are not systems and so cannot be named like one. `unmanaged` is
@@ -1125,7 +1261,7 @@ function makeNode({
   stackRoot = null,
 }: MakeNodeArgs): PortalNode {
   const n = nest(host);
-  const cls = classify(container, stackRoot);
+  const cls = classify(container, stackRoot, n);
   const L = container?.Labels || {};
   const pick = <T>(key: string, fallback: T): string | T => L[`dev.portal.${key}`] ?? fallback;
 
@@ -1136,7 +1272,12 @@ function makeNode({
   // Computed BEFORE the node literal because two fields need it: the slug the
   // app keys everything by, and the name a human reads. Deriving the title at
   // each render point instead is exactly the bug this replaces.
-  const group = pick('group', n.parent || (container ? cls.group : n.leaf || cls.group));
+  //
+  // Both come off classify() now. The nesting rule and the `dev.portal.group`
+  // override used to be re-applied here, on top of classify()'s answer, which is
+  // why allPorts() - which calls classify() and nothing else - disagreed with
+  // this function about which system a labelled container was in.
+  const group = cls.group;
 
   const node: PortalNode = {
     id: route ? route.name : `container:${container?.Id?.slice(0, 12)}`,
@@ -1151,16 +1292,10 @@ function makeNode({
     // truth rather than a guess.
     url: browsable ? containerUrl(container, path) : null,
     browsable,
-    // hostname nesting BEATS config_files: it's what puts cvops-tilt@file (no
-    // container at all) in the CVOps panel. Makes the DNS convention load-bearing.
-    //
-    // A depth-1 host process (tals.the name layer) has no parent, so it used to fall
-    // through to classify()'s 'host' sentinel - which filed Tals' own front-end
-    // under a fabricated system, separate from api/auth/algo.tals.the name layer. Its
-    // leaf IS its system name, so use that.
+    system: cls.system,
     group,
     groupTitle: names.get(group) || RESIDUE_TITLES[group] || titleCase(group),
-    groupKind: pick('groupKind', n.parent ? 'project' : cls.groupKind),
+    groupKind: cls.groupKind,
     parent: n.parent,
     depth: n.depth,
     order: Number(pick('order', 100)) || 100,
@@ -1240,6 +1375,19 @@ export function portsOf(container?: Container | null): Port[] {
 }
 
 // Every published port on the box, flattened - the collision map.
+//
+// It calls classify() and prints what it gets, which is now the same answer
+// makeNode() builds a node from. UNTIL THIS COMMIT IT WAS NOT: makeNode()
+// applied `dev.portal.group` and allPorts() did not, so a container moved into a
+// system by label appeared in that system's service list and its ports did not -
+// and `/control/systems/:name` filters ports with `p.group === name`, so the
+// Ports section of the very page the label exists to build came back empty.
+//
+// makeNode() was the correct one of the two. `dev.portal.group` is a documented,
+// supported override (docs/ARCHITECTURE.md, "Optional polish labels"); a
+// supported override that half the surfaces ignore is worse than no override,
+// because the disagreement reads as a discovery bug rather than a missing
+// feature. The fix is that neither function decides any more.
 export function allPorts(containers: Container[] = []): PortRow[] {
   const rows: PortRow[] = [];
   // Same map merge() uses, so a port row and a service row can never disagree
@@ -1253,6 +1401,7 @@ export function allPorts(containers: Container[] = []): PortRow[] {
         ...p,
         container: (c.Names?.[0] || '').replace(/^\//, ''),
         image: c.Image,
+        system: cls.system,
         group: cls.group,
         groupTitle: names.get(cls.group) || RESIDUE_TITLES[cls.group] || titleCase(cls.group),
         groupKind: cls.groupKind,

--- a/apps/portal-next/web/src/lib/projects.ts
+++ b/apps/portal-next/web/src/lib/projects.ts
@@ -84,6 +84,13 @@ function nodeOf(project: CollectorProject, svc: CollectorService): PortalNode {
     path: '/',
     url,
     browsable: url != null,
+    // A declaration IS the identity - the project wrote its own key down in
+    // project.dev.yml, which is a stronger claim than anything derived from a
+    // compose label. Identity and display grouping are the same here because
+    // there is no label on a declared host process to move it with; they are
+    // still two fields, so a declared service can be regrouped later without
+    // moving its URL, exactly like a discovered one.
+    system: project.key,
     group: project.key,
     // A declared project brings its own display name, so it needs no lookup -
     // which is the point of the field: every node carries the name a human

--- a/apps/portal-next/web/src/lib/systems.ts
+++ b/apps/portal-next/web/src/lib/systems.ts
@@ -14,6 +14,7 @@ import type { PortalNode, Status, ServiceType, VolumeRef } from './discover';
 import { TYPE_META } from './discover';
 import type { SystemDf } from './api';
 import { accentVar } from './accents';
+import { primaryIdentity } from './discover';
 
 export type SystemKind = 'project' | 'stack' | 'infra';
 
@@ -29,7 +30,19 @@ export interface UiLink {
 }
 
 export interface System {
-  key: string; // the compose group, e.g. 'tals' - also the /systems/:name param
+  key: string; // the display group, e.g. 'tals' - also the /systems/:name param
+  /**
+   * The derived identities folded into this card - every distinct `node.system`
+   * among its nodes, sorted. Exactly `[key]` until somebody sets
+   * `dev.portal.group`, and longer the moment they merge two systems into one.
+   *
+   * It is what makes regrouping non-destructive. A bookmark to
+   * /control/systems/postgres still resolves after postgres has been displayed
+   * inside a "Data" group, because findSystem() looks here when the key misses,
+   * and the accent is hashed from here so the colour a person recognises the
+   * card by does not move either.
+   */
+  identities: string[];
   title: string;
   kind: SystemKind;
   accent: string; // css var name, e.g. '--a3'
@@ -85,6 +98,15 @@ function kindOf(nodes: PortalNode[]): SystemKind {
   );
 }
 
+// primaryIdentity() and findSystem() live in discover.ts, next to the identity
+// they resolve, and are re-exported here because every consumer already imports
+// from this module. The reason they are not DEFINED here is mechanical and
+// load-bearing: this module imports things, so `checks/run.sh` cannot compile it
+// with a bare tsc, and the two rules that decide whether a bookmark still opens
+// and whether a card keeps its colour are exactly the rules that need a truth
+// table over them.
+export { primaryIdentity, findSystem } from './discover';
+
 export function uiLinkOf(n: PortalNode): UiLink | null {
   if (!n.browsable || !n.url) return null;
   // Only report a port for links that ARE a port. A routed service is reached by
@@ -132,12 +154,14 @@ export function systemsOf(nodes: PortalNode[]): System[] {
       if (!volSeen.has(v.name)) { volSeen.add(v.name); volumes.push(v); }
     }
     const uiLinks = ns.map(uiLinkOf).filter((x): x is UiLink => x != null);
+    const identities = [...new Set(ns.map((n) => n.system || key))].sort();
 
     systems.push({
       key,
+      identities,
       title: niceTitle(key, ns),
       kind: kindOf(ns),
-      accent: accentVar(`project:${key}`),
+      accent: accentVar(`project:${primaryIdentity(key, identities)}`),
       nodes: ns,
       total: ns.length,
       running: up + starting,

--- a/apps/portal-next/web/src/pages/ProjectDetail.tsx
+++ b/apps/portal-next/web/src/pages/ProjectDetail.tsx
@@ -3,7 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import { ChevronRight, HardDrive } from 'lucide-react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { usePortal, healthOf } from '../lib/data';
-import { groupByType, systemsOf, volumeSize, systemDiskBytes, fmtBytes } from '../lib/systems';
+import { groupByType, systemsOf, findSystem, volumeSize, systemDiskBytes, fmtBytes } from '../lib/systems';
 import { TypeIcon } from '../lib/icons';
 import { ServiceTable } from '../components/ServiceTable';
 import { PortsTab } from '../components/PortsTab';
@@ -26,7 +26,14 @@ export function ProjectDetail() {
 
   // Which half of the Reachability panel is showing. Not persisted: it is a
   // view of one page, not a fact about the box.
-  const [reach, setReach] = useState<'routes' | 'ports'>('routes');
+  //
+  // NULL MEANS "nobody has picked", which is not the same as "Routes". The
+  // initial value was 'routes', and the tab strip only offers a tab that has
+  // rows - so on a system with ports and no routes (postgres, redis, every
+  // exporter) the selected half was one that did not exist, and the panel
+  // rendered its header, a single "Ports 1" tab, and an empty box under it. The
+  // choice is resolved below, once the two counts are known.
+  const [reachPick, setReachPick] = useState<'routes' | 'ports' | null>(null);
 
   // WHETHER THE FILE IS AHEAD OF THE CONTAINER, reported up by the Name panel.
   //
@@ -48,16 +55,36 @@ export function ProjectDetail() {
 
   // The system rollup owns title, kind, accent and volumes - derive it once so
   // the header, chips and data card all agree.
+  // findSystem, not a `.find(s => s.key === name)`: the param is whatever was in
+  // somebody's bookmark, and after a regroup that is an IDENTITY rather than a
+  // display key. See findSystem() for why the fallback is the whole point.
   const system = useMemo(
-    () => systemsOf(data.nodes).find((s) => s.key === name) ?? null,
+    () => findSystem(systemsOf(data.nodes), name),
     [data.nodes, name],
   );
   const nodes = system?.nodes ?? [];
 
   const routerNames = new Set(nodes.filter((n) => n.route).map((n) => n.route!.router));
   const routers = data.routers.filter((r) => routerNames.has(r.name));
-  const ports = data.ports.filter((p) => p.group === name);
+  // Matched on the system rollup, not on the raw param, and on IDENTITY as well
+  // as display key. Filtering `p.group === name` meant this section came back
+  // empty for any system reached by an old URL, and - before allPorts() started
+  // honouring `dev.portal.group` - for any system assembled with that label.
+  const ports = data.ports.filter(
+    (p) => p.group === system?.key || (p.system != null && system?.identities.includes(p.system)),
+  );
   const h = healthOf(nodes);
+
+  // An explicit pick, but only while it still names a tab that is on screen -
+  // this component is reused when only the `:name` param changes, so a choice
+  // made on a routed system would otherwise follow the reader to one with ports
+  // only and blank the panel again.
+  const reach =
+    reachPick && (reachPick === 'routes' ? routers.length : ports.length)
+      ? reachPick
+      : routers.length
+        ? 'routes'
+        : 'ports';
 
   const sections = useMemo(() => groupByType(nodes), [nodes]);
 
@@ -209,7 +236,7 @@ export function ProjectDetail() {
               <Tabs
                 label="How this system is reached"
                 value={reach}
-                onChange={(k) => setReach(k as 'routes' | 'ports')}
+                onChange={(k) => setReachPick(k as 'routes' | 'ports')}
                 tabs={[
                   ...(routers.length ? [{ key: 'routes', label: 'Routes', count: routers.length }] : []),
                   ...(ports.length ? [{ key: 'ports', label: 'Ports', count: ports.length }] : []),

--- a/apps/portal-next/web/src/pages/ServiceDetail.tsx
+++ b/apps/portal-next/web/src/pages/ServiceDetail.tsx
@@ -4,7 +4,7 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { usePortal } from '../lib/data';
 import { HOST_OVERRIDES, logSourceOf } from '../lib/discover';
 import { LogPanel } from '../components/LogPanel';
-import { systemsOf } from '../lib/systems';
+import { systemsOf, findSystem } from '../lib/systems';
 import { accentVar } from '../lib/accents';
 import { ServiceIcon, StatusIcon } from '../lib/icons';
 import { systemLink, kindLabelOf, unknownReason } from '../lib/links';
@@ -54,7 +54,7 @@ export function ServiceDetail() {
   // The system's display title, not the raw group key - the breadcrumb used to
   // read "monitoring" while the page it links to is titled "Monitoring".
   const systemTitle =
-    systemsOf(data.nodes).find((s) => s.key === node.group)?.title || node.group;
+    findSystem(systemsOf(data.nodes), node.group)?.title || node.group;
   const c = node.container;
   // Null for an @file route with no container and no declaration - there is
   // genuinely nowhere to read logs from, so the panel is omitted rather than

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -630,7 +630,8 @@ compose file lives:
 
 | Config path | Classified as |
 |---|---|
-| Under the stacks root | **stack** (`edge`, `portal`, `portal-next` → **infra**) |
+| Under `<stacks root>/apps/` — Bothy's own tiers | **infra** |
+| Elsewhere under the stacks root | **stack** (`edge` → **infra**, by name: it is not under `apps/`) |
 | Anywhere else | **project** |
 | Missing entirely (e.g. minikube) | **unmanaged / infra** |
 
@@ -639,6 +640,39 @@ container-less `@file` host process into the right project panel.
 
 A route with no container is rendered loudly (rose dot, "no container" badge) -
 a dangling route is exactly what the portal should shout about.
+
+**Infra is a place on disk, not a list of names.** It was a set of five project
+names in `discover.ts` and the set had already gone stale — `bothy-control` and
+`bothy-config` were split out of the `bothy` project after it was written and
+rendered as two more "Stack" systems. A name test is also unsafe: compose project
+names are global to the docker daemon and belong to whoever claimed them first,
+so a checkout at `~/projects/portal` was being declared part of Bothy. The names
+survive only for the case the path test cannot answer — **no stack root known**,
+before the first `just up` or with the file tier down — where the portal must
+still avoid misfiling itself.
+
+### Identity vs display grouping
+
+Every node carries **two** group fields, and the difference is load-bearing:
+
+| Field | Means | Set by |
+|---|---|---|
+| `system` | what this service **is** | derived: hostname nesting → compose project → `unmanaged`/`host`. No label can move it |
+| `group` | where it is **shown** | `dev.portal.group`, falling back to `system` |
+
+They are the same string on a box with no `dev.portal.group` labels, which is why
+regrouping changes nothing until somebody asks for it. `group` used to be one
+field doing three jobs — the panel, the `/control/systems/:name` URL people
+bookmark, and the seed the accent colour is hashed from — so any user-facing
+regroup would have 404'd bookmarks and reshuffled colours. Now:
+
+- `System.identities` lists the `system` values folded into a display group;
+- the accent is hashed from `primaryIdentity()`, so a merged card keeps a
+  member's colour rather than inventing one;
+- `findSystem()` resolves a URL by display key **then** by identity, so a
+  bookmark taken before a regroup still opens.
+
+Truth table: `apps/portal-next/checks/grouping.mjs`.
 
 ### Optional polish labels
 
@@ -651,7 +685,7 @@ be correct, the defaults are wrong.
 | `dev.portal.name` | This service's display name |
 | `dev.portal.icon` | Emoji |
 | `dev.portal.desc` | Card body text |
-| `dev.portal.group` / `.groupKind` | Force which panel it lands in |
+| `dev.portal.group` / `.groupKind` | Force which panel it lands in. Display only — the node's `system` identity, its accent and its old URL are unaffected. Honoured by the Overview, Services **and** the Ports table (until 2026-08-19 the last one ignored it) |
 | `dev.portal.hidden=true` | Drop from Services (still listed in Ports and Routes) |
 | `dev.portal.path` | Deep link, e.g. `/targets` |
 | `dev.portal.order` | Sort order within a panel |

--- a/scripts/checks/mutants.sh
+++ b/scripts/checks/mutants.sh
@@ -122,6 +122,31 @@ mutant "asDir loses its trailing slash" \
   -- "${PORTAL_CHECKS[@]}"
 
 echo
+echo "── identity is not display grouping ────────────────────────────────"
+# A system's derived `system` and its displayed `group` are two fields precisely
+# so that `dev.portal.group` cannot move a bookmarked URL or an accent colour.
+# Collapse them back into one and every symptom is silent: the Overview looks
+# right, and only the person who opens an old /control/systems/ link finds out.
+mutant "a display label moves the identity too" \
+  apps/portal-next/web/src/lib/discover.ts \
+  '  const decide = (system: string, kind: string): Classification => ({
+    system,' \
+  '  const decide = (system: string, kind: string): Classification => ({
+    system: labels['"'"'dev.portal.group'"'"'] ?? system,' \
+  -- "${PORTAL_CHECKS[@]}"
+
+# The other half: makeNode() honoured dev.portal.group and allPorts() ignored it,
+# so a system assembled with that label listed its services and none of its
+# ports. Both read one classify() now; make the ports table read past it again.
+mutant "the ports table stops honouring the label" \
+  apps/portal-next/web/src/lib/discover.ts \
+  '        system: cls.system,
+        group: cls.group,' \
+  '        system: cls.system,
+        group: cls.system,' \
+  -- "${PORTAL_CHECKS[@]}"
+
+echo
 echo "── the palette contract ────────────────────────────────────────────"
 # Every colour must come from a token. A literal in a component is invisible in
 # one theme and wrong in the other four.


### PR DESCRIPTION
`System.key` was `n.group` was `PortalNode.group` — one string doing three jobs at once:

- the panel a service is displayed in,
- the `/control/systems/:name` URL people bookmark,
- the seed `accentVar()` hashes a system's colour from.

So the feature #93 asks for could not be built. Any user-facing regroup that moved `group` would have 404'd every bookmark into the systems it touched and reshuffled the accents of the ones it did not. **This PR separates a stable identity from the display grouping**, which is the part that has to exist before anything can be regrouped, and fixes the live inconsistency found while enumerating the consumers.

---

## 1. The identity split

Every node and every port row now carries **two** group fields:

| Field | Means | Set by |
|---|---|---|
| `system` | what this service **is** | derived: hostname nesting → compose project → `unmanaged`/`host`. No label can move it |
| `group` | where it is **shown** | `dev.portal.group`, falling back to `system` |

On top of that:

- **`System.identities`** — the `system` values folded into one display group. `['postgres']` today; `['postgres','redis']` the moment somebody merges them.
- **`primaryIdentity(key, identities)`** — the accent seed. The key when the key is itself an identity (every card on this box), otherwise the first identity by sort. A merged card keeps a *member's* colour rather than inventing one, and picks deterministically so a reshuffled container list cannot repaint it.
- **`findSystem(groups, name)`** — resolves a systems URL by display key, **then** by identity. A bookmark taken before a regroup still opens. Used by `ProjectDetail` and `ServiceDetail`.

Both helpers live in `discover.ts` rather than `systems.ts` and are re-exported. That is mechanical and load-bearing: `systems.ts` imports, so `checks/run.sh`'s bare `tsc` cannot compile it, and these two rules are exactly the ones whose failure is silent. `discover.ts` stays import-free.

**With no `dev.portal.group` label anywhere — which is this box — `system === group` on all 32 containers and nothing moves.** That is asserted, not claimed: `checks/grouping.mjs` merges a labelled container list, strips the labels, and checks the equality holds across both `merge()` and `allPorts()`.

### Consumer inventory

`classify()` — **3 call sites**, all in `discover.ts`: `defaultName()` (L929), `makeNode()` (L1264), `allPorts()` (L1398). Plus `checks/repo-roots.mjs`, which calls it directly. All still compile; the signature gained an optional third parameter.

`groupKind` — **11 references, 7 of them consumers**:

| Where | Reads it to |
|---|---|
| `systems.ts:kindOf()` | pick a System's kind by majority |
| `systems.ts:uiLinkOf()` | copy onto `UiLink` |
| `systems.ts:uiPorts()` | split "Open a UI" into project vs stack |
| `panels.ts` ×3 | the Projects / Stack / Infrastructure panels |
| `discover.ts:defaultName()` | decide whether to prefix `"CVOps · Postgres"` |
| `checks/repo-roots.mjs` | assert the stack/project split |

Producers: `makeNode()`, `allPorts()`, `projects.ts:nodeOf()` (declared projects). Nothing else writes it.

`System.key` as a URL — `App.tsx` route `systems/:name`, `CommandPalette.tsx:76`, `links.ts:systemLink()`, `ProjectDetail.tsx` `useParams`, `ServiceDetail.tsx` breadcrumb, `redirects.ts` (the `/systems/:name` → `/control/systems/:name` migration). All keep working; two now go through `findSystem()`.

---

## 2. The `allPorts()` bug

**`makeNode()` was the correct one.** `dev.portal.group` is a documented, supported override (`docs/ARCHITECTURE.md`, "Optional polish labels"); a supported override that half the surfaces ignore is worse than no override, because the disagreement reads as a discovery bug rather than a missing feature.

The concrete failure, reproduced against this box's real container list with `dev.portal.group=data` planted on the `postgres` project:

```
                             BEFORE                     AFTER
node  Postgres               data/stack                 data/stack
node  Postgres Exporter      data/stack                 data/stack
port  postgres:5432          postgres/stack             data/stack   <-- was wrong
```

`ProjectDetail.tsx` filters ports with `p.group === name`, so `/control/systems/data` listed two services and **zero ports** — the Ports section of the very page the label exists to build. Fixed by making neither function decide: `classify()` takes the nesting and applies the label, once, and both callers print what they get.

The mechanism was that `makeNode()` re-applied nesting *and* the label on top of `classify()`'s answer while `allPorts()` printed the answer raw. Those three lines are gone.

---

## 3. Infra is a place on disk, not a list of names

Not strictly asked for, but it is the issue's own complaint (*"three of those five names are dead deployments… that set is doing work it should not have to"*) and it was **already wrong**:

```ts
const INFRA_PROJECTS = new Set(['edge', 'bothy', 'portal', 'portal-next', 'portal-files']);
```

`bothy-control` and `bothy-config` are Bothy — the action tier and the config tier, split out of the `bothy` project after that set was written. Nobody added two strings, so they rendered as **two more "Stack" systems** beside monitoring and postgres.

A name test is also unsafe, and this is the trap named in the issue triage: **compose project names are global to the docker daemon and belong to whoever claimed them first.** This box runs `cvops`, `thales`, `mpeg` and `monorepo-inherited` out of `~/projects`; a checkout at `~/projects/portal` would have been declared part of Bothy on the strength of its directory name.

Infra is now `<stackRoot>apps/` — derived, exactly like the stack/project split already is. The names survive only for the case the path test cannot answer: **no stack root known** (before the first `just up`, or with the file tier down), where the portal must still avoid misfiling itself. `checks/repo-roots.mjs`'s existing assertions on that branch are untouched and still pass.

Note on the identity trap generally: a compose project name is unique *per daemon*, so adopting it as an identity cannot collide. What it can do is inherit meaning from an unrelated project — which is what the name-based infra test did, and what the path test now prevents.

---

## 4. Before / after, on this box's real containers

`merge()` + `allPorts()` from `origin/main` and from this branch, both run against the live `/containers/json` (32 containers) and the live Traefik router/service tables (16/12). Full output in the commit's check run; the diff is four rows:

```
service                    BEFORE               AFTER                 system
Bothy Config               bothy-config/stack   bothy-config/infra    bothy-config
Bothy Control              bothy-control/stack  bothy-control/infra   bothy-control
Socket Read                bothy-control/stack  bothy-control/infra   bothy-control
Socket Write               bothy-control/stack  bothy-control/infra   bothy-control

28 other nodes: unchanged.   10 port rows: unchanged.
```

Overview, rendered against the live box:

- **before** — `STACK 5`: Monitoring · Grafana, Identity · Keycloak, Database · Postgres, **Bothy Control**, **Bothy Config** · `INFRASTRUCTURE 2`
- **after** — `STACK 3`: Monitoring · Grafana, Identity · Keycloak, Database · Postgres · `INFRASTRUCTURE 4`: Bothy Control, Other containers, Bothy Config, Edge · Traefik

Every `system` equals its `group`, because nothing on this box sets `dev.portal.group`. That is the zero-config guarantee, measured rather than asserted.

---

## 5. One more thing, found by looking at the page

`ProjectDetail`'s Reachability panel initialised its tab to `'routes'`. The tab strip only offers a tab that has rows — so on **postgres, redis and every exporter** (ports, no routes) the selected half was one that did not exist, and the panel rendered its header, a lone `Ports 1` tab, and an empty box. Screenshot of that state is what sent me looking. The choice is now resolved after the counts are known, and survives the component being reused when only `:name` changes.

---

## Tests

`apps/portal-next/checks/grouping.mjs` — **38 assertions** in four sections, wired into `checks/run.sh`:

- a label moves where a service is **shown**, never what it **is** (incl. nesting, the depth-1 host process, the `host`/`unmanaged` residue)
- infra is `<root>apps/`, not a name — including *a foreign project named `portal` is not Bothy*, *a sibling checkout is not the repo*, and the three no-root-known fallbacks
- the node list and the ports table cannot disagree, and with no labels `group === system` on both
- regrouping moves neither the colour nor the bookmark

### Proving it can fail

Each mutation applied to the product, suite re-run, then restored:

| Mutation | Result |
|---|---|
| `allPorts()` prints `cls.system` as the group (undoes the fix) | **2 FAIL** — `both PORT ROWS are too` got `["postgres","redis"]` want `["data","data"]`; `a node and its port row agree on the group` got `false` |
| `decide()` sets `system` from `dev.portal.group` (collapses the split) | **1 FAIL** — `...and does NOT move the identity` got `"data"` want `"postgres"` |
| infra reverts to the name set only | **3 FAIL** — the action tier / the config tier / a tier that does not exist yet, all `"stack"` want `"infra"` |
| `primaryIdentity` returns the key; `findSystem` drops the identity lookup | **4 FAIL** — including `A BOOKMARK FROM BEFORE THE REGROUP still opens` got `undefined` want `"data"` |

The first two are now permanent entries in `scripts/checks/mutants.sh`, so the check cannot go decorative later.

Also run: `npm run typecheck` (clean), `npm run build` (clean), `bash apps/portal-next/checks/run.sh` **without** `--offline` against this box's real docker socket — 10/10 sections `all pass`, 524 PASS lines — `node apps/portal-next/checks/stray-colour.mjs`, `scripts/checks/portability.sh`, `scripts/checks/bash32.sh`.

---

## What is deliberately NOT here

The issue asks for user-defined grouping: name and order groups, collapse or hide them, save a filter. **The model now supports all of it; the editor does not exist**, and that is a scope decision rather than an omission.

`docs/plans/control-and-settings.md` §6b and `pages/Settings.tsx`'s header both say the settings surface is read-only **by design** — a store is a write path, and a write path is a threat model, an audit trail and a boundary. Group membership, group names and group order are per-user preferences with no home: that plan's table puts them in the "needs a real store" row and recommends not building one until somebody asks to keep a specific preference. Inventing an unauthenticated write endpoint for a display preference is exactly the trade that document declines.

So what ships is the **model** plus **label-driven grouping made consistent**, which is the sanctioned mechanism and was most of the value: `dev.portal.group` now works identically on the Overview, Services, the system page **and** the Ports table, and using it no longer costs a bookmark or an accent.

A user-facing editor still needs, in order:

1. **Membership** — `identity → display group`, per user. That is the store §6b declines to build yet. The same table would carry **name** and **order**, which today are `dev.portal.project` and the hardcoded `KIND_RANK` in `systems.ts`.
2. **Collapse** — the one part already pre-authorised: §6b's table lists *"theme, pane widths, collapsed groups"* as browser-owned, `localStorage`, "already correct, leave it". That can be built with no server change and no new endpoint, and it is the cheapest next step.
3. **Hide** — `dev.portal.hidden` exists per node; a per-group version is a filter over the same field and needs (1)'s store only for persistence.

Not `Closes #93`. It delivers the prerequisite the triage identified — *"first, because it changes a primary key"* — the `allPorts()` fix, and the label mechanism working everywhere. Refs #93.
