### PR TITLE
feat(control): start the declared services the console could already act on

### DIFF
--- a/apps/bothy-control/checks/composeenv.py
+++ b/apps/bothy-control/checks/composeenv.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Read the shipped compose.yml without a YAML dependency.
+"""Read a compose file without a YAML dependency.
 
 Shared by checks/grants.py and checks/transition.py, and the sharing is the
 point rather than an economy. grants.py asserts what the socket-proxy grants
@@ -13,6 +13,16 @@ check that does not run on a fresh box. compose.yml's environment blocks are
 flat `KEY: value` lines under a known service, which this reads correctly - and
 a shape change it cannot handle surfaces as a missing key, which every caller
 asserts on, rather than as a proxy reported safe because no keys were found.
+
+── one reader, any file ────────────────────────────────────────────────────
+
+The module-level functions still read THIS service's compose.yml and are
+unchanged for their two callers. `Compose` is the same reader pointed at an
+arbitrary path, which grants.py uses to sweep every compose file in the
+repository for a socket proxy: the dangerous grant pair is a property of any
+proxy anybody adds, not of the two this directory happens to own, and a check
+that can only see its own file would report a clean boundary while a third proxy
+next door held POST=1 and CONTAINERS=1 together.
 """
 from __future__ import annotations
 
@@ -22,43 +32,71 @@ import re
 COMPOSE = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "compose.yml")
 
-with open(COMPOSE, encoding="utf-8") as _fh:
-    TEXT = _fh.read()
+
+class Compose:
+    """One compose file, read once."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        with open(path, encoding="utf-8") as fh:
+            self.text = fh.read()
+
+    def services(self) -> list[str]:
+        """Every service key, and ONLY service keys.
+
+        Scoped to the `services:` block rather than matched across the file,
+        because `networks:` and `volumes:` have 2-space children too - a bare
+        `^  (\S+):` would report `controlsocknet` as a service and then read an
+        empty environment off it, which is the shape of a proxy reported safe
+        because nothing was found.
+        """
+        m = re.search(r"^services:$", self.text, re.M)
+        if not m:
+            return []
+        rest = self.text[m.end():]
+        nxt = re.search(r"^\S", rest, re.M)
+        body = rest[: nxt.start()] if nxt else rest
+        return re.findall(r"^  ([A-Za-z0-9][A-Za-z0-9._-]*):\s*$", body, re.M)
+
+    def block(self, service: str) -> str:
+        """The lines of one service, from its 2-space key to the next top-level key."""
+        m = re.search(rf"^  {re.escape(service)}:$", self.text, re.M)
+        if not m:
+            raise SystemExit(f"FAIL: no service {service!r} in {self.path}")
+        rest = self.text[m.end():]
+        nxt = re.search(r"^(  \S|\S)", rest, re.M)
+        return rest[: nxt.start()] if nxt else rest
+
+    def env(self, service: str) -> dict[str, str]:
+        """The environment mapping of one service, comments stripped."""
+        b = self.block(service)
+        m = re.search(r"^    environment:$", b, re.M)
+        if not m:
+            return {}
+        rest = b[m.end():]
+        nxt = re.search(r"^    \S", rest, re.M)
+        body = rest[: nxt.start()] if nxt else rest
+        out: dict[str, str] = {}
+        for line in body.splitlines():
+            line = line.split("#")[0]
+            m2 = re.match(r"^      ([A-Z_][A-Z0-9_]*):\s*(\S*)\s*$", line)
+            if m2:
+                out[m2.group(1)] = m2.group(2)
+        return out
+
+    def container_name(self, service: str) -> str:
+        m = re.search(r"^    container_name:\s*(\S+)", self.block(service), re.M)
+        return m.group(1) if m else ""
+
+    def image(self, service: str) -> str:
+        m = re.search(r"^    image:\s*(\S+)", self.block(service), re.M)
+        return m.group(1) if m else ""
 
 
-def block(service: str) -> str:
-    """The lines of one service, from its 2-space key to the next top-level key."""
-    m = re.search(rf"^  {re.escape(service)}:$", TEXT, re.M)
-    if not m:
-        raise SystemExit(f"FAIL: no service {service!r} in {COMPOSE}")
-    rest = TEXT[m.end():]
-    nxt = re.search(r"^(  \S|\S)", rest, re.M)
-    return rest[: nxt.start()] if nxt else rest
-
-
-def env(service: str) -> dict[str, str]:
-    """The environment mapping of one service, comments stripped."""
-    b = block(service)
-    m = re.search(r"^    environment:$", b, re.M)
-    if not m:
-        return {}
-    rest = b[m.end():]
-    nxt = re.search(r"^    \S", rest, re.M)
-    body = rest[: nxt.start()] if nxt else rest
-    out: dict[str, str] = {}
-    for line in body.splitlines():
-        line = line.split("#")[0]
-        m2 = re.match(r"^      ([A-Z_][A-Z0-9_]*):\s*(\S*)\s*$", line)
-        if m2:
-            out[m2.group(1)] = m2.group(2)
-    return out
-
-
-def container_name(service: str) -> str:
-    m = re.search(r"^    container_name:\s*(\S+)", block(service), re.M)
-    return m.group(1) if m else ""
-
-
-def image(service: str) -> str:
-    m = re.search(r"^    image:\s*(\S+)", block(service), re.M)
-    return m.group(1) if m else ""
+# This service's own file, and the four functions its two callers already use.
+CONTROL = Compose(COMPOSE)
+TEXT = CONTROL.text
+block = CONTROL.block
+env = CONTROL.env
+container_name = CONTROL.container_name
+image = CONTROL.image

--- a/apps/bothy-control/checks/grants.py
+++ b/apps/bothy-control/checks/grants.py
@@ -35,6 +35,24 @@ file only accepts the second.
   socket         mounted :ro on both, and NOT mounted into bothy-control at all
   ports          no proxy publishes a host port
   names          compose's container_name values and guard.SEVERING agree
+  the repo       EVERY socket proxy in EVERY compose file here, not just these
+                 two - see below for why that is a different question
+
+── the sweep, and the issue that asked for it ──────────────────────────────
+
+Issue #91 wants the console to start a service from a compose file it has never
+run. Starting a container that EXISTS is /containers/<name>/start and needs
+nothing new. Starting one that does not exist is /containers/create, and the
+cheap way to reach that is one character: CONTAINERS: 0 -> 1 on the write proxy.
+Nothing would look different. Worse, done on a THIRD proxy in another file,
+every assertion above would still pass - they all name `socket-read` and
+`socket-write` - and the box would be one bind mount of / away from root.
+
+So the last section stops asking about those two by name and asks about every
+service in the repository that runs the socket-proxy image: does any of them
+hold POST=1 and CONTAINERS=1 together, and does any of them grant EXEC. Those
+questions have an answer for a proxy nobody has written yet, which is the only
+kind this file could not otherwise see.
 """
 import os
 import re
