### PR TITLE
fix(auth): the realm described three roles by capabilities they never had

### DIFF
--- a/auth/realm-devbox.json
+++ b/auth/realm-devbox.json
@@ -20,17 +20,17 @@
     "realm": [
       {
         "name": "viewer",
-        "description": "Read-only: dashboards, logs, metrics, docs.",
+        "description": "Read the box: browse files, search their contents, download bytes, and read the config a service declares. Gates 3 routers (portal-files read + download, bothy-config read).",
         "composite": false
       },
       {
         "name": "editor",
-        "description": "Can change content - wiki/docs pages, dashboards.",
+        "description": "Change a file on disk, and patch a declared config field. Saves write straight to the working tree. Gates 3 routers (portal-files write + delete, bothy-config patch).",
         "composite": false
       },
       {
         "name": "operator",
-        "description": "Can act on the stack - restart containers, silence alerts.",
+        "description": "Act on what is running - restart, stop and start a service. Gates 3 routers, one per verb (bothy-control). There is no exec and no kill.",
         "composite": false
       },
       {


### PR DESCRIPTION
`auth/realm-devbox.json` is where the four roles are defined, and its descriptions are what **Keycloak's admin console shows anyone deciding what to grant**. All three non-`shell` roles named things that do not exist.

| role | claimed | reality |
|---|---|---|
| `viewer` | "dashboards, logs, metrics, docs" | Grafana, Prometheus and Loki are **not behind SSO at all** — they carry their own basic auth and no role gates any of them. `viewer` gates reading files and reading a declared config. |
| `editor` | "wiki/docs pages, dashboards" | the wiki was deleted 2026-08-18; no role gates a dashboard. `editor` gates write, delete, and config patch. |
| `operator` | "restart containers, **silence alerts**" | nothing on this box silences an alert. `operator` gates exactly three routers, one per verb. |

These were plausible **when they were written** — they describe the stack as it was planned rather than as it shipped — which is exactly why nobody re-read them.

Each now says what it gates and how many routers, so a reader can check it against `edge/dynamic/` instead of believing it. The wording follows `ROLE_MEANING` in `lib/me.ts`, which was already close to right, so the authoritative source and the user-facing one stop disagreeing.

`operator` also states there is **no `exec` and no `kill`** — the admin console is where somebody granting that role decides how much they are handing over, and it is the one place that fact was missing.

## Scope, and it is a real limit

The realm import is **first-boot-only**, and `keycloak-init` only *assigns* roles (`kcadm add-roles`) — it never creates or updates them. So this corrects **fresh installs**. An existing box keeps the old text in its admin console until the realm is reimported.

Syncing descriptions on every `just up-auth` would close that and is a larger change than this one — worth its own issue if the stale console text matters.