### PR TITLE
feat(services): a collapsed group stays collapsed, keyed on what a system IS

### DIFF
--- a/apps/portal-next/checks/collapsed-groups.mjs
+++ b/apps/portal-next/checks/collapsed-groups.mjs
@@ -1,0 +1,142 @@
+// Which service groups you collapsed, and the two ways remembering that goes
+// wrong without anybody seeing an error.
+//
+// The whole feature is per-browser state under one localStorage key, so there is
+// nothing to observe from outside a browser and no request to watch fail. Both
+// failure modes are silent:
+//
+//   1. THE KEY MOVES. `group` is `dev.portal.group ?? system` - a display name a
+//      label can change - and a panel's key is built from it. File the state
+//      under that and the first person to regroup anything, or to rename a
+//      compose project, finds every group they had collapsed quietly open again
+//      and a dead entry left behind under the old name. This is the same failure
+//      the accent seed and the bookmarked URL already have guards for in
+//      grouping.mjs; this is the third thing keyed off a group.
+//
+//   2. THE PRUNE EATS LIVE STATE. Stale keys have to go or the value grows for
+//      the life of the browser profile, but the list they are pruned against is
+//      not the list on screen. The Services page filters, and the portal polls -
+//      so "the groups currently rendered" is empty during an outage and a subset
+//      of the truth whenever a filter is on. Prune against either and the page
+//      forgets a layout nobody asked it to forget.
+//
+// Run from checks/run.sh, which compiles discover.ts and collapse.ts next door.
+import { groupStorageKey, primaryIdentity } from './discover.mjs';
+import {
+  COLLAPSED_KEY, parseCollapsed, pruneCollapsed, setAllCollapsed, toggleCollapsed,
+} from './collapse.mjs';
+
+let fails = 0;
+const eq = (label, got, want) => {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  if (!ok) fails++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label.padEnd(58)} ${ok ? '' : `got ${JSON.stringify(got)} want ${JSON.stringify(want)}`}`);
+};
+
+// ── the key a collapsed group is filed under ────────────────────────────────
+console.log('── a collapsed group stays collapsed when its LABEL moves ───────────');
+
+// The zero-config case, which is every box until somebody sets a label: the
+// stable key and the panel key are the same string, so nothing that exists today
+// is stored anywhere different.
+eq('unregrouped: the stable key IS the panel key',
+  groupStorageKey('project:tals', 'tals', ['tals']), 'project:tals');
+
+// THE ONE THAT MATTERS. Two systems displayed as one under `dev.portal.group`.
+// The panel key names the display group; the stored key names a member.
+eq('merged for display: keyed on an identity, not the new name',
+  groupStorageKey('project:data', 'data', ['postgres', 'redis']), 'project:postgres');
+eq('...the same one the accent is hashed from',
+  groupStorageKey('project:data', 'data', ['postgres', 'redis']),
+  `project:${primaryIdentity('data', ['postgres', 'redis'])}`);
+// primaryIdentity() takes a SORTED list and does not sort one itself
+// (grouping.mjs pins that). groupStorageKey() sorts anyway, because this key is
+// the one that gets written to disk - see the comment on it.
+eq('...and it does not follow the order docker returned',
+  groupStorageKey('project:data', 'data', ['redis', 'postgres']),
+  groupStorageKey('project:data', 'data', ['postgres', 'redis']));
+
+// Somebody labels ONE project into a group named after itself plus a friend. The
+// group they deliberately named wins, so the key does not jump to the friend.
+eq('a group whose key is also a member keeps its own key',
+  groupStorageKey('project:postgres', 'postgres', ['postgres', 'redis']), 'project:postgres');
+
+// The two aggregate panels are not display groups at all - they are sections
+// that collect every system of a kind, and their keys are constants in
+// panels.ts that no label can reach.
+eq('the Stack section keys on itself',        groupStorageKey('stack', null, []), 'stack');
+eq('the Infrastructure section too',          groupStorageKey('infra', null, []), 'infra');
+// A compose project literally named `stack` must not collide with that section.
+eq('a project named `stack` is not the Stack section',
+  groupStorageKey('project:stack', 'stack', ['stack']), 'project:stack');
+
+// Identity lost entirely - a node with no compose identity at all. The key falls
+// back to the display group rather than to `undefined`, which would stringify
+// into `project:undefined` and collapse every such group as one.
+eq('no identities at all -> the group, never undefined',
+  groupStorageKey('project:data', 'data', []), 'project:data');
+
+// ── reading a value somebody else wrote ─────────────────────────────────────
+console.log('\n── anything unreadable means "nothing is collapsed" ─────────────────');
+
+eq('nothing stored',                 parseCollapsed(null), []);
+eq('an empty string',                parseCollapsed(''), []);
+eq('a normal value',                 parseCollapsed('["infra","project:tals"]'), ['infra', 'project:tals']);
+eq('written in any order, read back canonical',
+  parseCollapsed('["project:tals","infra"]'), ['infra', 'project:tals']);
+eq('duplicates collapse',            parseCollapsed('["infra","infra"]'), ['infra']);
+eq('non-strings are dropped, the rest survives',
+  parseCollapsed('["infra",7,null,{"a":1}]'), ['infra']);
+eq('not JSON at all',                parseCollapsed('{oh no'), []);
+eq('JSON, but not an array',         parseCollapsed('{"infra":true}'), []);
+// The retired `portal-open-groups` held the INVERSE list - which groups were
+// OPEN. It parses cleanly here, which is exactly why this module's key is a
+// different string; asserted so nobody "tidies up" by reusing the old name.
+eq('the retired key is not this key',  COLLAPSED_KEY === 'portal-open-groups', false);
+
+// ── pruning, and the two lists that are not the same list ───────────────────
+console.log('\n── a stale key is dropped; a filtered-out one is NOT ────────────────');
+
+const LIVE = ['project:tals', 'project:cvops', 'stack', 'infra'];
+
+eq('a group that no longer exists is dropped',
+  pruneCollapsed(['project:tals', 'project:liba'], LIVE), ['project:tals']);
+eq('nothing stale, nothing changes',
+  pruneCollapsed(['project:tals', 'infra'], LIVE), ['project:tals', 'infra']);
+eq('an empty stored list stays empty',
+  pruneCollapsed([], LIVE), []);
+
+// THE GUARD. `live` is every group the box HAS, not every group on screen. If a
+// caller ever passes the filtered panel list, this is the assertion that goes
+// red rather than a person losing their layout while typing in a search box.
+eq('AN EMPTY LIVE LIST PRUNES NOTHING - a failed poll is not an empty box',
+  pruneCollapsed(['project:tals', 'infra'], []), ['project:tals', 'infra']);
+
+// ── toggling, and "collapse all" under a filter ─────────────────────────────
+console.log('\n── the two controls ────────────────────────────────────────────────');
+
+eq('collapsing a group adds it',     toggleCollapsed([], 'infra'), ['infra']);
+eq('expanding it removes it',        toggleCollapsed(['infra'], 'infra'), []);
+eq('the list stays canonical',       toggleCollapsed(['stack'], 'infra'), ['infra', 'stack']);
+eq('collapsing twice is not two entries',
+  toggleCollapsed(toggleCollapsed([], 'infra'), 'infra'), []);
+
+eq('collapse all, from nothing',
+  setAllCollapsed([], ['project:tals', 'infra'], true), ['infra', 'project:tals']);
+eq('expand all clears what it names',
+  setAllCollapsed(['project:tals', 'infra'], ['project:tals', 'infra'], false), []);
+
+// The filter case, and the reason setAllCollapsed takes a list at all rather
+// than clearing everything: with a filter on, `all` is the two panels you can
+// see, and a group that is not on screen must come out the other side exactly as
+// it went in - in both directions.
+eq('collapse all leaves an off-screen group alone',
+  setAllCollapsed(['project:cvops'], ['project:tals'], true), ['project:cvops', 'project:tals']);
+eq('EXPAND all does too - it cannot open what you cannot see',
+  setAllCollapsed(['project:cvops', 'project:tals'], ['project:tals'], false), ['project:cvops']);
+eq('collapse all over an already-collapsed group is idempotent',
+  setAllCollapsed(['infra'], ['infra', 'stack'], true), ['infra', 'stack']);
+
+console.log();
+console.log(fails ? `${fails} check(s) FAILED` : 'all pass');
+process.exit(fails ? 1 : 0);

--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -3,8 +3,9 @@
 # the status classifier and the dependency graph out of discover.ts, the retired
 # URLs out of pages/control/redirects.ts, the two Files URLs out of
 # pages/files/routes.ts, the document titles out of pages/files/titles.ts and the
-# reader's landing surface out of pages/files/start.ts, plus a pass over the
-# box's real container list.
+# reader's landing surface out of pages/files/start.ts and the per-browser
+# collapsed-group state out of lib/collapse.ts, plus a pass over the box's real
+# container list.
 #
 # There is no test runner in this app on purpose - one 13-case truth table did
 # not justify pulling vitest into a static SPA's toolchain. Both modules import
@@ -70,6 +71,9 @@ mv "$OUT/projects.js" "$OUT/projects-mod.mjs"
   --module esnext --target es2022 --moduleResolution bundler \
   --types vite/client --outDir "$OUT" >/dev/null)
 mv "$OUT/actions.js" "$OUT/actions-mod.mjs"
+(cd "$WEB" && npx tsc src/lib/collapse.ts --ignoreConfig \
+  --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
+mv "$OUT/collapse.js" "$OUT/collapse.mjs"
 (cd "$WEB" && npx tsc src/lib/customThemes.ts --ignoreConfig \
   --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
 mv "$OUT/customThemes.js" "$OUT/user-themes-mod.mjs"
@@ -84,7 +88,8 @@ mv "$OUT/pages/files/tree.js" "$OUT/wikilinks-mod.mjs"
 cp "$HERE/status-classifier.mjs" "$HERE/relations.mjs" "$HERE/redirect-table.mjs" \
    "$HERE/titles-table.mjs" "$HERE/theme-contract.mjs" "$HERE/user-themes.mjs" \
    "$HERE/wikilinks.mjs" "$HERE/repo-roots.mjs" "$HERE/grouping.mjs" \
-   "$HERE/start-table.mjs" "$HERE/declared-actions.mjs" "$OUT/"
+   "$HERE/start-table.mjs" "$HERE/declared-actions.mjs" \
+   "$HERE/collapsed-groups.mjs" "$OUT/"
 
 echo "── truth table ─────────────────────────────────────────"
 node "$OUT/status-classifier.mjs"
@@ -131,6 +136,13 @@ echo "── what a system IS vs where it is SHOWN ─────────�
 # The split between derived identity and display grouping, and the two things
 # keyed off it whose failure is silent: the accent seed and the systems URL.
 node "$OUT/grouping.mjs"
+
+echo
+echo "── which group state survives a reload, and under what ─"
+# The key a collapsed group is filed under, and the prune that keeps stale ones
+# from accumulating forever. Both fail silently: a key that moves loses a layout
+# with no error, and a prune given the wrong list eats live state the same way.
+node "$OUT/collapsed-groups.mjs"
 
 echo
 echo "── this box, right now ─────────────────────────────────"

--- a/apps/portal-next/web/src/lib/collapse.ts
+++ b/apps/portal-next/web/src/lib/collapse.ts
@@ -1,0 +1,135 @@
+// Which service groups you have collapsed, remembered per browser.
+//
+// ── why localStorage, and why that is not a shortcut ─────────────────────────
+//
+// docs/plans/control-and-settings.md §6b splits "settings" into three, and this
+// is the first row: theme, pane widths and collapsed groups belong to the
+// BROWSER, and the plan's words for that row are "already correct, leave it".
+// The row that needs a server - a default landing page, favourites - is the one
+// the plan declines to build, by design and not by omission, and Settings.tsx
+// says so on the page. Nothing here is a placeholder for a store that is coming.
+//
+// ── the shape ────────────────────────────────────────────────────────────────
+//
+// A list of the groups you COLLAPSED, not a map of every group's state. Two
+// consequences, both wanted:
+//
+//   * the default for a group nobody has touched is EXPANDED, and it is expanded
+//     because it is absent rather than because a default was written down. A
+//     Services page whose first frame is a stack of closed boxes hides the
+//     tables it exists to show, and #93's own requirement is that with nothing
+//     configured the page looks exactly as it does today;
+//   * the stored value reads as what the person did. Nobody has to diff it
+//     against a default to know what it means.
+//
+// The keys are STABLE IDENTITIES, not display group names - see
+// groupStorageKey() in discover.ts for why, and checks/collapsed-groups.mjs for
+// the truth table.
+//
+// This module imports NOTHING, on purpose: checks/run.sh compiles it with a bare
+// tsc and runs a truth table against it. `localStorage` is a global rather than
+// an import, which is what lets the read/write path live here beside the parse
+// and prune rules rather than being scattered into the page.
+
+/**
+ * Versioned like `bothy-files-panes-v1`, so a shape change is a reset rather
+ * than a crash on somebody's three-week-old value.
+ *
+ * DELIBERATELY NOT `portal-open-groups`. That key belonged to SystemGroup, the
+ * three collapsible Overview cards deleted in favour of SystemMatrix, and it
+ * held the INVERSE list - which groups were OPEN. A value left in a browser
+ * since then would parse cleanly here and mean the exact opposite of what it
+ * says, so it must not be able to collide.
+ */
+export const COLLAPSED_KEY = 'bothy-collapsed-groups-v1';
+
+/**
+ * Parse a stored value into the set of collapsed keys.
+ *
+ * Everything that is not a JSON array of strings is treated as "nothing is
+ * collapsed", including `null`. A hand-edited value, a half-written quota
+ * failure or a value from a future shape are all reasons to start from the
+ * default layout - never reasons for the page not to render.
+ */
+export function parseCollapsed(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const j: unknown = JSON.parse(raw);
+    if (!Array.isArray(j)) return [];
+    // Deduplicated and sorted so the stored value is canonical: without this,
+    // collapsing A then B and B then A write two different strings for the same
+    // state, and any future comparison of the two is wrong for no reason.
+    return [...new Set(j.filter((x): x is string => typeof x === 'string'))].sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Drop stored keys for groups the box no longer has.
+ *
+ * Without this the file grows forever: every renamed compose project, every
+ * project deleted from ~/projects and every one-shot that was collapsed once
+ * leaves an entry that nothing will ever read again.
+ *
+ * TWO GUARDS, and both of them are the difference between pruning and data loss.
+ *
+ * `live` must be EVERY group the box currently has, not the groups currently on
+ * screen. The Services page filters - by status, by project, by search text -
+ * and a filtered-out panel is not a deleted one. Pruning against the visible
+ * list would silently forget everything you collapsed the moment you typed into
+ * the search box.
+ *
+ * And an EMPTY `live` prunes nothing. The portal polls, and a poll that fails
+ * renders zero nodes - which is indistinguishable from "the box has no services"
+ * to this function, but is emphatically not a reason to erase the layout. A
+ * genuinely empty box has nothing to collapse and so nothing to lose either way.
+ */
+export function pruneCollapsed(stored: readonly string[], live: readonly string[]): string[] {
+  if (live.length === 0) return [...stored];
+  const alive = new Set(live);
+  return stored.filter((k) => alive.has(k));
+}
+
+/** Add or remove one key, keeping the canonical order parseCollapsed() produces. */
+export function toggleCollapsed(stored: readonly string[], key: string): string[] {
+  return stored.includes(key)
+    ? stored.filter((k) => k !== key)
+    : [...stored, key].sort();
+}
+
+/**
+ * Everything collapsed, or nothing - the "Collapse all" button's two states.
+ *
+ * `all` is the VISIBLE groups, unlike prune's argument: collapsing all means
+ * collapsing what you are looking at, and it must not reach past a filter to
+ * touch groups that are not on screen. Whatever was already stored for those is
+ * carried through untouched.
+ */
+export function setAllCollapsed(
+  stored: readonly string[],
+  all: readonly string[],
+  collapsed: boolean,
+): string[] {
+  const touched = new Set(all);
+  const rest = stored.filter((k) => !touched.has(k));
+  return (collapsed ? [...rest, ...all] : rest).filter((k, i, a) => a.indexOf(k) === i).sort();
+}
+
+/** Read the stored list. Never throws - private mode denies localStorage outright. */
+export function readCollapsed(): string[] {
+  try {
+    return parseCollapsed(localStorage.getItem(COLLAPSED_KEY));
+  } catch {
+    return [];
+  }
+}
+
+/** Write it back. A quota error or a denied store is not a reason to break a click. */
+export function writeCollapsed(keys: readonly string[]): void {
+  try {
+    localStorage.setItem(COLLAPSED_KEY, JSON.stringify([...keys]));
+  } catch {
+    /* private mode, quota - the page keeps working, it just forgets */
+  }
+}

--- a/apps/portal-next/web/src/lib/discover.ts
+++ b/apps/portal-next/web/src/lib/discover.ts
@@ -841,6 +841,41 @@ export function findSystem<T extends GroupIdentity>(groups: readonly T[], name: 
   );
 }
 
+/**
+ * The key a display group's per-browser UI state is stored under.
+ *
+ * The THIRD thing keyed off a group, after the accent seed and the bookmarked
+ * URL, and it fails the same silent way both of those did before the split
+ * above: `key` for a project panel is `project:<group>`, and `group` is
+ * `dev.portal.group ?? system`. Store a collapsed panel under that and the first
+ * person to set `dev.portal.group` - or to rename a compose project - finds
+ * every group they had collapsed silently expanded again, with a dead entry left
+ * in localStorage under the old name. Nothing errors; the layout just forgets.
+ *
+ * So a group that stands for exactly one display group is stored under its
+ * primary IDENTITY instead, which is the same string the accent is hashed from
+ * and therefore moves only when the underlying compose project does.
+ *
+ * `group === null` means the panel is not a display group at all - it is a
+ * structural section (`stack`, `infra`) that aggregates every system of a kind.
+ * There is no identity under it to key on, and its own key is a constant in
+ * panels.ts that no label can reach, so it IS the stable key.
+ */
+export function groupStorageKey(
+  key: string,
+  group: string | null,
+  identities: readonly string[],
+): string {
+  // SORTED HERE, not merely by the caller. primaryIdentity() reads
+  // `identities[0]` and deliberately does not sort - it is documented as taking
+  // a sorted list, and systems.ts and panels.ts both build one. But this key is
+  // written to disk: a caller that ever forgets leaves the key following the
+  // order docker happened to return its containers in, and a stored layout that
+  // moves when a poll comes back reordered is a bug nobody would think to look
+  // for. The cost is a copy of an array with one or two strings in it.
+  return group == null ? key : `project:${primaryIdentity(group, [...identities].sort())}`;
+}
+
 // Groups that are not systems and so cannot be named like one. `unmanaged` is
 // what classify() returns for a container with no compose labels - a `docker run`
 // nobody declared. It is not a system, it is *whatever did not match*, and

--- a/apps/portal-next/web/src/lib/panels.ts
+++ b/apps/portal-next/web/src/lib/panels.ts
@@ -1,3 +1,4 @@
+import { groupStorageKey } from './discover';
 import type { PortalNode } from './discover';
 
 export interface Panel {
@@ -7,6 +8,19 @@ export interface Panel {
   // The compose group this panel represents, when it represents exactly one
   // (project panels do; the aggregated Stack/Infrastructure panels do not).
   group: string | null;
+  /**
+   * Every derived `node.system` folded into this panel, sorted - the same field
+   * System carries, and for the same reason: `group` is a display name a label
+   * can move, and identity is the half that stays put.
+   */
+  identities: string[];
+  /**
+   * What per-browser UI state about this panel is filed under. Equal to `key`
+   * until somebody sets `dev.portal.group`; see groupStorageKey() in
+   * discover.ts for what goes wrong when a preference is keyed on a name a
+   * label can move.
+   */
+  storeKey: string;
   nodes: PortalNode[];
 }
 
@@ -33,17 +47,34 @@ export function panelize(nodes: PortalNode[], allNodes: PortalNode[] = nodes): P
   for (const n of allNodes) if (n.groupTitle) nice.set(n.group, n.groupTitle);
   const title = (g: string) =>
     nice.get(g) || g.replace(/[-_]/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase());
+  // Identities come from `allNodes` for exactly the reason the titles do. A
+  // panel's storage key must not depend on which of its services a filter left
+  // on screen: derive it from the filtered list and searching for "api" moves
+  // the key of every group whose other containers dropped out, so the layout
+  // forgets itself while you type.
+  const idents = (ns: PortalNode[]) =>
+    [...new Set(ns.filter((n) => !n.hidden).map((n) => n.system || n.group))].sort();
+  const identsOfGroup = new Map<string, string[]>();
+  for (const n of allNodes) if (!n.hidden) {
+    const cur = identsOfGroup.get(n.group) ?? [];
+    if (!cur.includes(n.system || n.group)) cur.push(n.system || n.group);
+    identsOfGroup.set(n.group, cur.sort());
+  }
+
   const byOrder = (a: PortalNode, b: PortalNode) =>
     (a.depth ?? 9) - (b.depth ?? 9) || a.order - b.order || a.name.localeCompare(b.name);
 
   const panels: Panel[] = [];
   const projects = [...new Set(vis.filter((n) => n.groupKind === 'project').map((n) => n.group))].sort();
   for (const g of projects) {
+    const identities = identsOfGroup.get(g) ?? [g];
     panels.push({
       key: `project:${g}`,
       title: title(g),
       sub: 'project · ' + g,
       group: g,
+      identities,
+      storeKey: groupStorageKey(`project:${g}`, g, identities),
       nodes: vis.filter((n) => n.group === g).sort(byOrder),
     });
   }
@@ -57,6 +88,10 @@ export function panelize(nodes: PortalNode[], allNodes: PortalNode[] = nodes): P
       title: 'Stack',
       sub: 'shared dev services · ' + [...new Set(stack.map((n) => n.group))].join(' · '),
       group: null,
+      identities: idents(allNodes.filter((n) => n.groupKind === 'stack')),
+      // A structural section, not a display group: no label reaches this string,
+      // so it is already the stable key.
+      storeKey: groupStorageKey('stack', null, []),
       nodes: stack,
     });
   }
@@ -68,6 +103,8 @@ export function panelize(nodes: PortalNode[], allNodes: PortalNode[] = nodes): P
       title: 'Infrastructure',
       sub: 'the edge itself · usually you can ignore this',
       group: null,
+      identities: idents(allNodes.filter((n) => n.groupKind === 'infra')),
+      storeKey: groupStorageKey('infra', null, []),
       nodes: infra,
     });
   }

--- a/apps/portal-next/web/src/pages/Services.tsx
+++ b/apps/portal-next/web/src/pages/Services.tsx
@@ -1,9 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { ArrowRight, ChevronDown, SlidersHorizontal, X } from 'lucide-react';
 import { usePortal } from '../lib/data';
 import { panelize } from '../lib/panels';
+import {
+  pruneCollapsed, readCollapsed, setAllCollapsed, toggleCollapsed, writeCollapsed,
+} from '../lib/collapse';
 import { accentVar } from '../lib/accents';
 import type { PortalNode, Status } from '../lib/discover';
 import { systemLink } from '../lib/links';
@@ -42,7 +45,13 @@ export function Services() {
   const [statusFilter, setStatusFilter] = useState<Set<Status>>(new Set());
   const [project, setProject] = useState('all');
   const [kind, setKind] = useState<KindFilter>('all');
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  // Which groups you collapsed, remembered per browser - lib/collapse.ts owns
+  // the rules and says why localStorage is the right and only home for it.
+  //
+  // A LIST, not a Set, because that is what is stored and what the pure helpers
+  // take. There are a dozen panels on the busiest box this runs on, so the
+  // lookup cost is not a consideration and one shape end to end is.
+  const [collapsed, setCollapsed] = useState<string[]>(readCollapsed);
 
   const setQ = (v: string) => {
     const next = new URLSearchParams(params);
@@ -106,6 +115,27 @@ export function Services() {
   // membership from the filtered set, display names from the full set
   const panels = useMemo(() => panelize(filtered, data.nodes), [filtered, data.nodes]);
 
+  // EVERY group the box has, filters ignored. This is what stale stored keys are
+  // pruned against, and it must not be `panels`: a filtered-out group is not a
+  // deleted one, and pruning against what is on screen would forget your layout
+  // the moment you typed into the search box. pruneCollapsed() also refuses to
+  // prune against an empty list, so a failed poll cannot erase it either.
+  const liveKeys = useMemo(
+    () => panelize(data.nodes).map((p) => p.storeKey),
+    [data.nodes],
+  );
+
+  useEffect(() => {
+    setCollapsed((prev) => {
+      const next = pruneCollapsed(prev, liveKeys);
+      // Same length means nothing was dropped. Returning `prev` unchanged keeps
+      // this effect from writing localStorage on every ten-second poll.
+      return next.length === prev.length ? prev : next;
+    });
+  }, [liveKeys]);
+
+  useEffect(() => { writeCollapsed(collapsed); }, [collapsed]);
+
   const toggleStatus = (s: Status) => {
     setStatusFilter((prev) => {
       const next = new Set(prev);
@@ -113,16 +143,15 @@ export function Services() {
       return next;
     });
   };
-  const toggleCollapse = (key: string) =>
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      next.has(key) ? next.delete(key) : next.add(key);
-      return next;
-    });
+  const toggleCollapse = (key: string) => setCollapsed((prev) => toggleCollapsed(prev, key));
 
-  const allCollapsed = panels.length > 0 && panels.every((p) => collapsed.has(p.key));
+  const allCollapsed = panels.length > 0 && panels.every((p) => collapsed.includes(p.storeKey));
+  // Acts on the VISIBLE panels only. "Collapse all" under an active filter means
+  // the groups you are looking at; reaching past the filter to close groups that
+  // are not on screen is a change you cannot see happen and cannot undo with the
+  // same button.
   const toggleAll = () =>
-    setCollapsed(allCollapsed ? new Set() : new Set(panels.map((p) => p.key)));
+    setCollapsed((prev) => setAllCollapsed(prev, panels.map((p) => p.storeKey), !allCollapsed));
 
   const activeFilters = statusFilter.size > 0 || project !== 'all' || kind !== 'all' || !!q;
   const clearAll = () => { setStatusFilter(new Set()); setProject('all'); setKind('all'); setQ(''); };
@@ -203,15 +232,31 @@ export function Services() {
       ) : (
         <div className="svc-groups">
             {panels.map((p, gi) => {
-              const isCollapsed = collapsed.has(p.key);
+              const isCollapsed = collapsed.includes(p.storeKey);
+              // Ties the header button to the region it opens, so a screen
+              // reader reading "collapsed" has somewhere to go for what is
+              // inside it. The id is built from the STABLE key for the same
+              // reason the state is stored under it.
+              const bodyId = `svc-group-body-${p.storeKey.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
               return (
                 <section
                   className="svc-group"
                   key={p.key}
-                  style={{ ['--acc' as string]: `var(${accentVar(p.key)})` } as React.CSSProperties}
+                  // Hashed from the STABLE key, not the display key. It was
+                  // `p.key`, which meant setting `dev.portal.group` repainted
+                  // this page's spines while the Overview - which already hashes
+                  // from primaryIdentity() - kept the old colours, so one system
+                  // was two different colours on two pages. Identical on a box
+                  // with no such label, which is every box today.
+                  style={{ ['--acc' as string]: `var(${accentVar(p.storeKey)})` } as React.CSSProperties}
                 >
                   <div className="svc-group-head-row">
-                    <button className="svc-group-head" onClick={() => toggleCollapse(p.key)} aria-expanded={!isCollapsed}>
+                    <button
+                      className="svc-group-head"
+                      onClick={() => toggleCollapse(p.storeKey)}
+                      aria-expanded={!isCollapsed}
+                      aria-controls={bodyId}
+                    >
                       <ChevronDown size={16} className={`chev ${isCollapsed ? 'closed' : ''}`} />
                       <span className="svc-group-idx">{String(gi + 1).padStart(2, '0')}</span>
                       <span className="svc-group-title">{p.title}</span>
@@ -232,21 +277,28 @@ export function Services() {
                     )}
                   </div>
 
-                  <AnimatePresence initial={false}>
-                    {!isCollapsed && (
-                      <motion.div
-                        className="svc-group-body"
-                        key="body"
-                        initial={reduced ? false : { height: 0, opacity: 0 }}
-                        animate={{ height: 'auto', opacity: 1 }}
-                        exit={reduced ? { opacity: 0 } : { height: 0, opacity: 0 }}
-                        transition={{ duration: 0.24, ease: [0.2, 0.7, 0.2, 1] }}
-                        style={{ overflow: 'hidden' }}
-                      >
-                        <ServiceTable nodes={p.nodes} compact label={`${p.title} services`} />
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
+                  {/* The id lives on a wrapper that is ALWAYS in the DOM, not on
+                      the animated body. The body unmounts when the group is
+                      collapsed, so putting it there leaves `aria-controls`
+                      pointing at nothing in exactly the state where a screen
+                      reader most needs the association to resolve. */}
+                  <div id={bodyId}>
+                    <AnimatePresence initial={false}>
+                      {!isCollapsed && (
+                        <motion.div
+                          className="svc-group-body"
+                          key="body"
+                          initial={reduced ? false : { height: 0, opacity: 0 }}
+                          animate={{ height: 'auto', opacity: 1 }}
+                          exit={reduced ? { opacity: 0 } : { height: 0, opacity: 0 }}
+                          transition={{ duration: 0.24, ease: [0.2, 0.7, 0.2, 1] }}
+                          style={{ overflow: 'hidden' }}
+                        >
+                          <ServiceTable nodes={p.nodes} compact label={`${p.title} services`} />
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  </div>
                 </section>
               );
             })}

--- a/apps/portal-next/web/src/pages/Settings.tsx
+++ b/apps/portal-next/web/src/pages/Settings.tsx
@@ -473,6 +473,18 @@ const STORES = [
       + 'they are used - the theme button in the topbar, the panes themselves - rather than here.',
   },
   {
+    what: 'Which service groups you have collapsed',
+    where: 'This browser',
+    store: 'localStorage',
+    elsewhere: 'Not there. Another browser starts with every group open, which is also what a browser '
+      + 'that has never been told otherwise shows.',
+    why: 'Only the groups you CLOSED are written down, so a group nobody has touched is open because '
+      + 'it is absent rather than because a default was recorded - the Services page looks exactly as '
+      + 'it always has until you collapse something. They are filed under what a system IS, not under '
+      + 'the name it is displayed by, so renaming a project or setting dev.portal.group does not make '
+      + 'the page forget. Groups the box no longer has are dropped rather than kept forever.',
+  },
+  {
     what: 'A theme you wrote yourself',
     where: 'The box, as a file',
     store: THEME_DIR_HOST,

--- a/scripts/checks/mutants.sh
+++ b/scripts/checks/mutants.sh
@@ -146,6 +146,29 @@ mutant "the ports table stops honouring the label" \
         group: cls.system,' \
   -- "${PORTAL_CHECKS[@]}"
 
+# THE THIRD THING KEYED OFF A GROUP, after the accent seed and the bookmarked
+# URL: which groups you collapsed, remembered per browser. Key it on the display
+# name and the first `dev.portal.group` - or the first renamed compose project -
+# silently expands every group somebody had closed and strands a dead entry in
+# localStorage under the old name. Nothing errors, and the person it happens to
+# has no reason to connect the two.
+mutant "collapsed groups are filed under the display name" \
+  apps/portal-next/web/src/lib/discover.ts \
+  'primaryIdentity(group, [...identities].sort())' \
+  'group' \
+  -- "${PORTAL_CHECKS[@]}"
+
+# The prune that keeps stale keys from accumulating for the life of a browser
+# profile, pointed at the wrong moment. The portal polls, and a poll that fails
+# renders zero nodes - which reaches pruneCollapsed() as an empty `live` list and
+# is indistinguishable from "the box has no services". Without the guard, one
+# failed poll erases a layout, and the erase is written straight back to disk.
+mutant "a failed poll prunes every collapsed group" \
+  apps/portal-next/web/src/lib/collapse.ts \
+  'if (live.length === 0) return [...stored];' \
+  'if (live.length < 0) return [...stored];' \
+  -- "${PORTAL_CHECKS[@]}"
+
 echo
 echo "── the palette contract ────────────────────────────────────────────"
 # Every colour must come from a token. A literal in a component is invisible in


### PR DESCRIPTION
Refs #93. **Not `Closes`** — the group *editor* #93 asks for needs a per-user
preference store, and `docs/plans/control-and-settings.md` §6b declines to build
one *by design, not by omission*. That half stays blocked, deliberately, and
`Settings.tsx` says so on the page. This is the part of #93 that needs no server:
collapsed-group state, which §6b puts in the browser beside the theme and the
Files pane widths.

## What changed

Groups on `/control/services` remember whether they are collapsed, per browser.
They already collapsed; the state was a `useState` Set and every reload, every
navigation away and back, threw it away.

## The key, which is the decision in this work

A panel's key is `project:<group>`, and `group` is `dev.portal.group ?? system` —
the one field a label is *allowed* to move. Store a collapsed group under that
and the first person to regroup anything, or to rename a compose project, finds
every group they had closed silently open again, with a dead entry stranded under
the old name. Nothing errors. Nobody connects the two.

#127 split `system` (derived, no label can move it) from `group` (display)
precisely because display keys are unstable, and pinned the two things keyed off
it whose failure is silent: the accent seed and the bookmarked `/control/systems/`
URL. **This is the third.** `groupStorageKey()` lives next to `primaryIdentity()`
in `discover.ts` — the same file, the same section, for the same reason — and
files a group under its primary identity:

| panel | panel key | stored under |
|---|---|---|
| a project | `project:tals` | `project:tals` |
| two projects merged by `dev.portal.group` | `project:data` | `project:postgres` |
| the Stack section | `stack` | `stack` |
| the Infrastructure section | `infra` | `infra` |

The two aggregate sections are **not display groups**. They collect every system
of a kind and their keys are constants in `panels.ts` that no label can reach, so
they are already stable and key on themselves. (A compose project literally named
`stack` is `project:stack` and cannot collide — asserted.)

It sorts the identities itself rather than trusting the caller to, because this
key is the one that gets **written to disk**: `primaryIdentity()` documents that
it takes a sorted list, and a caller that ever forgets would leave the stored key
following whatever order docker returned its containers in.

**The accent seed on this page moves with it.** It was `accentVar(p.key)` — the
display key — while the Overview hashes from `primaryIdentity()`, so setting
`dev.portal.group` would have repainted the spines here and not there: one system,
two colours, two pages. One identifier, and it is exactly the failure this PR is
about. Byte-identical on a box with no such label, which is every box today.

## The three defaults, and why

**Expanded, for a group nobody has touched.** Only what you *collapsed* is written
down, so an untouched group is open because it is *absent* rather than because a
default was recorded. #93's own requirement is that with nothing configured the
page looks exactly as it does now, and a page whose first frame is a stack of
closed boxes hides the tables it exists to show. It also makes the stored value
read as what the person did.

**A group the box no longer has is dropped**, or the value grows for the life of a
browser profile — every renamed project, every deleted checkout, every one-shot
collapsed once. Two guards on the prune, and both are the difference between
pruning and data loss:

* pruned against **every group the box has**, never against the panels on screen.
  This page filters by status, project, kind and free text, and a filtered-out
  group is not a deleted one — pruning against the visible list forgets your
  layout while you type;
* an **empty** live list prunes nothing. The portal polls; a failed poll renders
  zero nodes, which is indistinguishable from "the box has no services" and is
  emphatically not a reason to erase a layout.

**Per system identity, not per page.** "I don't care about this right now" is a
statement about the system, and the key carries no surface in it, so any surface
that later renders the same panels inherits the same answer. `Collapse all` is the
one thing scoped to what is on screen — under a filter it must not reach past it,
in *either* direction.

## Storage

`localStorage`, one key, `bothy-collapsed-groups-v1` — versioned like
`bothy-files-panes-v1`, and read/written the way `panes.ts` and `theme.tsx` do it
(a lazy `useState` initialiser, an effect that writes, every access in a `try`
because private mode denies the store outright). Deliberately **not**
`portal-open-groups`: that key belonged to the three Overview cards `SystemMatrix`
replaced, and it held the *inverse* list — which groups were OPEN. A value left in
a browser since then parses cleanly here and would mean the opposite of what it
says.

`Settings.tsx`'s `STORES` table gains a row. That panel exists to answer "where
does each setting live", and shipping a `localStorage` key without listing it
there is the gap #95 was about.

## Accessibility

The header was already a real `<button>` with `aria-expanded`. It gains
`aria-controls`, and the id it names lives on a wrapper that is **always** in the
DOM rather than on the animated body — the body unmounts when the group is closed,
so putting the id there leaves a dangling reference in exactly the state where the
association most needs to resolve. Verified in the browser: zero dangling
`aria-controls` in either state, and a group collapsed by focusing its header and
pressing Enter.

## Checks

`checks/collapsed-groups.mjs` — 30 cases over `groupStorageKey()` and the
parse/prune/toggle rules, both import-free modules compiled by `checks/run.sh`'s
bare `tsc`. Two rows added to `scripts/checks/mutants.sh`, and both proved red by
hand before being written down:

```
key it on the display name:
  FAIL  merged for display: keyed on an identity, not the new name  got "project:data" want "project:postgres"
  FAIL  ...the same one the accent is hashed from                   got "project:data" want "project:postgres"

drop the empty-live guard:
  FAIL  AN EMPTY LIVE LIST PRUNES NOTHING - a failed poll is not an empty box  got [] want ["project:tals","infra"]
```

## Verified

`npm run typecheck`, `npm run build`, `checks/run.sh --offline` (all pass, exit 0),
`checks/stray-colour.mjs`. Driven in real headless Chromium against `vite dev` on
127.0.0.1: collapsed Stack by click and Infrastructure by keyboard, hard-reloaded,
both came back collapsed and the three projects came back open; injected two dead
keys (`project:liba`, `project:gone`) and they were gone after the next load while
the live two survived; filtered the page down to two groups and confirmed the
stored value did not lose the groups that left the screen. Looked at in both
themes and at 390px wide.