@@ -60,7 +78,7 @@ def ok(cond: bool, label: str) -> None:
 # also uses. Sharing the reader is deliberate: this file asserts what the grants
 # ARE and transition.py starts real proxies with those grants and asserts what
 # they DO, so the two must be looking at the same bytes read the same way.
-from composeenv import block, container_name, env  # noqa: E402
+from composeenv import Compose, block, container_name, env  # noqa: E402
 
 READ, WRITE, SVC_NAME = "socket-read", "socket-write", "bothy-control"
 
@@ -178,6 +196,80 @@ ok("kill" not in guard.VERBS,
    "kill is NOT in guard.VERBS - the proxy would pass it; this is the only gate")
 ok(set(guard.VERBS) == {"restart", "stop", "start"},
    f"guard.VERBS is exactly the three: {guard.VERBS}")
+
+print()
+print("── every socket proxy in this repository, by image ─────────────")
+#
+# NOT by service name and NOT by directory. The two proxies above are found by
+# the names this file already knows; a third one added anywhere in the tree is
+# found by the only thing it cannot avoid having, which is its image line. That
+# is what makes this section able to fail on code nobody has written yet.
+#
+# `.git` and `node_modules` are skipped: the first holds packed objects that are
+# not YAML, the second is somebody else's dependency tree. Neither can define a
+# container this box runs.
+SOCKET_IMAGE = "tecnativa/docker-socket-proxy"
+REPO = os.path.dirname(os.path.dirname(SVC))
+SKIP_DIRS = {".git", "node_modules", "dist", ".venv"}
+
+found: list[tuple[str, str, dict[str, str], str]] = []
+for walk_root, walk_dirs, walk_files in os.walk(REPO):
+    walk_dirs[:] = [d for d in walk_dirs if d not in SKIP_DIRS]
+    for fn in sorted(walk_files):
+        if not fn.endswith((".yml", ".yaml")):
+            continue
+        path = os.path.join(walk_root, fn)
+        try:
+            cf = Compose(path)
+        except OSError:
+            continue
+        # The image name appears in prose in three other files - dependabot's
+        # comment, portal-api.yml's, this one's - so the text match only decides
+        # whether the file is worth parsing. What SELECTS a service is its own
+        # `image:` line.
+        if SOCKET_IMAGE not in cf.text:
+            continue
+        for service in cf.services():
+            if not cf.image(service).startswith(SOCKET_IMAGE):
+                continue
+            found.append((os.path.relpath(path, REPO), service, cf.env(service),
+                          cf.block(service)))
+
+# A sweep that finds nothing reports "all clear", which is the silent pass this
+# repo keeps rediscovering. The floor is the three proxies that exist today: the
+# portal's read-only one and this service's pair. Fewer than three means the
+# walk, the extension filter or the image match stopped working - not that the
+# box got safer.
+ok(len(found) >= 3,
+   f"the sweep finds the socket proxies it is meant to find "
+   f"({len(found)}: {', '.join(f'{f}:{sv}' for f, sv, _, _ in found)})")
+
+for rel, service, e, blk in found:
+    where = f"{rel}:{service}"
+    # THE PAIR. Either flag alone is a proxy this repo already ships and trusts:
+    # POST=1 with CONTAINERS=0 is four verb paths, CONTAINERS=1 with POST=0 is a
+    # read-only inspect. TOGETHER they are every POST under /containers, because
+    # the granular ALLOW_* lines are `allow` rules and the broad `^/containers`
+    # rule sits below them with no deny in between - so /containers/create is
+    # permitted, and a create with a bind mount of / is root on this box.
+    ok(not (e.get("POST") == "1" and e.get("CONTAINERS") == "1"),
+       f"{where} does not hold POST=1 and CONTAINERS=1 together - that pair "
+       f"grants /containers/create (POST={e.get('POST')!r}, "
+       f"CONTAINERS={e.get('CONTAINERS')!r})")
+    # A proxy that says nothing about POST leaves its mutation surface to an
+    # image default, which is the one thing this whole file refuses to accept.
+    ok("POST" in e, f"{where} states POST explicitly")
+    # CONTAINERS is 0 by default in the image, but "we did not enable it" and
+    # "it is off" are different statements - and this is the flag whose absence
+    # would make the pair check above pass for the wrong reason.
+    ok("CONTAINERS" in e, f"{where} states CONTAINERS explicitly")
+    ok(e.get("EXEC") == "0",
+       f"{where} EXEC=0 - an exec into a container holding the docker socket is "
+       f"a host root shell, and every proxy here holds it")
+    ok("/var/run/docker.sock:/var/run/docker.sock:ro" in blk,
+       f"{where} mounts the docker socket READ-ONLY")
+    ok(not re.search(r"^    ports:", blk, re.M),
+       f"{where} publishes NO host port - reachability IS authorisation")
 
 print()
 if fails:

