### PR TITLE
fix(docs): three screenshots were deleted and ARCHITECTURE.md kept naming them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,15 @@ jobs:
         if: always()
         run: bash scripts/checks/diagrams.sh
 
+      # Three screenshots were deleted from docs/assets in 2500aa0 and
+      # ARCHITECTURE.md kept naming all three. A broken image is invisible in a
+      # diff, GitHub draws it as a grey box that reads like a slow load, and the
+      # in-app reader emits an <img> that never resolves - so the doc looked
+      # fine to everyone who did not scroll that far.
+      - name: Every relative link in the docs resolves
+        if: always()
+        run: bash scripts/checks/doc-links.sh
+
       # scripts/bothy.sh is what `curl … | sh` runs, and it verifies the clone
       # against a commit id written into itself. That is a third copy of what
       # VERSION and the tag already say: left behind, it installs an old release

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -415,11 +415,7 @@ service that publishes a port but has no router still appears - it is discovered
 from `/containers/json`, not from a route. The route table is no longer the
 skeleton it was; it is closer to a rib.
 
-![The portal overview](assets/portal-overview.png)
-
-![The Services page](assets/portal-services.png)
-
-![The portal topology view](assets/portal-topology.png)
+![The portal overview](assets/overview.png)
 
 It is a Vite + React app built to static files by a multi-stage image (node
 builds, nginx serves `dist/`), routed by the catch-all `PathPrefix(/)` at

--- a/scripts/checks/doc-links.sh
+++ b/scripts/checks/doc-links.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Every relative link and image in a tracked markdown file points at something.
+#
+# THE FAILURE THIS PREVENTS, which had already happened three times over.
+# `docs/assets/portal-overview.png`, `portal-services.png` and
+# `portal-topology.png` were deleted in 2500aa0 ("a README is not a changelog")
+# and docs/ARCHITECTURE.md kept referencing all three. Nothing noticed: a broken
+# image is invisible in a diff, GitHub renders it as a small grey box that reads
+# like a slow load, and the in-app reader renders an <img> that never resolves.
+# The doc looked fine to everyone who did not scroll to that section.
+#
+# It is the same shape as the other things this directory exists to catch - a
+# statement that stopped being true and had nobody checking it - and it gets
+# worse as the docs grow, which they just did.
+#
+# WHAT IT DELIBERATELY IGNORES, and why each one would otherwise cry wolf:
+#
+#   · anything with a scheme (http:, mailto:) - not this repo's to resolve.
+#   · bare `#anchor` links - a heading, not a path.
+#   · CODE. A path inside `backticks` or a fenced block is an EXAMPLE, and
+#     examples are written from the perspective of the file being described,
+#     not the file doing the describing. docs/plans/all-open-issues.md says
+#     `![x](brand/wordmark-dark.svg)` while describing a probe that ran from
+#     docs/ - correct prose, and a false positive for any checker that reads it
+#     as a link from docs/plans/. Stripping code first is not a convenience, it
+#     is the difference between a check people keep and one they switch off.
+#   · wikilinks [[name]] - the reader RESOLVES those by search rather than by
+#     path (see resolveWikiIn in pages/files/tree.ts), so "does this path exist"
+#     is the wrong question to ask about one.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1
+
+python3 - <<'PY'
+import os, re, subprocess, sys
+
+files = [f for f in subprocess.run(['git', 'ls-files', '*.md'],
+                                   capture_output=True, text=True).stdout.split()
+         if not f.startswith('.cleanup-trash/')]
+
+# Fenced blocks first, then inline spans - order matters, a fence can contain
+# backticks and stripping spans first would leave the fence markers behind.
+FENCE = re.compile(r'^```.*?^```', re.S | re.M)
+SPAN = re.compile(r'`[^`\n]*`')
+LINK = re.compile(r'!?\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)')
+
+fails = 0
+for f in files:
+    src = open(f, encoding='utf-8', errors='replace').read()
+    src = SPAN.sub(' ', FENCE.sub(' ', src))
+    for m in LINK.finditer(src):
+        target = m.group(1)
+        if re.match(r'^[a-z][a-z0-9+.-]*:', target) or target.startswith(('#', '//')):
+            continue
+        path = os.path.normpath(os.path.join(os.path.dirname(f), target.split('#')[0]))
+        if not os.path.exists(path):
+            print('FAIL  %-38s -> %s' % (f, target))
+            fails += 1
+
+print()
+if fails:
+    print('%d broken relative link(s). The target was renamed, moved or deleted' % fails)
+    print('and the document that names it was not updated.')
+else:
+    print('ok - every relative link and image in %d markdown files resolves' % len(files))
+sys.exit(1 if fails else 0)
+PY

--- a/scripts/checks/mutants.sh
+++ b/scripts/checks/mutants.sh
@@ -234,6 +234,15 @@ mutant "a diagram source drifts from its SVG" \
   "$FLOW_KW LR" \
   -- bash scripts/checks/diagrams.sh
 
+# The regression this was written for, replayed: point a doc at a screenshot
+# that was deleted two commits ago. `overview.png` exists, `portal-overview.png`
+# is one of three that went in 2500aa0 while ARCHITECTURE.md kept naming them.
+mutant "a doc points at a file that was deleted" \
+  docs/ARCHITECTURE.md \
+  'assets/overview.png' \
+  'assets/portal-overview.png' \
+  -- bash scripts/checks/doc-links.sh
+
 echo
 echo "── the path boundary ───────────────────────────────────────────────"
 # THE containment check. Resolve first, compare after. Deleting it is the whole


### PR DESCRIPTION
Found while verifying #129 on the live box — the reader showed three images that never resolved.

`docs/assets/portal-overview.png`, `portal-services.png` and `portal-topology.png` were deleted in `2500aa0` ("a README is not a changelog"). `docs/ARCHITECTURE.md` still referenced all three.

**Nothing noticed, and nothing could.** A broken image is invisible in a diff, GitHub draws it as a small grey box that reads like a slow load, and the in-app reader emits an `<img>` that never resolves. The document looked healthy to anyone who didn't scroll four hundred lines in.

The overview screenshot still exists under its current name, so that one is repointed. The Services page and topology view no longer exist as such — both moved under Control — so naming a screenshot of them would be worse than showing nothing.

## The durable half

`scripts/checks/doc-links.sh`: every relative link and image in every tracked markdown file must point at something. **Four were broken across seventy files**, and the docs tree is about to grow considerably.

**It strips code first, and that is the design decision in it.** A path inside backticks or a fence is an *example*, written from the perspective of the file being described rather than the file describing it. `docs/plans/all-open-issues.md` contains ``![x](brand/wordmark-dark.svg)`` while describing a probe that ran from `docs/` — correct prose, and a false positive for any checker that reads it as a link from `docs/plans/`.

My first version of this fix "corrected" that line and turned accurate prose into wrong prose. Stripping code is the difference between a check people keep and one they switch off.

Wikilinks are ignored deliberately: the reader resolves those by **search**, not by path (`resolveWikiIn` in `pages/files/tree.ts`), so "does this path exist" is the wrong question about one.

## Proven three ways

| case | result |
|---|---|
| a genuinely broken link | **FAIL** |
| the exact `2500aa0` regression replayed | **FAIL** |
| a broken link inside backticks | **passes** — no cry wolf |

`14 mutation(s) planted, every one caught.`