### PR TITLE
docs(guide): the corpus for people who are not this repo's author

### DIFF
--- a/docs/guide/configuring.md
+++ b/docs/guide/configuring.md
@@ -1,0 +1,249 @@
+# The files you will actually edit
+
+Bothy is a set of Docker Compose stacks, a Traefik file-provider directory, two
+policy files and one `.env`. This page maps "I want to change X" onto the file
+that decides it, and says what has to happen before the change is live - because
+in nearly every case here, **saving the file is not applying it**.
+
+The reasoning for individual settings lives in the compose files themselves.
+Every non-obvious line in them carries a comment explaining what broke without
+it, and those comments are the primary source. This page is the index.
+
+## The rule that comes first
+
+Use `just`. The justfile does `set dotenv-load`, so recipes see the root `.env`.
+`docker compose` looks for a `.env` beside the compose file it was handed, finds
+none, and either falls back to an insecure default or aborts on a required
+variable. Every group has a recipe:
+
+| Recipe | Compose file |
+|---|---|
+| `just up-edge` | `edge/compose.yml` |
+| `just up-data` | `data/postgres/compose.yml` |
+| `just up-auth` | `auth/compose.yml` |
+| `just up-monitoring` | `monitoring/compose.yml` |
+| `just up-apps` | `apps/bothy/compose.yml`, plus the config and control tiers |
+
+`apps/bothy/compose.yml` is a stub that pulls three fragments together with
+`include:` - the web tier, the editor tier and the socket proxy. It is
+`include:` and not repeated `-f` for a specific reason worth knowing before you
+reach for the shorter form: with repeated `-f`, every relative path in every
+file resolves against the **first** file's directory. That built the editor tier
+from the web tier's Dockerfile, so `portal-files` came up as nginx and
+crash-looped, and its audit-log bind mount silently moved somewhere nothing
+looks.
+
+## `.env`
+
+One file, gitignored, and the only place several values exist on earth. The
+comments in [`.env.example`](../../.env.example) are the reference; these are the
+keys people actually go looking for.
+
+| Key | What it decides |
+|---|---|
+| `BOX_IP` | the address this box answers on. Read **directly** by `auth/compose.yml` in five places - Keycloak's hostname, the realm's redirect URI, the OIDC issuer, oauth2-proxy's redirect and its cookie whitelist |
+| `DEV_LOGIN_USER` / `DEV_LOGIN_PASSWORD` | the one shared credential every service with a native login uses, and the Keycloak admin password |
+| `NOTES_ROOT`, `PROJECTS_ROOT`, `HOME_ROOT`, `STATE_ROOT` | where the four things that live **outside** the repository are. Every one has a default; set one only if your layout differs |
+| `PUID` / `PGID` | who the three writing services run as. Left blank on purpose - `just bootstrap` fills them in from your own uid |
+
+Two things about `BOX_IP` that cost time if you learn them the hard way. It is
+the value most likely to be wrong in a way nothing reports: Keycloak advertises
+whatever it is told, oauth2-proxy independently validates that issuer, and if
+the two disagree by so much as a port the symptom is **an infinite redirect
+loop, not an error**. And nothing in `.env` is live until the stack that reads
+it is brought up again - for this key specifically, `just up-auth`.
+
+Never write a second spelling of that address. The internal shortcut
+`http://keycloak:8080` is deliberately unused in the OIDC configuration, because
+a second spelling *is* the bug.
+
+## Compose: adding a service
+
+The whole recipe, for the overwhelmingly common case:
+
+1. add the service to a compose file, or give it one of its own;
+2. **publish a host port** - there is no name layer, so this is how it is
+   reached;
+3. put it on `[default, devnet]`;
+4. add it to `just urls`, which is a human-maintained list and not a registry;
+5. `docker compose -f <file> up -d`, then confirm on `http://<node-ip>/` that
+   Bothy noticed it.
+
+That last step is the test of the whole design: **start any container and it
+appears on the Overview within ten seconds with no edit to Bothy.** If it does
+not appear, the problem is the container, not the console.
+
+> [!warning] Listing `networks:` on a service drops it off the compose default network
+> Always `[default, devnet]`. With `devnet` alone, the service silently loses
+> its own project's database.
+
+Pick a free port with care. `just urls` lists the *stack's* ports; a project's
+claims live in its own manifest and nothing reconciles the two. Keycloak was
+once published on a port a stopped project had already declared - the collector
+TCP-probed the declared port, found something listening, and reported a service
+nobody had started as up. Check `ss -ltn` **and** the project manifests.
+
+The full checklist, including the cases for a container nothing browses, a host
+process and a database, is
+[`docs/ARCHITECTURE.md` § 7](../ARCHITECTURE.md).
+
+## `edge/dynamic/` - the Traefik file provider
+
+Traefik watches this directory and **merges every `.yml` in it into one
+namespace**. That single fact explains most of the shape of what is in there.
+
+What is committed:
+
+| File | What it declares |
+|---|---|
+| `portal-api.yml` | the portal's read-only data plane. The security boundary - read it in full before touching it |
+| `auth.yml` | the `sso` and `sso-errors` middlewares, and the host-less `/oauth2/` router that makes the login flow reachable at all |
+| `portal-files.yml` | four role-gated routers for the file tier, and the `sso-viewer` / `sso-editor` middlewares |
+| `bothy-config.yml` | two role-gated routers for the config tier. It **borrows** the middlewares above |
+| `bothy-control.yml` | three role-gated routers, one per verb, and `sso-operator` |
+| `project.example.yml` | the annotated template, entirely commented out |
+| `portal-prom.example.yml` | the template for the generated Prometheus route |
+
+`portal-prom.yml` itself is gitignored and generated by
+`just portal-prom-route`, because it carries the basic-auth header the edge
+injects on the portal's behalf.
+
+### Why there are zero `Host()` rules
+
+The `.test` name layer was retired on 2026-08-12 - deleted, not dormant. A
+`Host()` rule written today registers with status `enabled` and then matches
+nothing, forever. `just verify` asserts the count of them is zero, and that zero
+is the invariant; the total number of routers moves as tiers are added.
+
+If a route is genuinely needed, the only shape that still works is a **host-less
+exact `Path()` rule**. Be aware of what that means: with no host to scope it,
+the route answers on every address this box has at once, in a shared global path
+namespace - so a generic path like `/api` will collide with the next project
+that wants `/api`. Prefix it with something unmistakably yours.
+[`edge/dynamic/project.example.yml`](../../edge/dynamic/project.example.yml) is
+the template, and it is commented out on purpose: the file provider merges
+everything here, so an example with live YAML is not an example, it is
+configuration. That is not hypothetical - an example file once declared the same
+router and middleware *names* as a real generated file, and the merge silently
+replaced a live credential with the example's placeholder. Every request 401'd
+while the router still reported "enabled".
+
+### `Path()`, never `PathPrefix()`
+
+Every rule in the tiers that can change something is an exact `Path()`, with the
+variable part in the query string or the JSON body. This is a security control
+and not a style preference: a prefix rule covers every endpoint the service
+grows **later**, including one nobody meant to expose. With exact paths a new
+endpoint is unreachable until somebody edits a rule here, which is the correct
+default for services holding write handles on two git repositories and a path to
+the Docker daemon.
+
+### The trap that voids a whole file
+
+> [!caution] A doubled brace anywhere in `edge/dynamic/`, comments included, voids the file
+> Traefik renders every file in that directory as a **Go template before it
+> parses the YAML**, and it does not skip comments. A doubled brace - the usual
+> way in is a `docker inspect -f` format string in a comment - is evaluated as a
+> template action, fails, and takes out the entire file: no routers, no
+> middlewares, silently, while the file on disk looks perfect. Traefik keeps
+> serving its last good configuration, so nothing looks wrong until the next
+> restart, when every file-provider router disappears at once. Use the `jq`
+> form. `just verify` check 5b exists to catch exactly this.
+
+And one more that is not a syntax error at all:
+
+> [!warning] The `edge/dynamic` bind mount goes stale after `git checkout`
+> A bind mount pins the host inode at container-creation time, and checkout
+> deletes and recreates directories. Traefik then keeps reading an orphaned copy
+> and `--providers.file.watch=true` stops meaning anything. It ran that way for
+> five days once, with every edit having no effect. After any branch switch:
+> `docker compose -f edge/compose.yml up -d --force-recreate`.
+
+### Attaching a login to a router
+
+Add **both middlewares, in this order**: `sso-errors@file`, then `sso@file`.
+Reversed, a signed-out user gets a blank 401 instead of a sign-in page - the
+request passes through `sso-errors` on the way in and the 401 travels back out
+through it.
+
+`sso` fails closed. If oauth2-proxy is down, every router carrying it returns
+500 to everyone. That is correct for an auth boundary and it is precisely why
+you do not attach it to the thing you would need in order to fix it.
+
+Which role a router requires lives in the **middleware**, not the service:
+`sso-viewer`, `sso-editor` and `sso-operator` are identical but for one word in
+a query string. Adding a tier is four lines of YAML, not another container. See
+[Roles](roles.md).
+
+## The `dev.portal.*` labels
+
+Everything on the Overview works with **zero labels**. If the page ever *needs*
+a label to be correct, the defaults are wrong. The labels are polish, read in
+`apps/portal-next/web/src/lib/discover.ts`:
+
+| Label | Effect |
+|---|---|
+| `dev.portal.project` | display name for a whole compose project - one label fixes every breadcrumb and panel title |
+| `dev.portal.name` | this service's display name |
+| `dev.portal.icon` | an emoji |
+| `dev.portal.desc` | the card's body text |
+| `dev.portal.group`, `dev.portal.groupKind` | force which panel it lands in. Display only - what a service **is** cannot be moved by a label, so its accent colour and its old URL are unaffected |
+| `dev.portal.hidden=true` | drop it from Services. Still listed under Ports and Routes |
+| `dev.portal.path` | a deep link, such as `/targets` |
+| `dev.portal.order` | sort order within a panel |
+
+`dev.portal.project` on **any** container in a project names the whole project,
+which is how `Edge · Traefik` and `Identity · Keycloak` get their titles. The
+naming form is `Role · Vendor`, and the argument for it is in
+`edge/compose.yml` beside the label: the Bothy prefix is earned by authorship,
+not proximity. Traefik is not "Bothy Edge" - if it breaks at 03:00 it is not
+Bothy's documentation you open.
+
+Labels are fixed at container creation. Editing one and running `docker restart`
+does nothing; the container has to be **recreated**.
+
+## The two `policy.toml` files
+
+Both are access policy expressed as data rather than as constants in Python,
+both are read once at startup, and both **fail closed** - a missing file, a
+parse error, or a declared root that does not exist stops the service starting.
+There is no permissive fallback, because the only safe default is "nothing" and
+a service that serves nothing looks broken in a way people work around.
+
+**`apps/portal-files/policy.toml`** governs Bothy Files: which roots exist and
+which are writable, which directories are never served at any depth, which files
+are *labelled* sensitive, how many undo snapshots are kept, and what warning a
+given path shows before you overwrite it. It is itself editable through the
+explorer, and marked `critical` for the reason above - a bad edit here does not
+produce a permissive service, it produces one that will not come back until
+somebody repairs it from a shell on the box. See [Bothy Files](files.md).
+
+**`apps/bothy-config/policy.toml`** governs the settings forms: one root, YAML
+files only, and a named allowlist of fields a form may patch. `.toml` is
+deliberately absent from its suffixes, so the file declaring what may be written
+cannot be rewritten through the API it declares. It is a much smaller surface
+than the file tier on purpose - a form that could set `volumes`, `privileged`,
+`command` or `network_mode` would be arbitrary code on the box, and those are
+edited as a diff by somebody who has read the comment above them.
+
+## After you save, what actually applies it
+
+| You changed | Live when |
+|---|---|
+| `edge/dynamic/*.yml` | immediately - Traefik watches the directory. Unless the mount is stale after a checkout |
+| a compose `labels:` or `ports:` entry | after `docker compose -f <file> up -d` **recreates** the container. A restart is not enough |
+| `.env` | after the stack that reads it is brought up again |
+| a `policy.toml` | after that service restarts. If it will not start, the policy is why |
+| a theme under `apps/portal-next/data/themes/` | on reload. Anything under `web/src/` needs a rebuild |
+
+Then:
+
+```sh
+just verify     # 23 checks against the running edge, asserting on content
+just doctor     # containers, Prometheus targets, disk, backup freshness
+```
+
+## Next
+
+- [Operating it from the console](the-console.md)
+- [Roles](roles.md)