--- a/apps/portal-next/checks/declared-actions.mjs
+++ b/apps/portal-next/checks/declared-actions.mjs
@@ -1,0 +1,259 @@
+// What a declared project can be ACTED on - run with ./checks/run.sh
+//
+// WHY THIS EXISTS. Two modules that never import each other decide, between
+// them, whether a stopped project can be started from the console:
+//
+//   lib/projects.ts   folds each declared service into a node, and decides
+//                     whether that node carries a container at all
+//   lib/actions.ts    turns a node's status and its container's docker state
+//                     into the verbs the dialog offers
+//
+// The failure they combine to produce is silent in both halves. `withDeclared`
+// REMOVES the discovered node for every container a project declares, so if the
+// declared node that replaces it has no container, the row simply stops offering
+// Restart/Stop/Start - no error, no empty state, just a cell that used to have a
+// control in it. That is what shipped: declaring a project took the action tier
+// away from its own containers, and a stopped one had no way back.
+//
+// ── the security half, which is the reason the table is written this way ────
+//
+// The line these two modules must hold is not "offer a button". It is:
+//
+//     OFFER A VERB ONLY ON A CONTAINER DOCKER HAS ACTUALLY REPORTED.
+//
+// A declaration is a statement of intent - `project.dev.yml` names the container
+// a project WOULD create. Starting a container that exists is
+// /containers/<name>/start, which bothy-control performs and guard.VERBS allows.
+// Creating one that does not exist is /containers/create, which the write socket
+// proxy refuses by holding CONTAINERS=0, because a create with a bind mount of /
+// is root on this box (apps/bothy-control/compose.yml). So a declared name that
+// docker does not report must resolve to NOTHING, and the cases below assert
+// that from three directions: docker silent, name absent, name merely similar.
+//
+// The dockerReachable case is the one worth stating out loud. When the docker
+// call fails, api.ts still renders from the collector's file - and every
+// declared node must then carry no container, so the page offers no verb it
+// could not perform rather than a row of buttons that would 404.
+
+import { withDeclared } from './projects-mod.mjs';
+import { verbsFor } from './actions-mod.mjs';
+
+// nodeOf() builds a URL from `location.hostname` for a declared UI service that
+// is up. That is a browser global and this is node, so the one case that
+// exercises it needs a stand-in - without which this file would pass by never
+// reaching the branch.
+globalThis.location ??= { hostname: 'box.example' };
+
+let bad = 0;
+const check = (label, got, want) => {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  if (!ok) bad++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label.padEnd(56)}${ok ? '' : ` want=${JSON.stringify(want)} got=${JSON.stringify(got)}`}`);
+};
+
+/** A node as merge() builds one from /containers/json?all=1 - the only shape
+ *  this module reads a container out of. */
+const discovered = (name, state) => ({
+  id: `node:${name}`,
+  kind: 'unrouted',
+  name,
+  host: null,
+  aliases: [],
+  path: '/',
+  url: null,
+  browsable: false,
+  system: 'unmanaged',
+  group: 'unmanaged',
+  groupTitle: 'Unmanaged',
+  groupKind: 'infra',
+  parent: null,
+  depth: null,
+  order: 0,
+  hidden: false,
+  route: null,
+  container: {
+    id: `deadbeef-${name}`,
+    name,
+    image: 'alpine:3',
+    state,
+    statusText: state === 'running' ? 'Up 3 hours' : 'Exited (0) 2 days ago',
+    health: null,
+    labels: { 'com.docker.compose.project': 'cvops' },
+  },
+  ports: [],
+  status: state === 'running' ? 'up' : 'stopped',
+  serviceType: 'runtime',
+  volumes: [],
+  dependsOn: [],
+  completesOnPurpose: false,
+  uptimeSecs: null,
+  icon: 'server',
+  desc: '',
+  logs: null,
+});
+
+const project = (services, over = {}) => ({
+  key: 'cvops',
+  name: 'CVOps',
+  kind: 'project',
+  // NOT a path under /home. portability.sh refuses a hardcoded home directory
+  // anywhere in the tree, and a fixture is not exempt - the whole point of that
+  // check is that this repository runs on somebody else's machine.
+  root: '/opt/checkout/cvops',
+  start: 'just up',
+  state: 'stopped',
+  services,
+  ...over,
+});
+
+const declaredNode = (nodes, name) => nodes.find((n) => n.id === `declared:cvops:${name}`);
+
+console.log('── a declared service that names a live container ──────');
+
+{
+  // The container is RUNNING. Before this change the declared node replaced a
+  // perfectly actionable discovered node with one carrying `container: null`.
+  const nodes = withDeclared(
+    [discovered('cvops-api', 'running')],
+    [project([{ name: 'api', container: 'cvops-api', state: 'up' }])],
+  );
+  const n = declaredNode(nodes, 'api');
+  check('the declared node carries docker\'s container', n.container?.name, 'cvops-api');
+  check('  and docker\'s own state, not the collector\'s word', n.container?.state, 'running');
+  check('  and its image, so the row is not a dash', n.container?.image, 'alpine:3');
+  check('  so the dialog offers the two live verbs',
+    verbsFor(n.status, n.container?.state), ['restart', 'stop']);
+  // The whole point of dropping the discovered node is that the thing is not
+  // counted twice. That must still hold now that its container survives.
+  check('the container appears exactly once',
+    nodes.filter((x) => x.container?.name === 'cvops-api').length, 1);
+  check('the discovered node itself is gone',
+    nodes.some((x) => x.id === 'node:cvops-api'), false);
+}
+
+console.log('\n── THE ISSUE (#91): a declared container that is stopped ');
+
+{
+  // `docker ps -a` on this box carries containers `just up` does not manage,
+  // exited and startable. This is the case the console could not act on, and it
+  // needs no grant that does not already exist.
+  const nodes = withDeclared(
+    [discovered('cvops-worker', 'exited')],
+    [project([{ name: 'worker', container: 'cvops-worker', state: 'stopped',
+                detail: 'container exited(0)' }])],
+  );
+  const n = declaredNode(nodes, 'worker');
+  check('the stopped container is carried through', n.container?.name, 'cvops-worker');
+  check('  docker says exited, not the collector\'s "stopped"', n.container?.state, 'exited');
+  check('  so the dialog offers exactly Start',
+    verbsFor(n.status, n.container?.state), ['start']);
+  // `start` is the one verb guard.severed() never refuses, so this offer is
+  // never a button that cannot be pressed.
+  check('  and Start is a single verb, not a menu',
+    verbsFor(n.status, n.container?.state).length, 1);
+}
+
+console.log('\n── a declared container docker has never created ───────');
+
+{
+  // The other half of #91, and the half that stays unbuilt on purpose: this
+  // container does not exist, so starting it means creating it, and creating it
+  // is the call the two-proxy split exists to refuse.
+  const nodes = withDeclared(
+    [discovered('cvops-api', 'running')],
+    [project([{ name: 'db', container: 'cvops-postgres', state: 'stopped',
+                detail: 'container does not exist' }])],
+  );
+  const n = declaredNode(nodes, 'db');
+  check('no container is invented for a name docker never reported',
+    n.container, null);
+  // ActionCell renders nothing at all for a node with no container, which is
+  // the assertion behind the assertion: no affordance, rather than one whose
+  // only outcome is a refusal.
+  check('  the node is still listed, and still says stopped', n.status, 'stopped');
+}
+
+{
+  // Name SIMILARITY is not identity. Compose numbers its containers
+  // (`cvops-api-1`), so a declaration naming `cvops-api` must not resolve to it
+  // - the verb would be performed on a container nobody named.
+  const nodes = withDeclared(
+    [discovered('cvops-api-1', 'running')],
+    [project([{ name: 'api', container: 'cvops-api', state: 'unknown' }])],
+  );
+  check('a near-miss name resolves to nothing',
+    declaredNode(nodes, 'api').container, null);
+  check('  and the container it nearly matched keeps its own node',
+    nodes.find((x) => x.id === 'node:cvops-api-1')?.container?.name, 'cvops-api-1');
+}
+
+{
+  // Docker unreachable: api.ts passes an empty container list and still renders
+  // the collector's file. Every declared service must then carry no container.
+  const nodes = withDeclared(
+    [],
+    [project([{ name: 'api', container: 'cvops-api', state: 'unknown',
+                detail: 'docker is unreachable - container state unknown' }])],
+  );
+  check('docker unreachable offers no verb on anything',
+    nodes.every((n) => n.container === null), true);
+}
+
+console.log('\n── a declared HOST process has no container to act on ──');
+
+{
+  // A `just dev` harness is the reason the collector exists. It is not a
+  // container and there is nothing for docker to be asked about.
+  const nodes = withDeclared(
+    [discovered('cvops-api', 'running')],
+    [project([{ name: 'web', port: 3000, ui: true, state: 'up' }])],
+  );
+  const n = declaredNode(nodes, 'web');
+  check('a service declaring no container carries none', n.container, null);
+  check('  and is still reachable by its declared port',
+    n.url, 'http://box.example:3000');
+}
+
+console.log('\n── every state the collector emits has a portal word ───');
+
+// collect.py's docstring lists seven. Two of them - collision and unverified -
+// were absent from the union for months and fell through a `?? 'unknown'`
+// guard, which is exactly the drift a truth table written from the OTHER file's
+// documentation catches.
+const STATES = [
+  ['up', 'up'],
+  ['starting', 'starting'],
+  ['stopped', 'stopped'],
+  ['stuck', 'down'],
+  // Positive evidence the service is not running: the collector identified the
+  // listener on its port as something else. collect.py's rollup folds it in
+  // with stopped, and the service word has to agree with the project word.
+  ['collision', 'stopped'],
+  // Something is listening and the collector could not say what. A statement
+  // about its own knowledge - never a pass, and never a fault either.
+  ['unverified', 'unknown'],
+  ['unknown', 'unknown'],
+];
+for (const [state, want] of STATES) {
+  const nodes = withDeclared([], [project([{ name: 's', state }])]);
+  check(`collector "${state}" reads as "${want}"`, declaredNode(nodes, 's').status, want);
+}
+
+// A state nobody has written down yet must not become a green dot. This is the
+// guard that let the two missing states above go unnoticed, and it stays.
+{
+  const nodes = withDeclared([], [project([{ name: 's', state: 'invented-later' }])]);
+  check('an unknown state falls back to unknown, never up',
+    declaredNode(nodes, 's').status, 'unknown');
+}
+
+console.log('\n── nothing declared changes nothing ────────────────────');
+
+{
+  const input = [discovered('grafana', 'running')];
+  check('no projects returns the discovered list untouched',
+    withDeclared(input, []) === input, true);
+}
+
+console.log(bad ? `\n${bad} FAILED` : '\nall pass');
+process.exit(bad ? 1 : 0);

--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -48,6 +48,28 @@ mv "$OUT/start.js" "$OUT/start-mod.mjs"
 (cd "$WEB" && npx tsc src/lib/contract.ts --ignoreConfig \
   --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
 mv "$OUT/contract.js" "$OUT/contract.mjs"
+# projects.ts and actions.ts, compiled for the declared-actions check: it asserts
+# a property the two produce JOINTLY - which declared nodes carry a container, and
+# therefore which verbs a row offers - and neither file can be asked that alone.
+#
+# projects.ts carries a TYPE-only import from discover.ts. tsc erases it from the
+# output, so the .mjs really does import nothing at runtime, but it still COMPILES
+# discover.ts alongside and drops a second discover.js here. Nothing imports it -
+# the copy the checks use was renamed to discover.mjs four lines up - but it is
+# worth knowing about before somebody reads this directory and wonders which of
+# the two is live.
+(cd "$WEB" && npx tsc src/lib/projects.ts --ignoreConfig \
+  --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
+mv "$OUT/projects.js" "$OUT/projects-mod.mjs"
+# `--types vite/client` for THIS one only. actions.ts reads `import.meta.env.DEV`
+# to keep a dev tab from acting on the live daemon, and without vite's ambient
+# types a bare tsc fails with TS2339 on `env` - which under `set -e` and the
+# >/dev/null above is an empty log and an exit 2. It types the compile; it changes
+# nothing about the emitted module, and the check below never calls act().
+(cd "$WEB" && npx tsc src/lib/actions.ts --ignoreConfig \
+  --module esnext --target es2022 --moduleResolution bundler \
+  --types vite/client --outDir "$OUT" >/dev/null)
+mv "$OUT/actions.js" "$OUT/actions-mod.mjs"
 (cd "$WEB" && npx tsc src/lib/customThemes.ts --ignoreConfig \
   --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
 mv "$OUT/customThemes.js" "$OUT/user-themes-mod.mjs"
@@ -62,7 +84,7 @@ mv "$OUT/pages/files/tree.js" "$OUT/wikilinks-mod.mjs"
 cp "$HERE/status-classifier.mjs" "$HERE/relations.mjs" "$HERE/redirect-table.mjs" \
    "$HERE/titles-table.mjs" "$HERE/theme-contract.mjs" "$HERE/user-themes.mjs" \
    "$HERE/wikilinks.mjs" "$HERE/repo-roots.mjs" "$HERE/grouping.mjs" \
-   "$HERE/start-table.mjs" "$OUT/"
+   "$HERE/start-table.mjs" "$HERE/declared-actions.mjs" "$OUT/"
 
 echo "── truth table ─────────────────────────────────────────"
 node "$OUT/status-classifier.mjs"
@@ -94,6 +116,15 @@ echo "── where this repo is, asked of docker not assumed ─────"
 # prefix of it, nothing mounted yet - which is precisely what could not be tested
 # while the value was a literal.
 node "$OUT/repo-roots.mjs"
+
+echo
+echo "── what a declared project can be acted on ─────────────"
+# The two modules that decide, between them, whether a stopped project can be
+# started from the console - and the line they must hold: a verb is only ever
+# offered on a container docker has actually reported. A declared name docker
+# does not know would have to be CREATED, and /containers/create is the one call
+# apps/bothy-control's two-proxy split exists to refuse.
+node "$OUT/declared-actions.mjs"
 
 echo
 echo "── what a system IS vs where it is SHOWN ───────────────"

--- a/apps/portal-next/web/src/lib/projects.ts
+++ b/apps/portal-next/web/src/lib/projects.ts
@@ -18,9 +18,14 @@
 // app (systems rollup, Overview, Services, Topology) needs no special case: a
 // declared service is just another node with a group.
 
-import type { PortalNode, Status, ServiceType } from './discover';
+import type { PortalNode, Status, ServiceType, NodeContainer } from './discover';
 
-export type CollectorState = 'up' | 'starting' | 'stopped' | 'stuck' | 'unknown';
+// ALL SEVEN THE COLLECTOR CAN EMIT. `collision` and `unverified` were missing
+// here while collect.py has emitted both since the port probe learned to identify
+// its listener, so they fell through the `?? 'unknown'` guard below - which is
+// why nothing broke, and why nothing said they were unhandled either.
+export type CollectorState =
+  | 'up' | 'starting' | 'stopped' | 'stuck' | 'collision' | 'unverified' | 'unknown';
 
 export interface CollectorService {
   name: string;
@@ -60,6 +65,16 @@ const STATE_TO_STATUS: Record<CollectorState, Status> = {
   starting: 'starting',
   stopped: 'stopped',
   stuck: 'down',
+  // `collision` is POSITIVE evidence that this service is not running - the
+  // collector identified the listener on its port as something else - so it is
+  // off, not unmeasured, and the project rollup in collect.py already folds it in
+  // with stopped. Reading it as `unknown` here made the service word disagree with
+  // the project word about the same fact.
+  collision: 'stopped',
+  // `unverified` is the opposite: something is listening and the collector could
+  // not say what. That is a statement about its own knowledge, and `unknown` is
+  // the portal's word for exactly that.
+  unverified: 'unknown',
   unknown: 'unknown',
 };
 
@@ -70,7 +85,47 @@ const KNOWN_TYPES = new Set<ServiceType>([
 const serviceTypeOf = (t?: string | null): ServiceType =>
   t && KNOWN_TYPES.has(t as ServiceType) ? (t as ServiceType) : 'runtime';
 
-function nodeOf(project: CollectorProject, svc: CollectorService): PortalNode {
+/**
+ * The live container behind a declared service, or null when there is not one.
+ *
+ * THIS IS THE WHOLE OF #91 THAT CAN BE BUILT SAFELY, and it is worth saying why
+ * it is a lookup rather than a start button of its own.
+ *
+ * A declared service names a container in `project.dev.yml`. That name is a
+ * DECLARATION - it says what the project would create, not what exists. Docker's
+ * own list (fetched with `?all=1`, so it carries stopped containers too) is the
+ * only thing that can say whether the container is actually there, and the two
+ * answers lead to two different products:
+ *
+ *   · the container EXISTS and is stopped -> `/containers/<name>/start`, which
+ *     `bothy-control` already performs and `guard.VERBS` already allows. No new
+ *     grant, no new verb, no new route. The affordance is the only thing missing.
+ *   · the container DOES NOT EXIST -> creating it is `/containers/create`, which
+ *     the write socket proxy refuses by holding CONTAINERS=0, on the grounds that
+ *     a create with a bind mount of `/` is root on this box
+ *     (apps/bothy-control/compose.yml). Bothy cannot do it and must not learn to.
+ *
+ * So this returns null in the second case, `nodeOf` leaves `container` null, and
+ * ActionCell draws nothing - which is the honest answer rather than a button
+ * whose only possible outcome is a refusal.
+ *
+ * THE LOOKUP IS EXACT, and that is a boundary rather than a detail. Compose
+ * numbers its containers (`cvops-api-1`), so a declaration naming `cvops-api`
+ * must resolve to nothing rather than to the nearest thing with that prefix -
+ * matching loosely here would aim a verb at a container nobody named.
+ */
+export function liveContainer(
+  svc: CollectorService,
+  live: ReadonlyMap<string, NodeContainer>,
+): NodeContainer | null {
+  return svc.container ? live.get(svc.container) ?? null : null;
+}
+
+function nodeOf(
+  project: CollectorProject,
+  svc: CollectorService,
+  live: ReadonlyMap<string, NodeContainer>,
+): PortalNode {
   const status = STATE_TO_STATUS[svc.state] ?? 'unknown';
   // Only offer a link to something actually listening - a link to a stopped
   // port is a browser error page dressed up as a feature.
@@ -102,7 +157,25 @@ function nodeOf(project: CollectorProject, svc: CollectorService): PortalNode {
     order: 0,
     hidden: false,
     route: null,
-    container: null,
+    // THE CONTAINER DOCKER REPORTS, NOT A STUB BUILT FROM THE DECLARATION.
+    //
+    // This field used to be a flat `null`, and that deleted an affordance the
+    // declaration was supposed to add: `withDeclared` removes the discovered node
+    // for every container a project declares, so declaring a project TOOK AWAY the
+    // restart/stop/start control its containers had before it was declared, and
+    // left a stopped one with no way back at all. The row for a container docker
+    // was holding, exited, said "nothing to act on".
+    //
+    // Carrying docker's own object also gives ServiceActions the second argument
+    // it has always wanted: `verbsFor(status, container.state)` reads `exited` and
+    // offers Start, where the collector's five words could only say `stopped`.
+    //
+    // Only `container` is taken from discovery. Everything else on this node -
+    // identity, grouping, display name, ports, description - stays the
+    // declaration's, because that is what the declaration is FOR. `dependsOn`
+    // stays empty even though the labels to fill it now arrive with this
+    // container; see the note on that field.
+    container: liveContainer(svc, live),
     // A declared host port is bound by a process on this box, not published by
     // docker, so it is loopback-scoped from the portal's point of view.
     ports: svc.port
@@ -111,12 +184,18 @@ function nodeOf(project: CollectorProject, svc: CollectorService): PortalNode {
     status,
     serviceType: serviceTypeOf(svc.type),
     volumes: [],
-    // A declared host process has no compose labels, so there is nothing to read
-    // an edge from - and nothing to declare it a one-shot either. Empty here is
-    // "nobody wrote it down", not "it has no dependencies". `project.dev.yml`
-    // could grow a `dependsOn:` key and feed this the same way compose does; it
-    // does not have one today, and inventing edges from the service list would
-    // be exactly the inference this work exists to remove.
+    // Empty here is "nobody wrote it down", not "it has no dependencies".
+    // `project.dev.yml` could grow a `dependsOn:` key and feed this the same way
+    // compose does; it does not have one today, and inventing edges from the
+    // service list would be exactly the inference this work exists to remove.
+    //
+    // NOT read off the container above, now that there is one. A declared
+    // service's container is present or absent depending on whether anybody has
+    // run the project, so edges derived from its compose labels would appear and
+    // vanish with it - a wiring diagram that changes shape when a container is
+    // removed is describing the daemon, not the project. resolveEdges() keys its
+    // lookup table on those labels either way, so a declared node can still be
+    // the far end of somebody else's edge; it just never claims one of its own.
     dependsOn: [],
     completesOnPurpose: false,
     uptimeSecs: null,
@@ -133,6 +212,12 @@ function nodeOf(project: CollectorProject, svc: CollectorService): PortalNode {
  * mpeg-keycloak are started by `docker run` with no compose labels, so discovery
  * files them under 'unmanaged' infra. The declaration knows they belong to their
  * project, and keeping both copies would double-count them in every total.
+ *
+ * It wins on IDENTITY, not on FACTS. The discovered node is dropped, but the
+ * container it carried is handed to the declared node that replaced it - see
+ * `liveContainer`. Before that, "wins" meant the container was thrown away along
+ * with the node, and declaring a project silently disabled the one tier that can
+ * act on it.
  */
 export function withDeclared(nodes: PortalNode[], projects: CollectorProject[]): PortalNode[] {
   if (!projects.length) return nodes;
@@ -142,7 +227,14 @@ export function withDeclared(nodes: PortalNode[], projects: CollectorProject[]):
     for (const s of p.services) if (s.container) claimed.add(s.container);
   }
 
+  // Built from the nodes BEFORE the filter below, and from every node rather than
+  // only the claimed ones: a declaration that names a container docker has never
+  // created must find nothing here, and the only way to be sure of that is to look
+  // at the whole list docker actually returned.
+  const live = new Map<string, NodeContainer>();
+  for (const n of nodes) if (n.container?.name) live.set(n.container.name, n.container);
+
   const kept = nodes.filter((n) => !(n.container?.name && claimed.has(n.container.name)));
-  const declared = projects.flatMap((p) => p.services.map((s) => nodeOf(p, s)));
+  const declared = projects.flatMap((p) => p.services.map((s) => nodeOf(p, s, live)));
   return [...kept, ...declared];
 }

--- a/apps/portal-next/web/src/pages/Detail.css
+++ b/apps/portal-next/web/src/pages/Detail.css
@@ -187,3 +187,15 @@
 /* In a header there is no row to hover, so the reveal that the table relies on
    never fires. It is simply visible here. */
 .detail-head-actions .svc-act-btn { opacity: 1; width: 30px; height: 30px; }
+
+/* ── starting what has never been started ──────────────────────────────────
+   The panel that says which declared services Bothy cannot start and prints the
+   command that can. Text and one code block, no controls: there is deliberately
+   nothing here to press, because pressing it would mean /containers/create. */
+.detail .start-why, .detail .start-run, .detail .start-where, .detail .start-warn {
+  margin: 0; max-width: 74ch; font-size: 13.5px; line-height: 1.6; color: var(--fg-muted); }
+.detail .start-run { margin-top: 14px; color: var(--fg); }
+.detail .start-cmd { display: block; margin: 8px 0; padding: 10px 13px;
+  background: var(--surface-2); border: 1px solid var(--line); border-radius: var(--r-lg);
+  color: var(--fg); font-size: 13px; overflow-x: auto; white-space: pre; }
+.detail .start-warn { margin-top: 14px; color: var(--st-warn); }

--- a/apps/portal-next/web/src/pages/ProjectDetail.tsx
+++ b/apps/portal-next/web/src/pages/ProjectDetail.tsx
@@ -88,6 +88,40 @@ export function ProjectDetail() {
 
   const sections = useMemo(() => groupByType(nodes), [nodes]);
 
+  // WHAT BOTHY CANNOT START, and the command that can.
+  //
+  // The action tier acts on CONTAINERS: a declared service whose container
+  // exists is one POST away from running, and its row carries the control that
+  // does it. A declared service with no container is a different thing entirely -
+  // starting it means CREATING it, which is /containers/create, which the write
+  // socket proxy refuses by holding CONTAINERS=0 so that a compromise of the
+  // console cannot build a privileged container (apps/bothy-control/compose.yml).
+  //
+  // So the page says so, and prints the command the project declared for itself.
+  // The alternative shapes were both worse: a Start button that 403s teaches
+  // people to distrust the buttons, and silence leaves the reader to work out
+  // why some rows have a control and others do not.
+  const declaredProject = useMemo(
+    () => data.projects.find(
+      (p) => p.key === system?.key || (system?.identities ?? []).includes(p.key),
+    ),
+    // `system` rather than its two fields: identities is a fresh array on every
+    // poll, so listing it here would recompute this on every render anyway while
+    // reading as though it did not.
+    [data.projects, system],
+  );
+  // Only services this page cannot act on AND that are not already running. A
+  // declared host process (a `just dev` harness) has no container either and
+  // belongs here for the same reason: it is started by the same command.
+  //
+  // The `declared:` prefix is the id nodeOf() builds in lib/projects.ts - it is
+  // what separates a declared service from a discovered container that happens
+  // to be filed under the same system.
+  const unstartable = nodes.filter(
+    (n) => n.id.startsWith('declared:') && !n.container
+      && n.status !== 'up' && n.status !== 'starting',
+  );
+
   const rise = (i: number) =>
     reduce
       ? {}
@@ -250,6 +284,52 @@ export function ProjectDetail() {
               <TabPanel tabKey="ports" active={reach === 'ports' && ports.length > 0}>
                 <PortsTab ports={ports} query="" compact />
               </TabPanel>
+            </div>
+          </motion.section>
+        )}
+
+        {/* Starting what has never been started - the honest half of #91.
+            Only when there is something here Bothy genuinely cannot start; a
+            project whose containers all exist has nothing to read and gets no
+            panel. */}
+        {declaredProject?.start && unstartable.length > 0 && (
+          <motion.section className="panel span-12" {...rise(panel++)}>
+            <div className="panel-h">
+              Starting this project
+              <span className="sub">
+                {unstartable.length} {unstartable.length === 1 ? 'service' : 'services'} Bothy cannot start
+              </span>
+            </div>
+            <div className="panel-b">
+              <p className="start-why">
+                {/* Mono, so a sentence that opens on a list of service names
+                    reads as identifiers rather than as a lowercase mistake. */}
+                <span className="mono">{unstartable.map((n) => n.name).join(', ')}</span>{' '}
+                {unstartable.length === 1 ? 'has' : 'have'} no container for Docker to start - starting
+                {unstartable.length === 1 ? ' it' : ' them'} means creating one, and Bothy deliberately
+                cannot create containers. The socket proxy behind Restart, Stop and Start is granted four
+                container paths and nothing else, so a create never reaches the daemon even if this page
+                asked for one.
+              </p>
+              <p className="start-run">Run this yourself:</p>
+              {/* The declaration's own command, verbatim. Not composed here, and
+                  not a form: `project.dev.yml` is the allowlist, and a project
+                  opts in by declaring one. */}
+              <code className="mono start-cmd">{declaredProject.start}</code>
+              {declaredProject.root && (
+                <p className="start-where">
+                  in <span className="mono">{declaredProject.root}</span>, over Tailscale SSH.
+                </p>
+              )}
+              {/* #91's own warning, and it is not theoretical: a clone in /tmp
+                  ran `just up` once and ADOPTED this box's running stack, because
+                  compose project names are global to the daemon. The directory is
+                  half of what decides that name, which is why it is printed. */}
+              <p className="start-warn">
+                Compose project names are global to the daemon, so running this from a different checkout
+                of the same repository can adopt and recreate containers that are already up. The path
+                above is the one this project declared.
+              </p>
             </div>
           </motion.section>
         )}

--- a/docs/plans/control-and-settings.md
+++ b/docs/plans/control-and-settings.md
@@ -249,6 +249,23 @@ arbitrary command, *the one the declaration names*. Same shape as §5: `operator
 role, audit log, bounded verbs. The declaration is the allowlist, which is the
 elegant part: a project opts in by declaring, and nothing else is runnable.
 
