### PR TITLE
fix(grants): the socket-proxy sweep walked agent worktrees and the trash

### DIFF
--- a/apps/bothy-control/checks/grants.py
+++ b/apps/bothy-control/checks/grants.py
@@ -210,7 +210,14 @@ print("── every socket proxy in this repository, by image ──────
 # container this box runs.
 SOCKET_IMAGE = "tecnativa/docker-socket-proxy"
 REPO = os.path.dirname(os.path.dirname(SVC))
-SKIP_DIRS = {".git", "node_modules", "dist", ".venv"}
+# .claude holds AGENT WORKTREES - full copies of this repository - and
+# .cleanup-trash is a quarantine of things already removed. Both contain compose
+# files that define no container this box runs, and both would be swept: on a
+# machine with seven worktrees this walk found 24 proxies instead of 3, so the
+# assertion below printed a paragraph and a rogue definition in a throwaway copy
+# would have failed CI for a file that is not part of the repository. Same two
+# exclusions, for the same reason, as scripts/checks/portability.sh.
+SKIP_DIRS = {".git", "node_modules", "dist", ".venv", ".claude", ".cleanup-trash"}
 
 found: list[tuple[str, str, dict[str, str], str]] = []
 for walk_root, walk_dirs, walk_files in os.walk(REPO):


### PR DESCRIPTION
Follow-up to #139, found by running its new check on a machine that had agent worktrees on disk.

#139 replaced `grants.py`'s by-name lookup of `socket-read`/`socket-write` with a walk of every compose file in the repo, so a third proxy holding `POST=1` + `CONTAINERS=1` couldn't slip past the way the portal's proxy already had. **That was the right change and it works** — I confirmed it catches a planted rogue.

What it doesn't exclude is `.claude/`, which holds **agent worktrees — complete copies of this repository** — and `.cleanup-trash/`, a quarantine of things already deleted. On a machine with seven worktrees the sweep found **24 proxies instead of 3**, reported in a single line long enough to bury the assertion it was making.

**The failure that matters is the other direction.** A compose file in a throwaway copy defines no container this box runs, and a rogue definition in one would have failed CI for a file that is not part of the repository and that `git ls-files` doesn't know about. A check that can be turned red by a scratch directory is a check people learn to ignore.

Same two exclusions `scripts/checks/portability.sh` already makes, for the same reason — its comment makes the same argument.

## Proved both directions

| case | result |
|---|---|
| dangerous pair in `apps/evil-proxy.yml` | **exit 1**, 1 FAIL |
| identical file under `.claude/worktrees/` | **exit 0**, ignored |
| clean tree | sweep names the 3 real proxies |