--- a/docs/guide/files.md
+++ b/docs/guide/files.md
@@ -1,0 +1,257 @@
+# Bothy Files
+
+`http://<node-ip>/#/files`. Every document on the box, read straight off the
+disk it lives on - rendered, searchable, linkable and editable. No second copy,
+no sync lag, nothing to keep out of git.
+
+One nav entry, two destinations, and they take the same `?root=` and `?path=`
+so an existing deep link resolves in either:
+
+- **`/files`** is a **reader**. A document, an index of documents, and its own
+  headings.
+- **`/files/edit`** is the IDE - an activity bar, a tree, resizable panes,
+  source control, and a real code editor.
+
+The reader is the default because the tax of four regions was being paid on
+every read by everyone, to make the rarer case one click cheaper. The line the
+reader is built around is worth quoting, because it is a structural claim rather
+than a promise:
+
+> **Reading mode never writes.** Not "does not write yet". No draft, no dirty
+> flag, no conflict check, no save, no local storage key.
+
+Nothing in the reader's import graph reaches the write path at all, which is
+also why it never downloads the code editor's chunk. Its answer to every request
+for a save button is the Edit button, which is a link.
+
+## The four roots
+
+A root is a **named place**. Clients send the name, never a filesystem path, so
+there is no default and no way to ask for "the whole disk". They are declared in
+[`apps/portal-files/policy.toml`](../../apps/portal-files/policy.toml), and a
+root declared there but not mounted in compose is a startup error rather than an
+empty directory - a silently empty root reads as "nothing to see".
+
+| Root | What it is | Writable |
+|---|---|---|
+| `stacks` | this repository | yes |
+| `notes` | your notes repository, wherever `NOTES_ROOT` points | yes |
+| `projects` | everything under `PROJECTS_ROOT` | no |
+| `home` | "any folder you can cd into" | no |
+
+`projects` is read-only twice over - the application refuses with a readable 403
+and the mount is `:ro`, so the kernel refuses regardless. Project repositories
+have their own review and CI, and an edit here would bypass both.
+
+`home` is read-only for a different reason: it **overlaps** `stacks` and
+`notes`, so the same file is reachable under two names and only one of them
+should be able to change it. It is also excluded from a search across all roots,
+because every hit in the other three would otherwise come back a second time
+under a `home/...` path - and the second copy is the one whose root cannot be
+written to, so clicking it opens a read-only view of a file that is editable
+elsewhere.
+
+Every top-level dot entry in the `home` root is denied as a class. A survey
+before mounting it found live OAuth credentials, a GitHub token, SSH and GPG
+keys, kube and docker credentials, minikube CA private keys, shell history and
+roughly 165,000 cache files - **all of them top-level dot entries**. Denying the
+whole class is one auditable rule instead of a list that needs a new line every
+time a tool is installed, and dot entries *below* the top level are still
+served, which is what keeps `.github/` inside a repository openable. The rule is
+per-root, because it would be wrong for a repository: `.gitignore` and
+`.env.example` are things you open on purpose.
+
+## What is never served, and what is served with a label
+
+**Never, at any depth, in any root:** `.git`, `.ssh`, `.gnupg`, and a list of
+build and cache directories. `.git` is the security one - it holds the object
+store and a config that can carry a credential. The rest are volume: tens of
+thousands of files nobody browses, which make the explorer useless and the
+listing slow. Both reasons matter.
+
+**Served, but labelled:** files matching the sensitive patterns - `.env`, keys
+and certificates, `*secret*`, `*password*`, `realm-*.json` and the rest. This
+changed on 2026-08-17 from a refusal to a label, and the argument is worth
+reading before assuming it was careless. This is one box, reached over a
+tailnet, owned by the person reading it, and a file explorer that hides the
+owner's own `.env` from them is not protecting anybody - it teaches them that
+Bothy cannot be trusted with the interesting half of the box.
+
+> [!warning] One consequence that is not "my box, my files"
+> `.env` contains `OAUTH2_COOKIE_SECRET`. Anyone who can read it can mint a
+> session cookie for any role, so on this deployment `viewer` is worth the same
+> as `operator`. That is fine while one person holds all four roles and it stops
+> being fine the moment a second person holds only `viewer`. If that day comes,
+> the answer is a role gate on the sensitive list, not a return to hiding files.
+
+There is a second list for patterns that describe a *word* rather than a file
+format. A documentation page called "Change Password.md" was being marked as a
+secret; `.md` and `.rst` are formats you write *about* credentials in, whereas
+`.txt` deliberately is not, because `db_password.txt` is exactly the shape of a
+file somebody leaves a credential in. And `.env.example` is explicitly exempt -
+it is the file you read to learn what to set, so marking it would be crying wolf
+on the one `.env`-shaped file that is safe by construction.
+
+## Reading
+
+The markdown reader is a **deliberately small hand-written subset**, built as
+React elements and never as an HTML string. That is what makes rendering
+arbitrary repository content safe with no sanitiser: there is no `innerHTML`
+anywhere, so every scrap of file content is escaped whether or not the parser
+understood it. Anything it does not understand falls through as literal text,
+and the Source toggle is one click away, so a mis-parse is cosmetic.
+
+What it renders: headings, fenced code with syntax highlighting, blockquotes,
+horizontal rules, lists, GFM tables, and inline code, emphasis, links and
+images.
+
+What it adds beyond that:
+
+- **Wikilinks.** `[[dns]]`, `[[network/dns]]`, `[[dns#ttl]]` and
+  `[[target|label]]`. They resolve against the index of documents that actually
+  exist - by exact path first, then by adding a known extension, then by
+  basename case-insensitively, preferring the shallowest match. A wikilink that
+  resolves to nothing renders inert with its target visible, and never as a live
+  button, because an unresolvable link rendered as resolved is the worst of the
+  three possible answers.
+- **Callouts.** `> [!note]`, `[!tip]`, `[!important]`, `[!warning]`,
+  `[!caution]`, with an optional title after the marker. Obsidian's syntax and
+  GitHub's, deliberately rather than an invented one: notes here are read in
+  this reader *and* elsewhere, and a note that renders as a panel in one and as
+  a literal `[!warning]` in the other is worse than plain prose in both.
+- **Backlinks and an outline**, and media rendered inline from disk. An image
+  becomes an image, an `.mp4` becomes a video and an `.mp3` becomes an audio
+  player - with controls, never autoplay, because a clip that starts itself in a
+  reading view is a jump-scare and, on a tailnet link, somebody's bandwidth. A
+  PDF or an HTML file stays inert on purpose: those are *document* contexts, and
+  the guarantee this renderer makes is meant to hold by reading this renderer.
+
+Three things it will not do, each on purpose:
+
+- **Raw HTML is never interpreted.** A line starting with a tag is consumed to
+  the next blank line and rendered as an inert chip naming the tag. Interpreting
+  it would mean turning file content into markup, which is the one thing this
+  renderer exists not to do. If you are writing documents to be read here, write
+  markdown, not HTML.
+- **Remote images do not load.** The content security policy blocks them, and
+  widening it would let any document in any root make the reader's browser talk
+  to a third party - on a box reached over a tailnet, an image tag is an
+  IP-address beacon. They render as a compact chip instead, which is what keeps
+  the top of a README with three badges in it from becoming a wall of query
+  strings.
+- **Mermaid is not executed**, for the same reason. A fence tagged `mermaid`
+  renders as what it literally is. Diagrams in this repository therefore live as
+  mermaid *sources* under `docs/diagrams/`, are rendered to SVG by
+  `just diagrams`, and are embedded as ordinary images - an SVG loaded through
+  an image element is an image context, with no script and no external
+  references, so the picture arrives with no new attack surface. A check
+  compares a hash the generator writes into the SVG, so a source and its picture
+  cannot drift.
+
+Reading requires the **`viewer`** role. That was not always true, and the change
+is documented at the top of
+[`edge/dynamic/portal-files.yml`](../../edge/dynamic/portal-files.yml): reads
+were open while the roots were two markdown trees of published documentation,
+and that reasoning died when the roots widened to "the box".
+
+## Searching, history and downloads
+
+Full-text search runs through the same walk the reader does - the same
+deny rules, the same per-root rules - and that sameness is a security property
+rather than an implementation detail. `safepath.collect()` is the **only** way
+the application can learn a set of paths, so a new endpoint inherits the rules
+by calling it rather than by its author remembering to.
+
+It was learned expensively twice. First a listing that did its own walk paid for
+30,093 refused files to serve 3,474. Then, when search was added, the same
+shortcut would have returned a matching **line** out of `.env` - the deny list
+would still have been correct, and the secret would still have been on screen.
+A check plants a credential-shaped token in three kinds of denied file and
+requires that only the served one comes back.
+
+Git history and a diff view are available per file where the root is a
+repository. `/git/diff` changes nothing, so it sits on the read router; the git
+*action* routes - stage, commit, pull, push - were removed on 2026-08-15 along
+with the tier they needed.
+
+Raw bytes and archive downloads are served on **`:8100`, never on `:80`**, and
+that is the security control rather than a deployment detail. A different port
+is a different origin, so a hostile SVG or PDF served there cannot read the
+portal's DOM or any response from the JSON API. Nothing else may ever be routed
+to that entrypoint. An unauthenticated download there gets a bare 401 rather
+than a sign-in page, deliberately: a login form rendered on the sandbox origin
+would be a document on the origin that exists to hold none.
+
+Reads are capped at one megabyte - a megabyte of markdown is already an
+unreasonable page. `/raw` is wider in bytes, because it sends binaries and files
+above that ceiling, but the file **set** is identical, since both go through the
+same resolver.
+
+## Writing
+
+Writing needs the **`editor`** role. A save writes straight to the working tree.
+There is no commit step; the git verbs were removed with the tier that gated
+them.
+
+Four things happen on every write, and none of them happens if you edit the same
+file another way:
+
+1. the **role gate** at the edge;
+2. a **conflict check** against the modification time the editor loaded, so a
+   stale tab cannot silently revert somebody's afternoon;
+3. a **snapshot of the outgoing bytes** - the last 20 states per file, kept 30
+   days;
+4. an **audit line** naming who did it, from the session rather than from
+   anything the browser sent.
+
+The snapshot directory is declared in policy and checked at startup like a root,
+because a snapshot directory that is not mounted would leave the undo net
+silently absent - and a safety net nobody notices is missing is worse than none
+at all.
+
+### There is no extension allowlist, and that was a decision
+
+There used to be one - markdown, text, SVG, HTML and a few others - justified as
+a blast-radius limit. It was removed on 2026-08-17, and the argument is the one
+worth carrying:
+
+> The allowlist did not stop the dangerous edit. It stopped the dangerous edit
+> from being **safe and attributed.**
+
+Bothy is dev-box tooling for the person who owns the box. If they want to edit a
+compose file and restart it, that is the job. A tool that refuses is a tool they
+work around with `vim`, which has none of the four properties above.
+
+What is still refused is different in kind: the deny list (files this service
+must never hand out at all, read or write), anything outside a root or reached
+through a symlink, the read-only roots, and anyone without the role.
+
+### In place of refusing, it tells you what will happen
+
+Every path can carry a **caution** - a level and a sentence, shown before the
+save. They refuse nothing. The notes say what breaks and how it is noticed,
+because a warning that does not name a consequence is decoration and it trains
+people to click past the ones that matter. A few, to give the shape:
+
+| You are editing | What it says |
+|---|---|
+| `edge/dynamic/*.yml` | a doubled brace, comments included, voids the whole file and nothing errors |
+| any `compose.yml` | a changed label or port does nothing until the container is **recreated**; editing is not applying |
+| `.env` | nothing is live until the stack is brought up again, and two values bite harder than the rest |
+| any `policy.toml` | this is the access model for the service about to write it, and it fails closed |
+| `scripts/**`, `justfile`, workflows | this is not configuration, it is code something will execute without asking again |
+| an HTML or SVG file | a script inside it runs in whatever application serves it, with that application's session |
+
+### What is genuinely missing
+
+If an edit breaks something, the repair paths are the snapshot and git, and both
+are file-level. **There is no terminal in Bothy** - `shell` is a role granted to
+nobody - so a change that stops a container from starting is repaired from a
+real shell on the box. That is the gap a terminal would close, and it is the
+honest reason to build one. See [Roles](roles.md).
+
+## Related
+
+- [Themes](themes.md) - the theme editor writes its file through this tier
+- [The files you will actually edit](configuring.md) - what those cautions are warning about
+- [`apps/portal-files/policy.toml`](../../apps/portal-files/policy.toml) - the policy itself, which is the reference for all of the above

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,0 +1,64 @@
+# The Bothy guide
+
+Bothy is a self-discovering console for one machine. This directory is the half
+of the documentation written for somebody who has **not** read the source: how to
+install it, which files you will actually end up editing, what the interface can
+and cannot do, who is allowed to do it, and how to make it look like yours.
+
+The reference documents stay where they are and are linked from here rather than
+restated. That is a rule and not a preference: this repository has twice shipped
+documentation describing services that had already been deleted, and a duplicated
+paragraph is a paragraph that goes stale in the copy nobody is looking at. Where
+a fact lives in a file, these pages name the file.
+
+## Where to start
+
+| If you want to | Read |
+|---|---|
+| get it running on a machine that has never had it | [Installing Bothy](installing.md) |
+| know which YAML is load-bearing, and what happens when you save it | [The files you will actually edit](configuring.md) |
+| use the thing - Overview, Control, the three verbs | [Operating it from the console](the-console.md) |
+| read, search and edit the box's own files from a browser | [Bothy Files](files.md) |
+| understand `viewer`, `editor`, `operator` and the role nobody holds | [Roles](roles.md) |
+| pick a theme, or write one | [Themes](themes.md) |
+
+## What is documented elsewhere, and why it stays there
+
+- The repository map, the three ideas the design rests on, and the traps that
+  cost real debugging time: [`README.md`](../../README.md).
+- The threat model - what "safe on a tailnet" does and does not mean, why the
+  socket proxy is protected by a network rather than a password, and what a
+  browser shell would cost before one exists:
+  [`SECURITY.md`](../../SECURITY.md).
+- The request path, the networks, the discovery join and the checklist for
+  adding a service: [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md).
+- Working on the code, the branch and commit rules, the portal's own test
+  suites: [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+- [`docs/kb/`](../kb/README.md) is deliberately **not** part of this guide. It is
+  one machine's operational history - real addresses, real incidents, runbooks
+  for that box. It is correct, and it is not user documentation.
+- [`docs/plans/`](../plans/reading-first.md) holds design arguments written
+  before the code. They are the best explanation of *why* several of the choices
+  below are what they are, and they are not kept in step with what shipped.
+
+## What this guide does not pretend
+
+- **Bothy is not a production platform.** Plain HTTP everywhere, one node, one
+  user, backups on the disk they protect. It is safe on a WireGuard tailnet and
+  it is not safe on a LAN or the internet. `SECURITY.md` argues this properly.
+- **There is no shell in the browser, and that is a decision.** `docker exec` is
+  root on the machine, so the Control tier has no `exec` verb and the `shell`
+  role is granted to nobody. See [Operating it from the console](the-console.md)
+  and [Roles](roles.md).
+- **Only three tiers are behind single sign-on.** Everything else - Grafana,
+  Prometheus, Keycloak's own console - carries its own login on one shared dev
+  credential, and the tailnet is the rest of the control. "SSO is running" does
+  not mean "this is behind SSO".
+
+## A note on addresses
+
+Every page here writes the machine's address as `<node-ip>`. Bothy publishes a
+host port per browser-facing service and is reached at
+`http://<node-ip>:<port>`; there is no name layer, and a `Host()` rule in
+Traefik would register happily and then match nothing, forever. `just urls`
+prints the real table on the box you are standing at.

--- a/docs/guide/installing.md
+++ b/docs/guide/installing.md
@@ -1,0 +1,280 @@
+# Installing Bothy
+
+Two supported paths. Both end at the same place: a checkout you can read, a
+`.env` full of secrets that were generated rather than typed, and about
+twenty-six containers running.
+
+The install is exercised on every pull request by
+[`.github/workflows/install.yml`](../../.github/workflows/install.yml) - clone
+into an empty directory, `cp .env.example .env`, `just up`, then every test
+suite in the repository run against the stack that came up. Nightly,
+[`.github/workflows/elsewhere.yml`](../../.github/workflows/elsewhere.yml) runs
+the same job at a path with a space in it and at a deeply nested path, because
+every portability bug this repository has had looked fine at exactly one path.
+
+## Before anything
+
+Bothy needs **docker with the compose v2 plugin, git, curl, python3 and
+openssl**. That list has one definition, in `check_prereqs()` in
+[`scripts/bothy`](../../scripts/bothy), and everything else asks that function
+rather than repeating it.
+
+- `just` is deliberately not in the list. `bothy init` installs it into
+  `~/.local/bin` for you; being the thing that removes that requirement is a
+  large part of why the CLI exists.
+- `jq` is optional and worth having. Without it `just doctor` reports less than
+  it should, and `scripts/bootstrap.sh` says so rather than staying quiet -
+  `doctor.sh` learned the hard way that a missing `jq` reads as a clean bill of
+  health.
+- Tailscale is not required. Without it Bothy resolves its own address to
+  `127.0.0.1`, which works and is reachable only from the machine itself.
+
+You can check the list before you have a checkout:
+
+```sh
+bothy doctor --pre
+```
+
+## Path A: you have git and you want to read the repository first
+
+```sh
+git clone https://github.com/YehudaBriskman/Bothy.git && cd Bothy
+cp .env.example .env
+just up
+just urls
+just doctor
+```
+
+**There is nothing to fill in.** Five credentials are generated for you - see
+*What gets generated, and what you must keep* below.
+
+## Path B: the installer, for a machine with no checkout at all
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/YehudaBriskman/Bothy/main/scripts/bothy.sh -o bothy.sh
+less bothy.sh
+sh bothy.sh
+```
+
+`curl … | sh` works too, and it is the convenience rather than the documented
+path. That ordering is argued at the top of
+[`scripts/bothy.sh`](../../scripts/bothy.sh) and again in
+[`SECURITY.md`](../../SECURITY.md): this ends at a program holding a Docker
+socket, which is root-equivalent on the machine, and a pipe from a URL to a
+shell should not be able to reach that in one step.
+
+What the installer actually does, and the list is short on purpose:
+
+1. checks that `git`, `curl` and `bash` exist - only those three, because it
+   delegates the full list to the checkout it is about to make;
+2. clones the repository and **verifies the tag against a commit id baked into
+   the script** (`BOTHY_PIN_VERSION` / `BOTHY_PIN_SHA`), refusing and deleting
+   its own clone if they disagree;
+3. copies `scripts/bothy` to `~/.local/bin/bothy` and records the checkout path
+   in `$XDG_CONFIG_HOME/bothy/config`, falling back to `~/.config`;
+4. prints `bothy init` - **and does not run it.**
+
+It never uses sudo, refuses to run under sudo, refuses a `BOTHY_DIR` outside
+`$HOME`, and writes exactly three paths. `sh bothy.sh --dry-run` names all of
+them and touches nothing.
+
+> [!note] Why a commit id and not a checksum
+> The release carries no assets of its own, and GitHub's auto-generated source
+> tarballs are not byte-stable - projects have published a checksum for one and
+> had it go wrong under them with no commit landing. A git commit id is already
+> a checksum over the whole tree, verified by git on every object it writes. It
+> proves the tree is the one this installer was published against. It proves
+> nothing about whether the installer itself is genuine, which is what reading
+> it first is for.
+
+Then, on the machine, having read what you are about to run:
+
+```sh
+bothy init            # defaults to ~/bothy
+```
+
+`init` re-runs the prerequisite check, clones if it has not already, installs
+`just`, copies `.env.example` to `.env`, runs `just up`, and finishes by
+printing `just urls`.
+
+## What `just up` does
+
+`up` depends on `bootstrap`, and that is load-bearing rather than tidy: on a
+fresh clone, four gitignored files that nothing creates are missing and
+Prometheus is started with `--web.config.file` pointing at one of them. The
+failure is not a message, it is a container that will not come up. The rule the
+repository states about itself applies - if a step can be forgotten, put it
+somewhere it cannot be skipped.
+
+[`scripts/bootstrap.sh`](../../scripts/bootstrap.sh) runs in three phases and
+prints `created` or `already present` for every action, so a second run is
+*seen* to be a no-op rather than assumed to be one:
+
+- **preflight** changes nothing and every failure names its fix;
+- **create** makes the directories the writing services need, including the two
+  snapshot directories that the file and config tiers refuse to start without;
+- **generate** writes the credentials and the two Prometheus files.
+
+Then the stack comes up in dependency order:
+`network`, `up-edge`, `up-data`, `up-auth`, `up-monitoring`, `up-apps`.
+
+Data before auth is a bug fix rather than a preference. Keycloak's database is
+created by a one-shot inside the *shared* Postgres, which lives in a different
+compose project, so `depends_on` cannot reach it and the script waits on
+`pg_isready` instead - and a wait cannot help when the thing waited for has not
+been started yet. On a genuinely fresh box with auth first, that one-shot spent
+a minute failing to resolve `postgres`, exited 2, and took `just up` with it. It
+never showed up on a developer machine because Postgres was already running from
+the previous `just up`, every time.
+
+> [!warning] Always `just`, never `docker compose` directly
+> `just` loads the root `.env` through `set dotenv-load`. `docker compose` looks
+> for a `.env` beside the compose file it was handed, finds none, and either
+> falls back to an insecure default or aborts on a required variable.
+
+## What gets generated, and what you must keep
+
+Five credentials are generated when they are blank or still hold a
+`.env.example` placeholder. The list has one definition, in
+[`scripts/lib/bootstrap-keys.sh`](../../scripts/lib/bootstrap-keys.sh), shared
+between `bootstrap` and the `up` recipe:
+
+| Key | What it is |
+|---|---|
+| `POSTGRES_PASSWORD` | the shared dev database |
+| `KEYCLOAK_DB_PASSWORD` | Keycloak's own database, in that same Postgres |
+| `OAUTH2_COOKIE_SECRET` | signs the SSO session cookie |
+| `KEYCLOAK_OAUTH2_CLIENT_SECRET` | the OIDC client secret, consumed at both ends |
+| `DEV_LOGIN_PASSWORD` | the password a human types |
+
+Bootstrap also resolves `BOX_IP` if it is still the shipped placeholder, and
+writes `PUID`/`PGID` when your uid is not 1000.
+
+Three properties are worth knowing before you go looking for a rotate button:
+
+- **The values are never printed.** Only key names. This runs in CI and into
+  scrollback that outlives the session.
+- **They are never overwritten, and `--force` does not change that.**
+  `POSTGRES_PASSWORD` and `KEYCLOAK_DB_PASSWORD` are baked into their database
+  volumes at first start, so regenerating one locks you out of your own data
+  with no error that mentions the script. Rotation is a real operation with a
+  real order, documented per key in [`.env.example`](../../.env.example).
+- **`.env` is gitignored and exists in exactly one place.** Losing it loses
+  every credential on the box. The nightly backup copies it; the backups sit on
+  the same disk they protect, which is not solved.
+
+`DEV_LOGIN_PASSWORD` is generated as 24 alphanumeric characters rather than
+base64, deliberately: it is the one a person types into a login form, far more
+often than it needs to be strong once, and a 44-character string containing `-`
+and `_` is a password people copy wrong.
+
+Two values you may still want to set, neither of which blocks a first start:
+
+- **`BOX_IP`** - the address this box answers on. Keycloak's issuer is built
+  from it, so changing it later means re-running `just up-auth` or every login
+  fails with a mismatch nobody can read from the error.
+- **`DEV_LOGIN_USER`** - your login, `dev@example.com` by default. It must be an
+  email address, because Keycloak here logs in by email and bootstrap refuses a
+  value without an `@` in it.
+
+## Reaching it
+
+```sh
+just urls
+```
+
+Start at `http://<node-ip>/`. Every browser-facing service publishes its own
+host port:
+
+| Port | Service |
+|---|---|
+| 80 | Traefik, which serves Bothy on the catch-all and the `/-/api/*` data plane |
+| 8100 | the sandbox origin - raw file bytes only, and nothing else may ever be routed here |
+| 8090 | Keycloak, admin console at `/admin` |
+| 3000 | Grafana |
+| 9090 | Prometheus |
+| 3100 | Loki - API only, a 404 at `/` is normal |
+| 8082 | cAdvisor |
+| 9100 | node-exporter |
+
+Postgres binds to loopback only and is never routed. Reach it over an SSH
+tunnel; `just urls` prints the command with the right address in it.
+
+> [!caution] A 200 proves nothing about routing
+> The portal's catch-all answers *every* unmatched request on `:80` with its own
+> HTML - from any hostname, from the bare IP, for any path no other rule matched.
+> A service you believe you routed can be dead while `curl` reports a cheerful
+> 200 and a page full of somebody else's markup. Assert on content, never on a
+> status code. `just verify` does exactly that.
+
+## Machines that are not WSL2 Ubuntu
+
+Bothy is built and run on WSL2 / Ubuntu 24.04 and CI installs it on
+`ubuntu-latest`. Two other shapes are coded for, and it is worth being precise
+about how well each is covered.
+
+**Ordinary Linux.** This is the case CI proves. What is genuinely WSL-specific
+is not Bothy but the host: WSL2 destroys its VM sixty seconds after the last
+Windows-side client disconnects, taking Docker and every container with it, so
+that box holds itself open with a Windows scheduled task. On a normal Linux
+machine none of that applies. The systemd units in
+[`host/`](../../host/README.md) - the nightly backup timer in particular - are
+copies of host configuration that git cannot see; nothing in `just up` installs
+them, so on a fresh machine the nightly backup does not exist until you install
+the timer yourself.
+
+**macOS.** Bothy claims macOS and CI never runs there, so read this as intent
+rather than as a tested guarantee. Three things are handled explicitly:
+
+- `scripts/bothy` avoids every bash 4 construct because macOS ships bash 3.2,
+  where an associative array or `${x,,}` fails at *parse* time and the error
+  names a line that looks fine. `scripts/checks/bash32.sh` enforces it.
+- `bootstrap` refuses a checkout outside `$HOME`, `/tmp`, `/private` or
+  `/Volumes`, because Docker Desktop only bind-mounts from a shared root and the
+  failure otherwise arrives at mount time with an error that never mentions file
+  sharing.
+- `PUID`/`PGID` are written from your own uid. The first macOS account is 501
+  and a GitHub runner is 1001; the three services that write into bind mounts
+  used to be hardcoded to `1000:1000`, which made Bothy installable only by
+  somebody who happened to *be* uid 1000. The failure was silent: the container
+  starts, its writes fail, and the tier looks broken.
+
+If you install as root, `PUID` deliberately stays 1000 and the bind-mounted
+directories are chowned instead. A root process holding container control is a
+straight path from "restart a container" to the host, and
+`apps/bothy-control/checks/grants.py` asserts that service is not root.
+
+## Living with it
+
+```sh
+bothy upgrade      # git pull --ff-only, then just up. No down, no -v.
+bothy download     # pre-fetch every image, so a later up needs no network
+bothy version      # what this checkout is
+just doctor        # containers, Prometheus targets, disk, backup freshness
+just verify        # 23 checks that the edge still routes the way it claims
+just portability   # what in the tree is tied to one machine
+```
+
+`bothy upgrade` deliberately has no `down` in it: the upgrade CI tier asserts
+that an upgrade preserves your data and does not recreate volumes, and a `down`
+would quietly break that. The CLI copy in `~/.local/bin` is a *copy*, not a
+symlink into the checkout, so re-run the installer to refresh it after an
+upgrade - a symlink would break the day somebody moved the checkout, with
+"command not found" for a program they can see on their PATH.
+
+Everything the CLI does not implement natively is handed straight to the
+justfile; `scripts/checks/cli-commands.sh` asserts every subcommand resolves to
+something that exists, so a renamed recipe fails CI instead of failing a person.
+
+## Removing it
+
+The installer's three paths - `~/.local/bin/bothy`, the checkout, and the config
+file - are all removable by hand. Containers and volumes are `just down` and, if
+you mean it, `just nuke`, which deletes every data volume and is the one recipe
+that asks for confirmation because it sits one keystroke from `just down` in the
+list.
+
+## Next
+
+- [The files you will actually edit](configuring.md)
+- [Operating it from the console](the-console.md)

--- a/docs/guide/roles.md
+++ b/docs/guide/roles.md
@@ -1,0 +1,212 @@
+# Roles
+
+Bothy has four roles: `viewer`, `editor`, `operator` and `shell`. They are flat
+and deliberately **non-composite** - holding one never implies another - because
+`shell` grants an arbitrary terminal and must never be reachable by holding one
+of the other three. Composites are how that happens by accident.
+
+They gate exactly three tiers. Everything else on the box is protected by the
+tailnet plus, where a service has one, its own login on the shared
+`DEV_LOGIN_*` credential. **"SSO is running" does not mean "this is behind
+SSO".**
+
+## What each role actually gets you
+
+| Role | What holding it lets you do, today |
+|---|---|
+| `viewer` | read through Bothy Files - browse, search, follow links, see history and diffs, download raw bytes and archives. Also read which compose fields are patchable in Settings |
+| `editor` | write and delete a file through Bothy Files, and patch a declared field through a Settings form |
+| `operator` | restart, stop and start a container |
+| `shell` | nothing. It is defined, granted to nobody, and referenced by no router |
+
+The Settings page renders `shell` as **"Granted to nobody"** rather than as an
+ordinary "Not held", because it is not an absence you can fix by asking. It is
+written as a condition rather than a constant, so if it is ever granted the page
+will say so rather than keep insisting.
+
+## Where each role is enforced
+
+Nine routers carry a role requirement, across three files in `edge/dynamic/`.
+The requirement lives in the **middleware**, not in the service, and the three
+middlewares are identical but for one word in a query string - which is the
+property that makes the design worth having: adding a tier is four lines of
+YAML, not another container.
+
+| Router | Role | Path |
+|---|---|---|
+| `portal-files-read` | `viewer` | roots, tree, read, search, links, history, repos, status, git diff |
+| `portal-files-download` | `viewer` | raw and archive, on the `:8100` sandbox entrypoint only |
+| `portal-files-write` | `editor` | write |
+| `portal-files-delete` | `editor` | delete |
+| `bothy-config-read` | `viewer` | config fields |
+| `bothy-config-write` | `editor` | config patch |
+| `bothy-control-restart` | `operator` | restart |
+| `bothy-control-stop` | `operator` | stop |
+| `bothy-control-start` | `operator` | start |
+
+Two structural choices in that table are worth reading rather than skimming.
+
+**Delete is `editor`, not a role of its own**, because removing a file *is* a
+write, and a separate role would be a second thing to grant, a second thing to
+revoke and a second thing to get wrong - for an action whose blast radius is
+smaller than an overwrite's, since the service refuses to delete unless the
+snapshot took a copy first. It still gets its **own router**: two rules that
+share a role today must not share it by accident tomorrow.
+
+**The three control verbs are three routers**, not one rule with three
+alternatives, for the same reason. The day `stop` needs a tier above `restart`,
+that is an edit to one router instead of a rule that has to be split first,
+under pressure.
+
+The middlewares themselves are defined next to what they gate, and that
+placement is itself an argument:
+
+- `sso-viewer` and `sso-editor` live in `edge/dynamic/portal-files.yml`;
+- `sso-operator` lives in `edge/dynamic/bothy-control.yml`;
+- `sso-errors` - which turns a bare 401 into a sign-in page - lives in
+  `edge/dynamic/auth.yml` and is borrowed by everything.
+
+The config tier borrows `sso-viewer` and `sso-editor` rather than defining its
+own copies. Traefik's file provider merges every file in the directory into one
+namespace, so two definitions of a middleware named `sso-editor` is a collision
+whose winner no single file can decide - and the two would then drift
+invisibly, with both routers still answering and one of them against the wrong
+role. The cost is real and is stated in the file: deleting `portal-files.yml`
+would silently unauthenticate the config tier's routers.
+
+`sso-operator` was deleted once, on 2026-08-15, along with the routes it gated,
+for a reason worth keeping: *a middleware nothing references is a loaded gun
+with no trigger - it looks like protection while protecting nothing, and the
+next router to want a gate might pick it up believing it is already proven in
+use.* It came back with the control tier, in the file that uses it.
+
+One more, for completeness: the plain `sso` middleware in `auth.yml` - the one
+that checks for *any* session rather than a role - is attached to **no router at
+all**. Only the three role-scoped variants are in use.
+
+## It fails closed, and that was verified before it was trusted
+
+Against a role the user does **not** hold:
+
+```
+allowed_groups=editor  -> 202   (they have it)
+allowed_groups=shell   -> 403   (nobody has it)
+allowed_groups=<junk>  -> 403   (fails closed)
+```
+
+`just files-check` re-runs that probe, so the property is tested rather than
+assumed. The third line is the one that matters most: because oauth2-proxy fails
+closed on a group nobody holds, a tier can ship **before** its role exists in
+the realm and refuse everybody rather than admit everybody. That is the safe
+direction to be wrong in, and it is how the control tier was released.
+
+## Where the roles come from
+
+Keycloak, in a container on `:8090`, in a realm called `devbox`. The four roles
+are declared in [`auth/realm-devbox.json`](../../auth/realm-devbox.json).
+Keycloak puts realm roles at a nested claim while oauth2-proxy reads a flat one,
+so a protocol mapper flattens them into `groups` - without it,
+`allowed_groups=operator` would silently match nothing.
+
+There is deliberately **no default-role block**, so a new user lands with zero
+capability and is granted roles explicitly.
+
+Who holds what is seeded by the `keycloak-init` one-shot in
+`auth/compose.yml`, which grants your `DEV_LOGIN_USER` **`viewer`, `editor` and
+`operator`, and never `shell`**. Without that step a fresh install refuses
+everyone: the realm file declares four roles and zero users, so every gated
+route would answer 403 to the only person who has just installed it, and the
+product would look broken rather than unconfigured.
+
+Two properties of that step you will meet eventually:
+
+- **The realm import is first-boot only.** Adding a user or a role to the JSON
+  on an existing install does nothing, silently. Anything that must be true on
+  both a new box and an old one belongs in the one-shot, which re-runs on every
+  `just up-auth`.
+- **Roles are re-asserted on every `just up-auth`; the password is not.**
+  Granting a role somebody already holds is a no-op, so re-running restores a
+  role revoked by accident in the console - the roles are declared in this
+  repository, not in a console. A password is the opposite: somebody who changed
+  theirs must not have it reset from under them.
+
+To grant or revoke by hand, use the admin console at
+`http://<node-ip>:8090/admin`, as `KEYCLOAK_ADMIN_USER` (`admin` by default)
+with `DEV_LOGIN_PASSWORD`. Remember that the next `just up-auth` re-grants the
+three seeded roles.
+
+## Three things that are not true, however they read
+
+**The interface is not the boundary.** `lib/me.ts` reads
+`/oauth2/userinfo` and the Settings page lists your roles, but that is a
+description of a token. Hiding a button is a courtesy that saves a round trip
+and turns a bare 403 into a sentence arriving before the click. Every decision
+is taken at the edge by a middleware reading a signed cookie that never trusts
+anything the browser says. If that file were ever the only thing standing
+between a user and an action, the action would be unprotected.
+
+**Identity headers are attribution, not permission.** The services name the
+commit author or the audit actor from `X-Auth-Request-Email`. Each of the three
+tiers strips every client-supplied `X-Auth-Request-*` header *before*
+`forwardAuth` runs, so the only one that can reach a service is the one
+oauth2-proxy produced. If that were missing, the worst case would be a forged
+*name* in a log, not an unauthorised action - which is exactly why it is defence
+in depth rather than the defence. It matters most on the control tier: a forged
+file write leaves a diff a human can read and revert, and a forged
+`stop postgres` is over before anybody reads anything.
+
+**`viewer` is not weaker than `operator` on this deployment.** Bothy Files
+serves `.env`, and `.env` contains the cookie secret. Anyone who can read it can
+mint a session for any role. That is a deliberate trade for a single-owner box
+and it is documented at the point it is made, in
+[`apps/portal-files/policy.toml`](../../apps/portal-files/policy.toml). It stops
+being acceptable the moment a second person holds only `viewer`.
+
+## The three sources do not agree, and here is how
+
+The roles are described in three places, and each is authoritative for a
+different question. They have drifted.
+
+**The realm** (`auth/realm-devbox.json`) is the definition. Its descriptions
+name capabilities that do not exist here:
+
+- `viewer` is described as *"Read-only: dashboards, logs, metrics, docs."*
+  Grafana and Prometheus are not behind SSO at all; they carry their own login,
+  so `viewer` grants nothing there. What it actually gates is the file tier and
+  the config tier's read.
+- `editor` is described as *"Can change content - wiki/docs pages,
+  dashboards."* The wiki was deleted on 2026-08-18, and no role gates a
+  dashboard. What it actually gates is a file write, a file delete, and a
+  config patch.
+- `operator` is described as *"Can act on the stack - restart containers,
+  silence alerts."* Restarting containers is right. Nothing anywhere silences an
+  alert.
+
+**The interface** (`ROLE_MEANING` in
+`apps/portal-next/web/src/lib/me.ts`) is the user-facing wording and is much
+closer, but it is scoped to the file tier and predates the config tier:
+`viewer` reads "browse files, search their contents, download bytes" and also
+gates reading config fields; `editor` reads "change a file on disk" and also
+gates deleting one and patching a compose label through a form.
+
+**The README** is the third, and it undercounts. Its single-sign-on table lists
+**three** routers, all in `portal-files.yml` - read, download and write -
+omitting `portal-files-delete`, omitting `/links` from the read router's paths,
+and omitting the config and control tiers entirely. The prose beside it says
+"three routers require a role today". Nine do.
+
+`SECURITY.md` disagrees with itself in the same way and in one section: the
+status blockquote at the top of § 1 correctly says *nine role-gated routers in
+three files*, and four paragraphs later the same section still says *"Three
+routers do now, all in `edge/dynamic/portal-files.yml`"*.
+
+The router table is the one that is true, because it is the one that runs. It
+is live at `http://<node-ip>/-/api/traefik/http/routers`, and there is no
+Traefik dashboard to check instead - it was deleted because it leaked a
+credential.
+
+## Related
+
+- [Operating it from the console](the-console.md) - what `operator` unlocks
+- [Bothy Files](files.md) - what `viewer` and `editor` unlock
+- [`SECURITY.md`](../../SECURITY.md) - the threat model, and the case for and against a `shell` role that does something

--- a/docs/guide/the-console.md
+++ b/docs/guide/the-console.md
@@ -1,0 +1,187 @@
+# Operating it from the console
+
+Bothy is the web application on `:80`. Open `http://<node-ip>/` and you land on
+the Overview; everything else is one of three top-level destinations.
+
+| Route | What it is |
+|---|---|
+| `/` | **Overview** - the box at a glance, and the front door |
+| `/control` | **Control** - triage, then Services, Ports, Routes and Topology in a left sidebar |
+| `/files` | **Bothy Files** - every document on the box, rendered. Its own page: [Bothy Files](files.md) |
+| `/settings` | reachable from the person menu rather than the nav |
+
+The nav carries three entries and not six on purpose. Services, Access and
+Topology were three renderings of **one dataset** holding three of five nav
+slots, which mis-states what the box contains; Files is a genuinely different
+dataset. The argument is in
+[`docs/plans/control-and-settings.md`](../plans/control-and-settings.md) § 2.
+Every retired URL still redirects, query string included, because this is a
+dashboard people deep-link to from notes and chat.
+
+## The Overview
+
+Ordered by the question it answers, largest type first:
+
+1. **A status line** - up, unknown and stopped against the number expected, plus
+   how many things want a look. This is the question the page exists for, so it
+   is first and biggest.
+2. **The attention strip** - what is actually wrong, and invisible when nothing
+   is. A section that disappears on a healthy box and cannot be missed on a sick
+   one; an empty triage panel is the report, not a design failure.
+3. **The system matrix** - one card per system, discovered from Docker.
+4. **Vitals** - CPU, memory and network, from Prometheus. Deliberately *below*
+   the health answer: a row of charts above it would be three pretty things
+   standing in front of the one sentence you came to read.
+5. **Open a UI**, **Data and disk**, and the busiest containers.
+
+**Everything on this page was discovered by asking Docker.** Bothy joins two
+read-only APIs, both proxied under its own origin: Traefik's router table is the
+skeleton, and the Docker socket proxy is enrichment. Either can die and the page
+still renders. Start any container and it appears within ten seconds with no
+edit to Bothy; stop it and its dot goes red just as fast.
+
+One consequence worth knowing before you file a bug: a route with no container
+is rendered loudly, as `unknown` with a "no container" badge, and it is not a
+mistake. There is deliberately **no browser-side reachability probe** - a
+cross-origin `fetch` returns an opaque response that resolves for *any* HTTP
+status, so an earlier version reported 502 and 401 as "up" and dead services
+rendered a green chip. Honest `unknown` beats a green lie.
+
+## Control
+
+`/control` opens on a triage page that says nothing at all when there is nothing
+to say. When there is, it names three classes of problem that appear nowhere
+else in one place:
+
+- **systems with something wrong**, grouped by system rather than by service,
+  because the answer to "what do I open" is a system page;
+- **port collisions** - the Ports table is sorted by port so two rows on the
+  same one are adjacent, but only if you went to look;
+- **a disabled router** - one badge in one column of a table nobody opens until
+  something is already broken.
+
+The sidebar holds Services (every container, with its status, image and ports),
+Ports, Routes (the live Traefik router table) and Topology, a lazily loaded 3D
+rack view.
+
+## The three verbs
+
+Bothy Control does exactly three things to a container:
+
+| Verb | What it means |
+|---|---|
+| `restart` | stop it and start it again. It keeps its configuration |
+| `stop` | leave it stopped. It will not come back until something starts it |
+| `start` | start a stopped container. It keeps the configuration it was created with |
+
+The affordance is one small trigger per row, not three buttons. Which verbs it
+offers depends on what the container is actually doing: a running container gets
+Restart and Stop, an exited one gets only Start, and a container Docker is
+flapping gets **Stop first**, because restarting something that is already
+restarting is the least useful thing you can do. Offering all three always would
+be simpler and worse - `Start` beside a running container is a button whose only
+outcome is a 409, and the interface knew that before the click.
+
+The result is reported as a **transition**: `from` state, `to` state, and how
+long the daemon took. Both inspects happen server-side rather than being left to
+the browser, because a UI that has to poll to find out what its own action did
+will show a spinner during the gap and guess wrong about a container that was
+already in the target state. `from == to` is a complete and honest answer.
+
+Acting requires the **`operator`** role. What the interface hides is never what
+the API enforces: the buttons are drawn inert without the role as a courtesy
+that turns a bare 403 into a sentence arriving before the click, and a
+hand-written `curl` is refused at the edge exactly the same way. See
+[Roles](roles.md).
+
+### Two refusals, and they are different in kind
+
+**Foot-gun warnings.** Seven containers carry a sentence said *before* the act,
+because stopping them takes away the page you are acting from - Traefik,
+`portal-next`, the socket proxy, `portal-files`, `bothy-config`, Keycloak and
+oauth2-proxy. Stopping Keycloak means nobody can sign in again, including you.
+These are warnings. You may proceed, and the interface says the sentence rather
+than overruling the decision.
+
+**Hard refusals.** Four containers cannot be stopped or restarted at all, and
+the rule that picks them is mechanical rather than a taste judgement:
+
+> A container is refused if stopping it prevents **this request** from
+> completing and reporting its own outcome.
+
+That comes out at exactly four - Traefik (the request arrived through it),
+`bothy-control` (the process holding the request), and its two socket proxies
+(one is how every action begins with an inspect, the other is the only path to
+the daemon at all). `apps/bothy-control/checks/grants.py` asserts the list is
+still four, so it cannot quietly grow or shrink.
+
+`start` is exempt from all of it. Starting something cannot remove a dependency
+- it is the recovery verb, and refusing it would refuse the recovery.
+
+The distinction is worth carrying: **the interface warns about what you might
+regret, and the service refuses what it cannot describe.** Conflating them is
+how a deny list turns into a list of things somebody once found scary.
+
+Every action, refusal and failure is appended to an audit log at
+`apps/bothy-control/audit/actions.log`, naming the actor from the session. It is
+bind-mounted so that a rebuild does not erase it.
+
+## What Bothy Control deliberately will not do
+
+There is **no `exec`**, and no shell in the browser. `docker exec` is root on
+this box, so the verb does not exist:
+
+- `EXEC: 0` is written out explicitly on all three socket proxies rather than
+  left to a default, each with the same comment - *container exec == root on
+  this box* - and `checks/grants.py` asserts both that the variable is present
+  and that its value is `0`;
+- the verb list is a literal three-element tuple in
+  [`apps/bothy-control/guard.py`](../../apps/bothy-control/guard.py), written
+  out and never derived from the handlers, because a derived allowlist grows
+  when the thing it is derived from grows;
+- `kill` is absent from that tuple and a check asserts it stays absent. This is
+  the interesting omission: the write proxy's `ALLOW_RESTARTS` flag grants
+  `kill` alongside `stop` and `restart` in one rule that cannot be split, so the
+  proxy would pass it and **that tuple is the only thing that refuses it**. The
+  proxy is a coarse grant; the guard is the fine one;
+- the `shell` role exists in the realm, is granted to nobody, and is referenced
+  by no router.
+
+Also out of scope, and staying there: `create`, `rm`, image pulls, volume and
+network management, anything under `/build`. Those are `just` recipes and a
+terminal.
+
+This is a real regression for anyone who used Portainer, which was deleted on
+2026-08-18, and it is stated rather than discovered later. The replacement is
+`docker exec` over Tailscale SSH. `just urls` prints the same sentence to
+whoever runs it, and
+[`SECURITY.md`](../../SECURITY.md) spends a whole section on what a browser
+shell would cost and the conditions under which it would be acceptable - written
+first, on its own, so the boundary can be argued with before any capability
+exists to point at as already done.
+
+Two more things went at the same time and are worth naming: image, volume and
+network management, which are the docker CLI; and a true streaming log tail -
+Bothy polls Loki over a range instead, which also means logs survive the
+container that produced them.
+
+## Settings
+
+Three groups, and only one of them changes anything:
+
+- **You** - who the session says you are, which of the four roles you hold, and
+  where the session came from. Read-only on purpose: all of it arrives with the
+  token and is changed in the realm, not here.
+- **Appearance** - the theme picker and the two ways to make one. This writes
+  one key to this browser's local storage. See [Themes](themes.md).
+- **Where these are kept** - which of the three stores holds what, and what is
+  not stored at all.
+
+The one rule to carry out of the roles panel: it is a description of a token,
+not a permission check. A role missing from that list has never stopped a
+request; it explains, in advance, the 403 that would have come back.
+
+## Next
+
+- [Roles](roles.md) - who may do which of the above
+- [Bothy Files](files.md) - the reading and editing tier

--- a/docs/guide/themes.md
+++ b/docs/guide/themes.md
@@ -1,0 +1,183 @@
+# Themes
+
+Bothy ships five themes and will load any number you add. A theme you add is
+**one `.css` file in one directory** - no rebuild, no npm, no restart, and it
+survives `docker compose up --build`, which replaces the image and everything in
+it.
+
+## Picking one
+
+The moon button in the topbar is the quick dark / light / system toggle.
+The full list is in **Settings → Appearance**, tagged so you can tell a theme
+Bothy ships from one that came off the disk.
+
+The five:
+
+| Theme | Appearance |
+|---|---|
+| Bothy Dark | dark - the default, neutral zinc, control-room contrast |
+| Bothy Light | light - the same palette re-measured for a white page |
+| Tokyo Night | dark |
+| Gruvbox | dark |
+| Catppuccin Latte | light |
+
+It was seven until 2026-08-18, and the two that went are a useful statement of
+the bar. Catppuccin Mocha and Nord were dropped because, measured in OKLCH
+across the three tokens that carry a theme's identity, they were not telling
+anyone apart from Tokyo Night - mocha against tokyo scored 0.0747 while every
+surviving pair is 0.34 or more. Three dark blue-violet themes at the same
+lightness is one theme and two near-misses. **The bar for adding one is that it
+is legibly different from all of these, not that somebody likes it.**
+
+Which theme you picked is remembered **in this browser only**. A theme you write
+is a file on the box, so every browser that reaches it sees the same one.
+
+## Two ways to make one, and they produce the same file
+
+Settings → Appearance offers both side by side, deliberately: the editor is not
+a lighter-weight alternative to writing the file, it is a preview attached to
+the same output.
+
+**In the theme editor** (`/settings/theme/new`). It starts from the theme you
+are looking at now - "begin with what you are looking at" needs no explanation,
+whereas seeding from a hard-coded palette would silently start you on Bothy Dark
+while the screen showed something else. Every change applies to the whole page
+as you type, so you are judging the real thing rather than a swatch in a corner.
+It is its own route rather than a dialog for exactly that reason, and a URL
+means an unfinished theme survives a reload.
+
+The editor has a form of grouped colour fields and a live CSS pane, and editing
+either updates the other, so the form and the file cannot disagree. Saving
+writes the file through Bothy Files and therefore needs the **`editor`** role;
+without it everything else on the page still works and the preview is still
+live, you just cannot write.
+
+**Or write the file.** Drop a `.css` into `apps/portal-next/data/themes/` on the
+box and reload. The filename is the theme's id, so renaming the file renames the
+theme - **the file is the registration**, because nginx lists the directory as
+JSON and there is no index to update and therefore none to forget.
+
+The format is documented where somebody standing in that directory will find it:
+[`apps/portal-next/data/themes/README.md`](../../apps/portal-next/data/themes/README.md).
+The short version is a header comment and a doubled attribute selector:
+
+```css
+/* bothy-theme
+   name: Deep Ocean
+   appearance: dark
+   note: One line, shown under the name in the picker.
+*/
+
+:root[data-bothy-theme='deep-ocean'][data-bothy-theme],
+[data-bothy-theme='deep-ocean'][data-bothy-theme] {
+  color-scheme: dark;
+
+  --bg: #0b1a24;
+  --fg: #dbe7ef;
+  --accent: #4bb3d4;
+}
+```
+
+The header is optional; a file with none still loads and takes its name from the
+filename. The attribute is doubled because `:root[data-theme='light']` and
+`:root[data-bothy-theme='x']` score the same specificity, so which one applied
+would come down to emission order - and Vite hoists and rewrites imports, which
+makes that a build detail rather than a decision. Doubling it wins from
+anywhere in the bundle. The second, bare selector is what lets the picker paint
+your theme's swatches while you are looking at a different one.
+
+`color-scheme` is the one line not to omit. It is what makes the browser paint
+scrollbars and form controls correctly, and Bothy reads it to decide whether to
+start you on the dark or light base before your stylesheet has finished loading.
+Without it you may see one frame of the wrong palette.
+
+## What the contract enforces
+
+The rules a palette must satisfy live in one module,
+[`apps/portal-next/web/src/lib/contract.ts`](../../apps/portal-next/web/src/lib/contract.ts),
+imported by **two** consumers: the build-time check that holds Bothy's own
+themes to them, and the editor, which runs them live as you type. One set of
+rules, because a rule that lives in the check and a rule that lives in the
+editor drift apart invisibly - the editor says a colour is fine, the check says
+it is not, and whichever you happened to run is the answer you believe.
+
+In the editor they are **advice, not a gate**. You can save a theme that breaks
+them. What they check:
+
+- **completeness** - every required token is declared. The required set is
+  *derived* from the base palette rather than listed, because the failure mode
+  of a hand-maintained list is silence: a missing token inherits the base
+  palette, which is how you get a Gruvbox page with one blue button on it;
+- **contrast** - foregrounds at 4.5:1 against **every** ground they are actually
+  painted on, not against one canonical background. That distinction found a
+  real bug immediately: two status foregrounds had been measured on a card while
+  being used mostly in the file explorer, which sits on a darker ground, so the
+  real ratios were about 0.35 lower than the ones written down and below the
+  floor;
+- **accent legality** - the five panel accents must stay at least 45 degrees of
+  hue from any chromatic status colour, or a coloured panel edge starts reading
+  as an alert;
+- **chart slots** inside a lightness band for the appearance, and clear of the
+  card behind them;
+- **the syntax palette, all or nothing.** A theme that restyles code must
+  declare every highlight token. Four of five is the bad case, because the fifth
+  silently comes from a palette chosen for a different background. It is not
+  hypothetical - a mutation renaming one of them passed every check that existed
+  at the time, which is how the rule got written.
+
+Three exemptions are recorded **with their reasons** rather than suppressed,
+because an exemption nobody can see is one nobody can argue with. Three
+light-mode status fills sit below the contrast floor on purpose: they are large
+solid areas beside a track, never small glyphs, and status is never encoded by
+colour alone.
+
+The three rules that matter most when you are actually picking colours - the
+five statuses are reserved, the five panel accents never encode state, and
+`--brand` is the deliberate exception to the second - are stated in full in the
+themes directory README linked above.
+
+## `--brand`, and why your old theme now looks incomplete
+
+`--brand` was added on 2026-08-19. Before that, the dot in the wordmark was
+painted with `--accent` - the token whose job is "this is interactive" and which
+every theme is entitled to repaint. So the mark that exists to say *which
+product this is* restated whatever hue the current theme had picked for its
+buttons: blue on Bothy Dark, blue-grey on Gruvbox, lavender on Catppuccin.
+
+It is a fifth colour job beside surface, status, chrome and chart. It is
+theme-tunable rather than one blessed hex, because no single value stays visible
+on both a near-black card and a white one - the light palettes take a darker
+rung of the same green ramp. The contract measures whatever it resolves to on
+each palette, at 3:1 rather than 4.5:1, because the dot is a filled circle a few
+pixels across: a mark on chrome, never text.
+
+It is **deliberately exempt from the accent hue rule**. Bothy's green sits 17
+degrees from the "up" status hue, so the mark would fail that rule outright. The
+rule exists so a coloured control cannot be misread as a state; the dot encodes
+nothing - it is the same dot on a page reporting five containers down, it never
+changes with state, and it is never beside a status glyph. Applying the rule
+there would not prevent a confusion, it would only forbid the brand from being
+green.
+
+> [!note] What this means for a theme you already wrote
+> A theme file written before 2026-08-19 does not declare `--brand`, so opening
+> it in the editor reports it as incomplete - one failing line, `missing 1`. The
+> theme still **renders** correctly: the mark simply inherits Bothy's green.
+> Set the token and save once and the warning clears.
+
+That gap is also why a companion rule exists, and it is worth knowing if you
+ever add a token to the palette: **every required token must appear in exactly
+one group in the editor's layout.** The editor renders a field only for tokens a
+group names, while the required set is derived from the live stylesheet - so a
+required token in no group is one the editor demands with nowhere to type it,
+and the completeness rule fails and hides every other finding behind it. The
+reading-scale tokens spent a release in exactly that state before being
+reclassified as structural, where they belonged.
+
+## Related
+
+- [`apps/portal-next/data/themes/README.md`](../../apps/portal-next/data/themes/README.md) - the file format, the token count, and the three colour rules in full
+- [`docs/brand/foundations/theming.md`](../brand/foundations/theming.md) - how light and dark coexist without a flash on load
+- [`docs/brand/reference/tokens.md`](../brand/reference/tokens.md) - the token reference
+- [`docs/brand/foundations/colour.md`](../brand/foundations/colour.md) - the palette, and what each colour job is for
+- [Bothy Files](files.md) - the tier the theme editor saves through


### PR DESCRIPTION
`docs/guide/` - seven pages that take a reader from "I cloned this" to "I
understand what I am running", written for somebody who has not read the source.

Everything the reading work was built to carry now exists. The corpus did not.

## The tree

| Page | Covers |
|---|---|
| `index.md` | the front door, and what is deliberately documented elsewhere |
| `installing.md` | prerequisites, both install paths, what `just up` does, the five generated secrets, reaching it, macOS and non-WSL2 Linux, upgrading, removing |
| `configuring.md` | which compose file, which `edge/dynamic/*.yml`, why there are zero `Host()` rules, the `dev.portal.*` labels, both `policy.toml` files, and what actually applies a change |
| `the-console.md` | Overview, Control, the three verbs, the two kinds of refusal, and the deliberate absence of `exec` |
| `files.md` | the four roots, what is never served vs served-with-a-label, the reader's markdown subset, and the four things a write gets that `vim` does not |
| `roles.md` | `viewer`/`editor`/`operator`/`shell`, the nine role-gated routers, and where the sources disagree |
| `themes.md` | picking one, the drop-in `.css` format, the editor, the contract, and `--brand` |

Everything **links down** into the existing reference documents instead of
restating them. Duplicated prose is prose that goes stale, and this repo has
been bitten by exactly that.

The install text is lifted from the `v2026.8.1` release notes, which were the
best getting-started prose in existence and were not in the repository.
`scripts/bothy` and `scripts/bothy.sh` were documented nowhere outside the CLI's
own `usage()`; the curl path is written as it ships, read-it-first order
included.

## Deliberately left to #104

**`README.md` is untouched.** Three things in it are wrong and are the other
stream's to fix, not mine:

- the recipe list and the `up` ordering still name **`up-mgmt`**, which was
  deleted with `mgmt/` on 2026-08-18. The real order is
  edge -> data -> auth -> monitoring -> apps, not edge -> auth -> monitoring ->
  data -> mgmt -> apps;
- the single-sign-on table lists **three** routers, all in `portal-files.yml`,
  and says "three routers require a role today". Nine do, across three files.
  It omits `portal-files-delete` entirely and omits `/links` from the read
  router's paths;
- the mermaid block says **7 routers** and the sentence under it says **10**.
  Neither matches the tree today - the invariant that is actually asserted is
  *zero `Host()` rules*, and the count moves as tiers are added.

`docs/ARCHITECTURE.md` and `docs/kb/` are untouched, as agreed.

## The role discrepancies

The four roles are described in three places, each authoritative for a different
question, and they have drifted. `docs/guide/roles.md` states this rather than
silently picking one.

**`auth/realm-devbox.json` (the definition) names capabilities that do not
exist here:**

| Role | The realm says | What is actually true |
|---|---|---|
| `viewer` | "Read-only: dashboards, logs, metrics, docs." | Grafana and Prometheus are not behind SSO at all - they carry their own login. `viewer` gates the file tier's reads and downloads, plus `bothy-config-read` |
| `editor` | "Can change content - wiki/docs pages, dashboards." | the wiki was deleted 2026-08-18 and no role gates a dashboard. `editor` gates file write, file delete, and config patch |
| `operator` | "Can act on the stack - restart containers, silence alerts." | restart/stop/start is right. Nothing anywhere silences an alert |
| `shell` | "HIGH PRIVILEGE: arbitrary terminal..." | agrees with everything else. No drift |

**`ROLE_MEANING` in `lib/me.ts` (the user-facing wording)** is much closer but
predates the config tier: `viewer` reads "browse files, search their contents,
download bytes" and also gates reading config fields; `editor` reads "change a
file on disk" and also gates deleting one and patching a compose label through
a form.

**`SECURITY.md` disagrees with itself inside one section.** The status
blockquote at the top of §1 correctly says *nine role-gated routers in three
files*; four paragraphs later the same section still says *"Three routers do
now, all in `edge/dynamic/portal-files.yml`"*.

The router table is the one that is true, because it is the one that runs.

## Other things found and not fixed

- **`apps/portal-next/web/src/pages/Settings.tsx`** says Keycloak's `/admin`
  "refuses without HTTPS on this box", and that is why it is not linked. It is
  no longer true: `keycloak-init` runs
  `kcadm.sh update realms/master -s sslRequired=NONE` and echoes "plain HTTP
  admin console over the tailnet". The admin console does answer over plain
  HTTP, and `just urls` and `README.md` both advertise it.
- **`docs/ARCHITECTURE.md` §6** still diagrams `redis_redis_data`,
  `kafka_kafka_data` and `mgmt_portainer_data` as backed-up or uncovered
  volumes. All three services were deleted, and their volumes with them.
- **A redaction artefact is baked into committed prose.** `SECURITY.md` has
  `http://a service hostname/oauth2/callback`, `discover.ts` has
  `tals.the name layer` and `a depth-1 host process (tals.the name layer)`, and
  `justfile`'s `urls` recipe says "Name-based routing ... DELETED" in a sentence
  that reads as though a word was substituted. Something once rewrote the old
  `.dev.test` spellings in place and left ungrammatical sentences behind.
- **`edge/dynamic/portal-files.yml` and `bothy-control.yml` both carry a real
  username** in their verification comments (`devssh has it`). It is not caught
  by `portability.sh`, which looks for home paths, tailnet addresses and
  addresses that resolve to a mailbox.
- **`scripts/backup.sh`'s redis step** still runs and always reports "redis not
  running - skipped". Known and documented in `README.md`; noting it because a
  first-time reader reads it as a fault.

## Checks

- `bash scripts/checks/portability.sh` - PASS, nothing newly tied to this
  machine. Every address in the guide is a `<node-ip>` placeholder.
- Every internal link resolves to a file that exists (checked mechanically, all
  49 of them).
- **No raw HTML anywhere**, and no line begins with `<`: the reader renders an
  HTML block as an inert `<tag> block` chip by design. Every table has
  consistent column counts, every fence is balanced, and every callout uses the
  `> [!kind]` form the reader understands. The pages also avoid the syntaxes the
  hand-written subset does not implement.
- The tree is a real test of the reader at size: ~1,430 lines of new markdown
  under a root `policy.toml` already makes browsable.

Closes #96