+> **2026-08-19, from #91: this is not the same shape as §5, and the difference
+> is the whole cost.** §5 acts on a container through a socket proxy. A declared
+> `start` is a HOST SHELL COMMAND - `just up`, `tilt up` - so running it needs a
+> process on the host that executes strings, which is
+> [`SECURITY.md`](../../SECURITY.md)'s shape 3: no socket grant moves, and the
+> boundary that does move is "the portal cannot run code". Routing it through
+> Docker instead is worse, not better: creating a container is
+> `/containers/create`, and `POST=1` with `CONTAINERS=1` is the pair
+> `apps/bothy-control` was split into two proxies to avoid.
+>
+> What shipped from #91 is the part that needs neither: a declared service whose
+> container EXISTS gets the three verbs it was already entitled to (that is
+> `/containers/<name>/start`, already in `guard.VERBS`), and a declared service
+> with no container says so and prints the command instead of running it. Layer
+> 2 as written above remains undone, and it is a host-executor decision rather
+> than a UI one.
+
 **Layer 3 - Change (dangerous, decide separately).** Editing values. If it
 happens: field-level allowlist declared in the project file (not "any key"), a
 diff-and-confirm before writing, an audit entry, and a written threat model

--- a/scripts/checks/mutants.sh
+++ b/scripts/checks/mutants.sh
@@ -244,6 +244,87 @@ mutant "a doc points at a file that was deleted" \
   -- bash scripts/checks/doc-links.sh
 
 echo
