### PR TITLE
fix(settings): a token can be out of date with respect to the account

### DIFF
--- a/apps/portal-next/web/src/pages/Settings.tsx
+++ b/apps/portal-next/web/src/pages/Settings.tsx
@@ -362,6 +362,20 @@ function You({ me }: { me: Me }) {
           <ul className="roles">
             {ROLES.map((r) => <RoleRow key={r} role={r} held={me.roles.includes(r)} />)}
           </ul>
+          {/* A TOKEN CAN BE OUT OF DATE WITH RESPECT TO THE ACCOUNT, and nothing
+              here could tell. Realm roles arrive as a flat `groups` claim from a
+              protocol mapper, which means they are stamped into the token AT
+              SIGN-IN. Grant yourself a role afterwards and this page keeps
+              saying "not held" - correctly, about the token - while Keycloak
+              has already granted it. The 403 that follows is then unexplainable
+              from the one screen that exists to explain it.
+              Observed on this box: `operator` was granted by keycloak-init and
+              the live session, started earlier, did not carry it. */}
+          <p className="set-note">
+            This describes the token this browser is carrying, which was issued when you
+            signed in. A role granted to your account after that is not in it - sign out
+            and back in to pick one up.
+          </p>
         </div>
       </section>
     </>
@@ -429,8 +443,8 @@ function Session() {
             </span>
           </Field>
           <Field label="Enforced by">
-            <span className="mono">sso-viewer</span> and <span className="mono">sso-editor</span>,
-            forwardAuth middlewares at the edge
+            <span className="mono">sso-viewer</span>, <span className="mono">sso-editor</span> and{' '}
+            <span className="mono">sso-operator</span>, forwardAuth middlewares at the edge
             <span className="set-note">
               Not by this page. The list above describes your token; the refusal, when it comes,
               is decided before a request ever reaches an application.


### PR DESCRIPTION
Closes #128 — hit for real on this box today.

Realm roles reach the app as a flat `groups` claim from a protocol mapper, so they are stamped into the token **at sign-in**. Grant yourself a role afterwards and this page keeps saying `not held` — correctly, about the token — while Keycloak has already granted it.

**That gap is not cosmetic.** `operator` gates the whole control tier, one router per verb, so on a box where the role *has* been granted, restart/stop/start **403 with no explanation** — and the one screen that exists to explain a 403 says "not held".

Observed here: `keycloak-init` grants `viewer editor operator`, and a session started before that grant carried only the first two. After a sign-out and back in:

```
What you may do            3 held
viewer     HELD
editor     HELD
operator   HELD
shell      GRANTED TO NOBODY
```

## The fix, and what it deliberately is not

The page was already careful to say it describes a *token* rather than performing a check. What it could not say is that a token can be **stale**, and that signing out and in is the remedy. Now it does.

No new request and no new data path — a sentence on a read-only page, which is the honest minimum and fits the page's stated design. Detecting the drift properly would mean asking Keycloak what the account holds and comparing: a Keycloak read the portal does not make, through a route that does not exist. That is a feature and should be judged as one, not smuggled in behind a bug fix.

Also fixes "Enforced by", which named only `sso-viewer` and `sso-editor`. There are three middlewares, gating nine routers between them.

Verified on the live box after deploy — typecheck, build, `stray-colour`, and the offline check suite all clean.