+echo "── the grant that would make a browser root ────────────────────────"
+# THE most dangerous single character in this repository. The socket-proxy
+# image's granular ALLOW_* lines are `allow` rules with a broad `^/containers`
+# rule below them and no deny in between, so POST=1 together with CONTAINERS=1
+# permits every POST under /containers - /containers/create included, and a
+# create with a bind mount of / is root on this box. apps/bothy-control runs two
+# proxies precisely so that neither one holds both flags.
+#
+# This row plants the pair on the WRITE proxy: the exact edit somebody reaching
+# for "start a service from a compose file" (#91) would make, because it is the
+# one that would appear to work.
+mutant "the write socket proxy is granted CONTAINERS" \
+  apps/bothy-control/compose.yml \
+  'CONTAINERS:     0' \
+  'CONTAINERS:     1' \
+  -- bash apps/bothy-control/checks/run.sh --offline
+
+# THE SAME PAIR, ON A PROXY THAT DOES NOT EXIST YET - and this is the row the
+# one above cannot stand in for. Every named assertion in grants.py asks about
+# `socket-read` and `socket-write`; a THIRD proxy added in another file walks
+# past all of them, which is why that check now sweeps every compose file in the
+# tree by image rather than by service name.
+#
+# The mutation plants a fourth proxy holding POST=1 and CONTAINERS=1 into the
+# portal's socket-proxy file. Revert the sweep to the two named services and this
+# row goes red while the row above stays green.
+mutant "a fourth socket proxy appears with both flags" \
+  apps/bothy/socket-proxy.yml \
+  '
+services:
+' \
+  '
+services:
+  socket-proxy-run:
+    image: tecnativa/docker-socket-proxy:0.3.0
+    environment:
+      POST:       1
+      CONTAINERS: 1
+      EXEC:       0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks: [socketnet]
+' \
+  -- bash apps/bothy-control/checks/run.sh --offline
+
+# EXEC on the portal's read-only proxy. An exec into a container that holds
+# /var/run/docker.sock is a host root shell, and all three proxies hold it - so
+# EXEC=0 is written out on every one of them. Only the repo-wide sweep asserts
+# it on THIS file; the named assertions cover bothy-control's pair alone.
+mutant "exec creeps on to the portal socket proxy" \
+  apps/bothy/socket-proxy.yml \
+  'EXEC:         0   # container exec == root on this box' \
+  'EXEC:         1   # container exec == root on this box' \
+  -- bash apps/bothy-control/checks/run.sh --offline
+
+echo
+echo "── a declared project can still be acted on ────────────────────────"
+# The regression this shipped with: `withDeclared` drops the discovered node for
+# every container a project declares, so a declared node carrying `container:
+# null` DELETES the restart/stop/start control from its own containers - and a
+# stopped one then has no way back. Nothing errors; the cell is simply empty.
+mutant "a declared service loses its container" \
+  apps/portal-next/web/src/lib/projects.ts \
+  'container: liveContainer(svc, live),' \
+  'container: null,' \
+  -- "${PORTAL_CHECKS[@]}"
+
+# The inverse, and the one with teeth: resolving a declared NAME to whatever
+# container looks close enough. Compose numbers its containers (`cvops-api-1`),
+# so a loose match would aim a verb at a container nobody named - and a name that
+# matches nothing must resolve to nothing, because the only way to start a
+# container that does not exist is /containers/create.
+mutant "a declared name is matched loosely" \
+  apps/portal-next/web/src/lib/projects.ts \
+  'return svc.container ? live.get(svc.container) ?? null : null;' \
+  'if (!svc.container) return null;
+  const want = svc.container;
+  return live.get(want) ?? [...live.entries()].find(([k]) => k.startsWith(want))?.[1] ?? null;' \
+  -- "${PORTAL_CHECKS[@]}"
+
+echo
 echo "── the path boundary ───────────────────────────────────────────────"
 # THE containment check. Resolve first, compare after. Deleting it is the whole
 # directory-traversal class in one line, and 30 unit cases exist to catch it.


### PR DESCRIPTION
## What #91 actually is

The issue reads as one feature and is two, with very different costs:

**(a) Start a container that already EXISTS but is stopped.** `POST
/containers/<name>/start` - already in `guard.VERBS`, already granted by the
write socket proxy, no new route, no new role, no new grant.

**(b) Create and start from a compose file that has never run.** That is
`/containers/create`, which the write proxy refuses by holding `CONTAINERS=0`.
`apps/bothy-control/compose.yml` records the haproxy rule text out of
`tecnativa/docker-socket-proxy:0.3.0`: the granular `ALLOW_*` lines are `allow`
rules, the broad `^/containers` rule sits below them, and there is **no deny in
between** - so `POST=1` together with `CONTAINERS=1` permits every POST under
`/containers`, `/containers/create` included, and a create with a bind mount of
`/` is root on this box. That is why there are two proxies.

**This PR ships (a) and does not build (b).** See "What (b) would take" below.

## (a) was not a missing feature - it was a regression

`withDeclared()` drops the discovered node for every container a project
declares, and the declared node that replaced it carried `container: null`. So
**declaring a project took the restart/stop/start control away from its own
containers**, and a declared container that was stopped had no way back from the
console at all. Nothing errored; the cell was simply empty.

The declared node now carries docker's own container object. That also hands
`verbsFor(status, dockerState)` the second argument it has always wanted:
`exited` offers exactly **Start**, where the collector's five words could only
say `stopped`.

The lookup is **exact** and only ever resolves names docker actually reported
(`/containers/json?all=1`, which the portal already fetches, carries stopped
containers). A declaration is intent; a container is a fact; a verb is offered
on the fact. A declared name docker has never created resolves to nothing, and
`ActionCell` draws nothing - the honest answer rather than a button whose only
outcome is a refusal.

## Where there is no container, the page says so

The system page gets a **Starting this project** panel, shown only when a
declared project has something Bothy genuinely cannot start. It names those
services, says why (creating a container is the call the two-proxy split exists
to refuse), prints the command the declaration itself carries, and repeats
#91's own warning that compose project names are global to the daemon - the
trap that once let a clone in `/tmp` adopt and recreate this box's stack.

There is nothing in that panel to press.

## What (b) would take, and why it is not here

`docs/plans/control-and-settings.md` §6c pre-authorises a "Layer 2 - Run" and
says it is "the same shape as §5". It is not, and that is the whole cost - the
plan now carries a note saying so:

- §5 acts on a **container** through a socket proxy.
- A declared `start` is a **host shell command** (`just up`, `tilt up`). Running
  it needs a host-side process that executes strings, which is `SECURITY.md`'s
  **shape 3**: no socket grant moves, and the boundary that does move is "the
  portal cannot run code".
- Routing it through Docker instead is worse, not better: it is precisely the
  `POST=1` + `CONTAINERS=1` pair the architecture is split in two to avoid, and
  putting it on a fourth dedicated proxy relocates the problem rather than
  solving it.

That is a host-executor decision with its own threat model, not a UI change, and
it is not made here.

## Checks (each proven able to fail)

**`apps/portal-next/checks/declared-actions.mjs`** - a truth table over
`lib/projects.ts` and `lib/actions.ts` **together**, because neither can be
asked on its own which rows get a verb. Cases: a live container, the #91 case
(an exited container offering exactly Start), a declared name docker never
created, a near-miss name (`cvops-api` must not resolve to `cvops-api-1`),
docker unreachable (no verb offered on anything), a declared host process, and
all seven states `collect.py` can emit.

**`apps/bothy-control/checks/grants.py`** now sweeps **every compose file in the
repository** for the socket-proxy image, by `image:` line rather than by service
name, and asserts of each one: not `POST=1` with `CONTAINERS=1`; `POST` and
`CONTAINERS` stated explicitly; `EXEC=0`; socket mounted `:ro`; no published
port. Every existing assertion in that file names `socket-read` or
`socket-write`, so a **third** proxy added anywhere in the tree walked past all
of them - which is exactly how someone would implement (b) "safely". The sweep
also asserts it found at least the three proxies that exist, so it cannot report
all-clear by finding nothing.

`composeenv.py` grew a `Compose` class for that; its four module-level functions
are unchanged for their two existing callers.

**Five rows in `scripts/checks/mutants.sh`**, each verified red by hand:

| Mutation | Result |
|---|---|
| `CONTAINERS: 0` → `1` on the write proxy | grants.py exit 1, 2 assertions red |
| a **fourth** proxy with `POST=1` + `CONTAINERS=1` planted in `apps/bothy/socket-proxy.yml` | grants.py exit 1 - **caught only by the new sweep** |
| `EXEC: 0` → `1` on the portal's proxy | grants.py exit 1 - also only the sweep |
| declared node back to `container: null` | portal suite exit 1, 5 assertions red |
| declared name matched loosely by prefix | portal suite exit 1 |

## Verified

`apps/portal-next/checks/run.sh --offline` (582 assertions, 0 failures),
`apps/bothy-control/checks/run.sh --offline`, `apps/bothy-config/checks/run.sh`,
`apps/portal-files/checks/run.sh --offline`, `portability.sh`, `doc-links.sh`,
`bash32.sh`, `shellcheck -x -S warning` on every script touched, `npm run
typecheck`, `npm run build`, and `csp_hash.mjs` against the fresh build.

The panel was rendered for real (vite dev against the live box's `/-/api`, with
a throwaway `projects.json` fixture) in both themes, and the row-level control
was confirmed present on a declared service whose container exists and absent on
one whose container does not.

## Also

`collision` and `unverified` were missing from `CollectorState` while
`collect.py` has emitted both since the port probe learned to identify its
listener - they fell through a `?? 'unknown'` guard, which is why nothing broke
and nothing said they were unhandled. `collision` now reads as `stopped`, which
is what `collect.py`'s own project rollup already says about it.

Refs #91 - the discovery half (walking the disk for compose files) is
deliberately not implemented: `control-and-settings.md` is explicit that the
declaration layer, not a compose parser, is the sanctioned input, and starting
what discovery would find is (b).
