### PR TITLE
fix(reader): one stretching width for a document, and backlinks that are actually after it

### DIFF
--- a/apps/portal-next/web/src/index.css
+++ b/apps/portal-next/web/src/index.css
@@ -171,6 +171,18 @@
      72ch is prose, not a terminal. The measure rule changes reading speed more
      than the typeface does. */
   --read-measure: 72ch;
+  /* The OTHER width, and the reason there are exactly two.
+     A table, a code fence and a figure are not prose and must be let out of the
+     measure - a generated diagram capped at 72ch renders its 15px labels at
+     about 10px (#103), which is unreadable. They used to be let out to
+     `max-width: 100%`, and that is not a width at all: it means "however wide
+     the window happens to be", so on a 1440px screen the prose was ~660px and
+     the table above it ~1100px and the document changed width every few blocks.
+     Bounding the COLUMN is what fixes that - `.fx-read` is capped at this, so
+     `100%` on the escapes now means "the full column" and the widest block on
+     any page is a known quantity. A genuinely wider table scrolls inside its own
+     frame, which is what `.md-tbl-wrap`'s `overflow: auto` was always for. */
+  --read-wide: 96ch;
   /* 16px, not 14.5px. The measure was already right - 72ch, verified rendering
      at exactly 72 characters - but the body was set at the app's UI size, and a
      document is not a dashboard. 14.5px is a good size for a control that sits

--- a/apps/portal-next/web/src/index.css
+++ b/apps/portal-next/web/src/index.css
@@ -170,19 +170,26 @@
 
      72ch is prose, not a terminal. The measure rule changes reading speed more
      than the typeface does. */
-  --read-measure: 72ch;
-  /* The OTHER width, and the reason there are exactly two.
-     A table, a code fence and a figure are not prose and must be let out of the
-     measure - a generated diagram capped at 72ch renders its 15px labels at
-     about 10px (#103), which is unreadable. They used to be let out to
-     `max-width: 100%`, and that is not a width at all: it means "however wide
-     the window happens to be", so on a 1440px screen the prose was ~660px and
-     the table above it ~1100px and the document changed width every few blocks.
-     Bounding the COLUMN is what fixes that - `.fx-read` is capped at this, so
-     `100%` on the escapes now means "the full column" and the widest block on
-     any page is a known quantity. A genuinely wider table scrolls inside its own
-     frame, which is what `.md-tbl-wrap`'s `overflow: auto` was always for. */
-  --read-wide: 96ch;
+  /* ONE width, and it STRETCHES. Every top-level block in a rendered document
+     gets this and nothing gets an exception - prose, tables, code fences,
+     figures, callouts, backlinks.
+
+     It was 72ch, with tables, code and figures let out to `max-width: 100%`.
+     Two widths, and on a 1440px screen that was prose at ~660px next to a table
+     at ~1100px: a block 1.7x the width of the paragraph above it reads as a
+     different document, and the page changed width every few blocks.
+
+     The fix that did NOT work was capping the column - putting a `max-width` on
+     `.fx-read`. `.fx-read` is the element with `overflow: auto`, so capping it
+     moves the SCROLLBAR off the edge of the pane and into the middle of the
+     page. A scroll container is the wrong thing to size.
+
+     So the one width is the one the pane already gives, and the blocks fill it.
+     Long lines on a very wide screen are the cost, and it is paid knowingly:
+     the alternative on this surface was two widths that did not agree.
+
+     Still a token, so a theme that wants a measure back sets one value. */
+  --read-measure: 100%;
   /* 16px, not 14.5px. The measure was already right - 72ch, verified rendering
      at exactly 72 characters - but the body was set at the app's UI size, and a
      document is not a dashboard. 14.5px is a good size for a control that sits

--- a/apps/portal-next/web/src/lib/contract.ts
+++ b/apps/portal-next/web/src/lib/contract.ts
@@ -146,7 +146,7 @@ export const STRUCTURAL = new Set([
   // asking (see checks/theme-contract.mjs). They are lengths and a ratio: a
   // colour rule cannot measure them and the editor cannot offer a swatch for
   // them, so "required" was never the right answer.
-  '--read-measure', '--read-wide', '--read-fs', '--read-lh', '--read-gap',
+  '--read-measure', '--read-fs', '--read-lh', '--read-gap',
   '--read-h1', '--read-h2', '--read-h3', '--read-h4',
 ]);
 

--- a/apps/portal-next/web/src/lib/contract.ts
+++ b/apps/portal-next/web/src/lib/contract.ts
@@ -146,7 +146,7 @@ export const STRUCTURAL = new Set([
   // asking (see checks/theme-contract.mjs). They are lengths and a ratio: a
   // colour rule cannot measure them and the editor cannot offer a swatch for
   // them, so "required" was never the right answer.
-  '--read-measure', '--read-fs', '--read-lh', '--read-gap',
+  '--read-measure', '--read-wide', '--read-fs', '--read-lh', '--read-gap',
   '--read-h1', '--read-h2', '--read-h3', '--read-h4',
 ]);
 

--- a/apps/portal-next/web/src/pages/files/FileContent.tsx
+++ b/apps/portal-next/web/src/pages/files/FileContent.tsx
@@ -186,6 +186,7 @@ export function Source({ src, lang }: { src: string; lang: string }) {
 
 export function FileContent({
   root, path, content, size, lang, kind, view, source, onDownload, canDownload, onFallback, links,
+  footer,
 }: {
   /** The root key, for the sandbox-origin URL. Building a string is not I/O. */
   root: string;
@@ -215,6 +216,21 @@ export function FileContent({
    *  go. Absent means the reader has no navigation to offer, and those links
    *  keep rendering as inert text - see md.tsx. */
   links?: MdLinks;
+  /** Rendered as the last block INSIDE the rendered document, after the markdown.
+   *
+   *  It exists because "after the document" and "below the document" are not the
+   *  same place and the difference is invisible until you scroll. `.fx-read` is
+   *  the element with `overflow: auto`, so anything rendered as a SIBLING of it
+   *  is laid out below the scroll container - permanently in view, docked to the
+   *  bottom of the pane, taking height from every page. That is where the
+   *  reader's backlinks panel was, and its own comment said it meant to be
+   *  "AFTER the document". A prop is the smaller fix than moving the scroller,
+   *  and it keeps Toc's `scrollerOf()` walk resolving to the same element.
+   *
+   *  Only the RENDERED MARKDOWN branch takes one, and that is honest rather than
+   *  an omission: an image, a PDF and a download card are not documents, they
+   *  have no end to be after, and there is no `.fx-read` to be inside. */
+  footer?: ReactNode;
 }) {
   if (kind === 'image') {
     return <RawPreview src={rawUrl(root, path)} name={baseName(path)} onFallback={onFallback} />;
@@ -240,6 +256,7 @@ export function FileContent({
         aria-label={`${baseName(path)} - rendered`}
       >
         {renderMd(content, 'b', links)}
+        {footer}
       </article>
     );
   }

--- a/apps/portal-next/web/src/pages/files/FileView.tsx
+++ b/apps/portal-next/web/src/pages/files/FileView.tsx
@@ -18,7 +18,7 @@
 // ~/projects - so a signed-out visitor gets the invitation the rest of the page
 // gives them, not a red box.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import {
   ApiError, isAuthError, langFor, looksBinary, openDownload, rawUrl, readFile,
   type FileRead,
@@ -37,7 +37,7 @@ type State =
   | { at: 'error'; why: string };
 
 export function FileView({
-  root, path, view = 'preview', frag = '', onOpen, onLoad, resolveWiki,
+  root, path, view = 'preview', frag = '', onOpen, onLoad, resolveWiki, footer,
 }: {
   root: string;
   path: string;
@@ -61,6 +61,11 @@ export function FileView({
    *  the alternative is the page fetching the file a second time to learn what
    *  this component already knows. */
   onLoad?: (file: FileRead | null) => void;
+  /** The last block of the rendered document - passed straight through to
+   *  FileContent, which is where the reasoning for it is written down. Note
+   *  that it renders only for a rendered markdown document, so a caller must
+   *  not put anything load-bearing in it. */
+  footer?: ReactNode;
 }) {
   const [state, setState] = useState<State>({ at: 'loading' });
   const [tick, setTick] = useState(0);
@@ -179,6 +184,7 @@ export function FileView({
         // back to labels itself.
         onFallback={() => {}}
         links={onOpen ? { dir, open: onOpen, resolveWiki, src: (p) => rawUrl(root, p) } : undefined}
+        footer={footer}
       />
     </div>
   );

--- a/apps/portal-next/web/src/pages/files/Reader.tsx
+++ b/apps/portal-next/web/src/pages/files/Reader.tsx
@@ -32,6 +32,7 @@ import {
   type FileRead, type FileRoot,
 } from '../../lib/files';
 import { ErrState } from '../../components/states';
+import { Tooltip } from '../../components/Tooltip';
 import { useMe } from '../../components/UserMenu';
 import { hasRole } from '../../lib/me';
 import { DocIndex, type RootTree } from './DocIndex';
@@ -425,10 +426,29 @@ export function Reader() {
                       </button>
                       /{dirName(path)}<b>{baseName(path)}</b>
                     </p>
+                    {/* A GLYPH, not a word. Editor.tsx:704 states the rule
+                        where it is enforced - "chrome that spells itself out in
+                        words is chrome that keeps taking width from the file" -
+                        and the editor's own Edit control, one click away, is
+                        this exact button with this exact icon. Two treatments
+                        for one action was the only thing between them.
+
+                        Still a <Link>, and `.fx-hbtn` is a class rather than an
+                        element rule so it dresses an anchor unchanged. The
+                        destination, the role gate and the `writable` check are
+                        untouched; `aria-label` keeps the control named for
+                        anyone not reading pixels, which the word did
+                        implicitly. */}
                     {mayEdit && (
-                      <Link className="btn sm rd-edit" to={filesHref('edit', root, path)}>
-                        <Pencil size={13} aria-hidden="true" /> Edit
-                      </Link>
+                      <Tooltip label="Edit this file" align="end">
+                        <Link
+                          className="fx-hbtn rd-edit"
+                          to={filesHref('edit', root, path)}
+                          aria-label="Edit this file"
+                        >
+                          <Pencil size={14} aria-hidden="true" />
+                        </Link>
+                      </Tooltip>
                     )}
                   </div>
                   {/* One provenance line, not the inspector's eleven facts. The
@@ -473,14 +493,24 @@ export function Reader() {
                       (trees[root]?.entries ?? []).map((e) => e.path), t,
                     )}
                     onLoad={onFileLoad}
-                  />
-                  {/* AFTER the document, never beside it. Backlinks are context
-                      you want once you have read the thing, and a sidebar of
-                      them competes with the outline for the same glance. */}
-                  <Backlinks
-                    index={graph[root] ?? null}
-                    path={path}
-                    onOpen={(p) => openDoc(root, p, undefined)}
+                    // AFTER the document, never beside it. Backlinks are context
+                    // you want once you have read the thing, and a sidebar of
+                    // them competes with the outline for the same glance.
+                    //
+                    // A PROP AND NOT A SIBLING, which is the whole of #153: as a
+                    // sibling it landed below `.fx-read`, and `.fx-read` is the
+                    // element that scrolls - so the panel was docked to the
+                    // bottom of the pane, in view at every scroll position, on
+                    // every document. "After the document" and "below the
+                    // document" are different places and the difference is
+                    // invisible until you scroll.
+                    footer={(
+                      <Backlinks
+                        index={graph[root] ?? null}
+                        path={path}
+                        onOpen={(p) => openDoc(root, p, undefined)}
+                      />
+                    )}
                   />
                 </div>
               </>

--- a/apps/portal-next/web/src/pages/files/editor.css
+++ b/apps/portal-next/web/src/pages/files/editor.css
@@ -577,31 +577,26 @@
    for a control that no longer exists. */
 
 /* ── read view (markdown) ────────────────────────────────────────────────── */
-/* `max-width` on the SCROLLER, and it is the load-bearing half of the two-width
-   rule (--read-wide in index.css, where the reasoning is). It bounds the column,
-   which is what makes the `100%` escapes below mean "the full column" rather
-   than "the full window" - the difference between a document with two related
-   widths and one that changes width every few blocks. */
-.bothy-files .fx-read {
-  flex: 1; min-height: 0; overflow: auto; margin: 0; padding: 24px 28px 44px;
-  max-width: var(--read-wide);
-}
+/* NO `max-width` HERE, ever. This is the element with `overflow: auto`, so a
+   max-width on it puts the SCROLLBAR wherever the cap lands - in the middle of
+   the page rather than at the edge of the pane. Sizing a scroll container is
+   how you move a scrollbar; it is not how you size a document. The blocks are
+   sized instead, one rule below. */
+.bothy-files .fx-read { flex: 1; min-height: 0; overflow: auto; margin: 0; padding: 24px 28px 44px; }
 .bothy-files .fx-read:focus-visible { outline: 2px solid var(--ring); outline-offset: -2px; }
-/* The measure comes from --read-measure (index.css, where the reasoning is).
-   Full-bleed for the two things that are not prose - and "full" is now the
-   column, not the viewport. */
+/* ONE width for every block, from --read-measure (index.css, where the
+   reasoning is), which is now a stretch. There is deliberately no exception
+   under this line: a rule that lets one kind of block out is the thing that
+   made a table 1.7x the width of the paragraph above it. */
 .bothy-files .fx-read > * { max-width: var(--read-measure); }
-.bothy-files .fx-read > .md-tbl-wrap,
-.bothy-files .fx-read > .md-pre { max-width: 100%; }
-/* A FIGURE IS NOT PROSE EITHER, and it is the third thing that has to be let out
-   of the measure. `![x](y)` on its own line lands inside a .md-p - it is parsed
-   as inline content, so there is no element of its own to target, hence `:has`
-   (already used in explorer.css and shell.css, so no new browser assumption).
-
-   Measured on docs/ARCHITECTURE.md's generated diagrams: capped at 72ch they
-   render at ~0.7 scale, which puts their 15px labels at about 10px. A diagram
-   nobody can read is the failure this whole change set exists to fix. */
-.bothy-files .fx-read > .md-p:has(> .md-img) { max-width: 100%; }
+/* The `:has(> .md-img)` escape that used to be here is GONE, and its argument
+   went with the measure rather than being overruled: it existed so a figure
+   could break out of 72ch, because a diagram capped at 72ch rendered its 15px
+   labels at about 10px (#103). With one stretching width there is nothing left
+   to break out of - a figure gets the same full width every other block gets,
+   which is more than the escape ever gave it. `.md-img` keeps its own
+   `max-width: 100%`, which is what stops a 1280px screenshot widening the
+   column it sits in. */
 
 .bothy-files .md { color: var(--fg-muted); font-size: var(--read-fs); line-height: var(--read-lh); }
 .bothy-files .md .md-h { color: var(--fg); letter-spacing: -0.015em; line-height: 1.25; margin: 26px 0 10px; font-weight: 700; }
@@ -642,7 +637,7 @@
 }
 /* A CLIP CARRIES .md-img AS WELL AS .md-video and therefore needs no rules of
    its own: it wants exactly the same box as a picture - block flow, the frame,
-   `max-width: 100%`, and the `:has(> .md-img)` escape from the measure above.
+   `max-width: 100%`, and the one stretching width every block above gets.
    The second class is a hook for the day one of those stops being true. */
 /* Audio has no picture, so none of .md-img's framing applies: this is a strip of
    transport controls, which the browser draws itself. It only needs to be a

--- a/apps/portal-next/web/src/pages/files/editor.css
+++ b/apps/portal-next/web/src/pages/files/editor.css
@@ -577,10 +577,19 @@
    for a control that no longer exists. */
 
 /* ── read view (markdown) ────────────────────────────────────────────────── */
-.bothy-files .fx-read { flex: 1; min-height: 0; overflow: auto; margin: 0; padding: 24px 28px 44px; }
+/* `max-width` on the SCROLLER, and it is the load-bearing half of the two-width
+   rule (--read-wide in index.css, where the reasoning is). It bounds the column,
+   which is what makes the `100%` escapes below mean "the full column" rather
+   than "the full window" - the difference between a document with two related
+   widths and one that changes width every few blocks. */
+.bothy-files .fx-read {
+  flex: 1; min-height: 0; overflow: auto; margin: 0; padding: 24px 28px 44px;
+  max-width: var(--read-wide);
+}
 .bothy-files .fx-read:focus-visible { outline: 2px solid var(--ring); outline-offset: -2px; }
 /* The measure comes from --read-measure (index.css, where the reasoning is).
-   Full-bleed for the two things that are not prose. */
+   Full-bleed for the two things that are not prose - and "full" is now the
+   column, not the viewport. */
 .bothy-files .fx-read > * { max-width: var(--read-measure); }
 .bothy-files .fx-read > .md-tbl-wrap,
 .bothy-files .fx-read > .md-pre { max-width: 100%; }

--- a/apps/portal-next/web/src/pages/files/read.css
+++ b/apps/portal-next/web/src/pages/files/read.css
@@ -15,9 +15,10 @@
    argues for in the IDE and for the same reason - a fixed centre plus a
    remainder rail is a reconciliation bug waiting for a resize.
 
-   The document is NOT stretched to the column: `.fx-read > *` is already capped
-   at 72ch (editor.css), which is the measure this whole page exists to give
-   back. The extra width becomes margin, which is what a wide screen is for. */
+   The document STRETCHES to the column - one width for every block in it, from
+   --read-measure (editor.css applies it, index.css argues for it). It used to
+   be capped at 72ch with tables and code let out to `100%`, which is how the
+   same page came to have two widths that did not agree. */
 .bothy-files.bothy-read .rd-grid {
   flex: 1; min-height: 0;
   display: grid;

--- a/apps/portal-next/web/src/pages/files/read.css
+++ b/apps/portal-next/web/src/pages/files/read.css
@@ -172,7 +172,12 @@
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .bothy-files .rd-crumb b { color: var(--fg); font-weight: 700; }
-.bothy-files .rd-edit { flex: none; text-decoration: none; gap: 6px; }
+/* Edit is a `.fx-hbtn` now (#154), which already brings the box, the hover and
+   the 24px square. All an anchor wearing it needs from here is the underline
+   removed - and its Tooltip wrapper needs `flex: none`, or a long crumb shrinks
+   the button instead of ellipsising itself. */
+.bothy-files .rd-edit { text-decoration: none; }
+.bothy-files .rd-head-row > .tip-wrap { flex: none; }
 
 .bothy-files .rd-prov {
   display: flex; align-items: baseline; gap: 7px; margin: 7px 0 0;
@@ -442,8 +447,13 @@
    Under the document, separated by a rule rather than boxed: it is a footnote
    to the page, not a second panel competing with it. Renders nothing at all
    when a document has no inbound links - see the component. */
+/* NO max-width of its own. It is rendered INSIDE `.fx-read` now (#153 - as a
+   sibling it sat below the scroll container and was docked to the bottom of the
+   pane), so `.fx-read > * { max-width: var(--read-measure) }` already gives it
+   the document's measure. Restating it here would be a second copy of a number
+   that has to agree, which is how the reading widths drifted in the first
+   place. */
 .bothy-files .rd-backlinks {
-  max-width: var(--read-measure);
   margin: 34px 0 8px;
   padding-top: 16px;
   border-top: 1px solid var(--line);

--- a/docs/plans/the-guide-and-the-reader.md
+++ b/docs/plans/the-guide-and-the-reader.md
@@ -1,0 +1,293 @@
+# The guide, and the reader around it
+
+_Written 2026-08-20. Status: proposed, nothing started._
+
+`docs/plans/reading-first.md` argued that Files should open as a reader, and it
+shipped (#94, #103, #129, #138). This document is the next argument, and it comes
+from using the thing: the reader is right about the document and wrong about
+almost everything around it.
+
+Ten complaints, and they are not ten separate bugs. They are three:
+
+1. **The reader does not know what it is for.** It opens on whichever root
+   happens to be writable first - one person's private notes - and offers the
+   guide as one card among seven. The manual for the product is not the
+   destination; it is a link.
+2. **The side panel is still the Explorer's controls in the reader's clothes.**
+   A four-root scope select, a glob box and a case toggle, crammed into 296px,
+   answering questions a reader browsing a manual does not have.
+3. **The document has no single width, and one panel is not inside the
+   document at all.**
+
+---
+
+## 1. Files opens on the guide. Not "usually" - always.
+
+`/files` today lands on Start with `?root=` set by `defaultRoot()`, which picks
+the first writable root. On this box that is `notes`. #94 already fixed this once
+- it used to redirect straight into that root's README, and the complaint was
+that "open Files" meant "open somebody else's filing system". Start replaced the
+redirect, which stopped the ambush but left the destination unanswered: the first
+screen is still a chooser, and the thing a new reader needs is one click past it.
+
+**The proposal: `/files` is the guide.**
+
+```
+/files              →  redirect to /files/guide
+/files/guide        GUIDE   the manual. The default, and what the nav points at.
+/files?root=&path=  BROWSE  today's reader, unchanged. Every deep link survives.
+/files/edit         WORK    the IDE, unchanged.
+```
+
+`routes.ts` is where this goes, because that module already owns every Files URL
+and already has a truth table over it (`checks/redirect-table.mjs`). Two rules it
+imposes on this change: `/files/guide` must be tested **before** `/files` in
+`filesMode()` for the same reason `/files/edit` is (one is a prefix of the
+other), and the builder must keep `?root=&path=` working on the browse mode or
+the redirect table will say so.
+
+**Guide mode is a mode, not a second page.** Same `Reader`, same `FileView`, same
+`md.tsx`, same `Toc`. What changes is what the side panel is pointed at:
+`root=stacks`, scoped to `docs/guide`, and no control that offers to leave.
+
+**The way out is one control**, in the panel header, reading something like
+"Browse all files". Guide mode has no root picker (item 3), because a manual with
+a root picker on it is a filesystem browser that happens to be showing a manual.
+
+---
+
+## 2. The index is a tree of the guide, and nothing else
+
+`DocIndex` is flat inside a root by design, and the design document says why:
+"prose is ~84 files across the two documentation roots, and a tree exists to make
+3,500 files navigable". That reasoning was right for a panel listing four roots.
+It is wrong for a panel listing one folder of one root, where the folder
+structure *is* the table of contents.
+
+In guide mode the index is:
+
+- **One root section, and it is not drawn as one.** No `stacks` header, no
+  chevron, no lock glyph, no count - there is nothing to choose between.
+- **A real tree**, nested, with expand and collapse. `tree.ts`'s `buildTree`
+  already produces exactly this shape and the Explorer already renders it; the
+  reader should reuse it rather than grow a second one.
+- **Guide files only.** `isProse` is the wrong filter here - the scope is.
+  The listing is fetched with `?path=docs/guide`, so the service walks the
+  folder and nothing else can appear.
+- **Ordered by the guide's own reading order**, not alphabetically. Today
+  `configuring` sorts before `installing`, which is backwards for a manual whose
+  pages end in `## Next`. The order lives in one place; see §7.
+
+In browse mode the index keeps every root, and gains the same tree - the flat
+"folder, then its files" grouping is the thing item 4 is complaining about.
+
+---
+
+## 3. The side panel's controls fit the panel they are in
+
+`SearchView` is reused whole by the reader, which was the right call and is now
+the source of three of these complaints. Its options row - a `select` capped at
+110px, a mono glob input, and a 24px case toggle - is an IDE control strip at
+296px, and it wraps, crowds and touches the edge.
+
+**Guide mode gets two controls, side by side:** the search box, and the case
+toggle. Nothing else. Search runs with `root=stacks` and `path=docs/guide`,
+which `searchFiles()` already supports (`opts.path`) and `app.py` already
+implements - no service change. No "every root", no glob: within seven documents
+neither has a question to answer.
+
+**Browse mode keeps all four**, but they stop competing for one row:
+
+- search on its own row, full width;
+- scope (root + folder) becomes the header control described in §4, not a
+  `select` in the options row;
+- glob and case share the second row, with the glob box given the width the
+  scope select was taking.
+
+The panel also needs its edges back. `padding: 0 10px` on a row whose text is
+ellipsised means the last legible character is four pixels from a border. The
+rail's own gutter should be one value, applied to every row in it.
+
+---
+
+## 4. Choosing where you are looking is a control, not links at the edge
+
+Two defects, one cause.
+
+**The scope does not survive opening a file.** `Reader.openDoc()` builds a fresh
+`URLSearchParams` with `root` and `path` and nothing else, so `?in=` - the folder
+you narrowed to - is dropped the moment you click a document. That is item 5's
+"works only until I'm choosing a file and then it comes back". It is a two-line
+fix and it is a bug, not a design question: `onScope` deliberately preserves
+`path` for exactly the symmetric reason ("narrowing the index is a change to what
+you are BROWSING, not to what you are reading").
+
+**Choosing a root is a list of chips at the bottom of a scrolling panel.** In
+browse mode the roots are `RootSection` headers interleaved with their contents,
+so "go to `projects`" means scrolling past `notes`.
+
+The replacement is one control in the panel header - a chip reading
+`stacks / docs/guide` - opening a popover with:
+
+- the roots, as the `fx-rootchip` group the Explorer already renders;
+- a path input, monospace, with completions drawn from the listing the panel
+  already holds (no new request, no new endpoint);
+- Enter to go, Escape to close.
+
+`fx-rootchip` and `fx-hbtn` both exist in `shell.css` and `explorer.css` and are
+already the app's answer to these two shapes. This is assembly, not new chrome.
+
+---
+
+## 5. Two things in the document that are simply wrong
+
+**The backlinks panel is not inside the document.** `Reader` renders
+`<Backlinks>` as a *sibling* of `<FileView>` inside `.rd-body`, which is a flex
+column; `FileView`'s root is `.fx-doc { flex: 1 }` and the scrolling element is
+`.fx-read` inside it. So the panel is laid out **below the scroll container** -
+permanently docked to the bottom of the pane, in view at every scroll position,
+stealing height from the document on every page whether or not you care about
+inbound links. The comment above it says "AFTER the document, never beside it",
+which is the correct intent and the opposite of what the layout does.
+
+The fix is to render it **inside** the scroller, as the last block of the
+document, where its existing `max-width: var(--read-measure)` and its top rule
+already make it read as a footnote. `FileView` taking a `footer` node is the
+smaller change than making `.rd-body` the scroller, and it keeps `Toc`'s
+`scrollerOf()` walk finding the same element.
+
+**The Edit control is the only worded button in a strip of glyphs.** The reader
+draws `<Link className="btn sm"><Pencil/> Edit</Link>`. Every other action bar in
+Files - the editor's toolbar, the explorer's header - uses `.fx-hbtn`, a glyph, a
+`<Tooltip>` and an `aria-label`, and `Editor.tsx` writes the rule out: "chrome
+that spells itself out in words is chrome that keeps taking width from the file".
+The reader's Edit should be that, with the same `Pencil` at the same size.
+
+---
+
+## 6. One width for a document
+
+Today `.fx-read > *` is capped at `--read-measure` (72ch), and three kinds of
+block are let out of it to `max-width: 100%`: tables, code fences, and paragraphs
+containing an image. On a 1440px screen that is a document whose prose is ~660px
+and whose tables are ~1100px - which is item 9, and it is not a nit. A block that
+is 1.7× the width of the paragraph above it reads as a different document.
+
+**The two escapes were each individually right.** #103's argument for figures
+stands (a diagram capped at 72ch renders its 15px labels at 10px). The mistake is
+that the escape hatch is `100%` - an unbounded value that means "however wide the
+window happens to be" - rather than a second, bounded width.
+
+So: **two tokens, both bounded, and the column itself capped.**
+
+```
+--read-measure: 72ch     prose. Unchanged - it is the one number here that
+                         was already right.
+--read-wide:    96ch     tables, code fences, figures, and the callout and
+                         backlink blocks that sit at document level.
+```
+
+`.fx-read` gets `max-width: var(--read-wide)` so nothing in it can exceed the
+column, and the three escapes target `--read-wide` instead of `100%`. Left edges
+stay aligned; the widest block on the page is a known quantity; and a theme that
+wants a different reading rhythm sets two values rather than fighting a `100%`.
+
+Both are `ch`, so both track `--read-fs` - which is what makes §7 work.
+
+---
+
+## 7. Reading size, and where a preference lives
+
+The right-hand outline is 11.5px and the index rows are 12.5px, on a surface
+whose whole argument is that a document is not a dashboard. They should be
+bigger, and more usefully they should be **settable**, because "bigger" is a
+different number for a 14" laptop and a 27" monitor.
+
+Two tokens, applied on the reader's root element:
+
+```
+--read-fs         the document. Already exists (16px).
+--rd-ui-fs        the panels - index rows, outline entries, breadcrumbs.
+                  New; these are ~30 literal values today, which is the same
+                  problem --read-* was tokenised to fix in the first place.
+```
+
+**Where the value is stored is a real decision and #145 is already open on it.**
+`docs/plans/control-and-settings.md` §6b draws the line: theme, pane widths and
+collapsed groups belong to the **browser** and `localStorage` is honest about
+that; identity and roles belong to the **user**; and only "default root, default
+landing page, favourites" needs a store that does not exist.
+
+A text size is on the browser's side of that line by the same test - it is a fact
+about the screen you are sitting at, not about you - so it can ship now, as
+`bothy-reading-v1`, beside `bothy-files-panes-v1` and `bothy-read-recent-v1`, and
+Settings can document it in the table that already documents those three.
+
+A VS-Code-style per-user `settings.json` is a larger thing and it is #145's
+question, not this document's. If the answer there turns out to be yes, this
+preference moves into it and the localStorage key becomes the fallback - which is
+the same migration the theme would make.
+
+---
+
+## 8. The guide is seven pages and the product is bigger than seven pages
+
+`docs/guide/` covers installing, configuring, the console, files, roles and
+themes. Everything below is either documented only in a design document, only in
+`ARCHITECTURE.md`, or only in the source:
+
+| New page | What it has to say | Source that already exists |
+|---|---|---|
+| `the-cli.md` | every `bothy` subcommand, what passes through to `just`, `init`/`upgrade`/`self-update` | `scripts/bothy` `usage()`, `scripts/checks/cli-commands.sh` |
+| `projects.md` | declaring a project so the console can see it - **`project.dev.yml`, which is YAML and not TOML** - every key, every service key, every state | `apps/portal-collector/README.md`, `collect.py:664`, `edge/dynamic/project.example.yml` |
+| `services.md` | adding a service to the stack, the `dev.portal.*` labels, grouping, what publishes a port | `ARCHITECTURE.md` §7, §5, `CONTRIBUTING.md` |
+| `settings.md` | what Settings shows, what it deliberately will not write, and why | `control-and-settings.md` §6, `Settings.tsx` |
+| `monitoring.md` | what is scraped, what is retained, where the dashboards come from | `ARCHITECTURE.md` §5, `monitoring/` |
+| `backups.md` | the timer, retention, what is and is not covered, restoring | `README.md` §Backups, `scripts/backup.sh` |
+| `troubleshooting.md` | the traps, generalised - a 200 proves nothing, no `Host()` rules, dotless hostnames | `README.md` §"Things that will catch you", `ARCHITECTURE.md` §8 |
+| `upgrading.md` | what `bothy upgrade` does to the box vs `self-update` to the tool | `scripts/bothy`, #141 |
+
+`themes.md` also needs the file-format half it currently defers to
+`apps/portal-next/data/themes/README.md`, since the guide is written for
+"somebody who has not read the source".
+
+Three constraints, all of them existing:
+
+- **No front-matter.** Nothing in this repository has any. One H1 on line 1.
+- **Every relative link must resolve** - `scripts/checks/doc-links.sh` fails CI
+  otherwise.
+- **Adding a page means editing three other things**: the "Where to start" table
+  in `docs/guide/index.md`, the table in `README.md` (including its hard-coded
+  "Seven pages", which is exactly the rotting sentence `start.ts` warns about),
+  and the `## Next` footer of its neighbours.
+
+That third constraint is the argument for §2's ordering living in one place: an
+ordered manifest the guide index, the README table and the reader's tree can all
+read, instead of three hand-maintained lists that already disagree.
+
+---
+
+## 9. Sequence
+
+Each step ships on its own and leaves the product coherent.
+
+1. **The two document-level bugs** (§5) - backlinks inside the scroller, Edit as
+   a glyph. Smallest, visible immediately, no new concepts.
+2. **One width** (§6) - two tokens, four rules.
+3. **The tree** (§2, browse mode) - reuse `buildTree`, nested and collapsible.
+4. **Guide mode** (§1, §3) - the route, the redirect, the scoped listing, the
+   two-control panel. Depends on 3.
+5. **The scope control** (§4) - the header chip and its popover, and the
+   `openDoc` fix, which can land with any of the above.
+6. **Reading size** (§7) - the tokens, the store, the Settings row.
+7. **The pages** (§8) - and the ordering manifest, which step 4 will want.
+
+## 10. What this is not
+
+- **Not a second reader.** Guide mode is a scope and a panel, not a page. If it
+  ever needs its own renderer or its own document component, the split is wrong.
+- **Not a write path.** `reading-first.md` §7 stands unchanged: reading mode
+  never writes. Every preference here is `localStorage`.
+- **Not a docs site.** The guide is still files in a root, served by the same
+  four endpoints, editable by the same editor, with no index to keep in sync
+  beyond the one ordering manifest §8 asks for.


### PR DESCRIPTION
Step 1 of `docs/plans/the-guide-and-the-reader.md` §9 — the three smallest items from the reader review, plus the plan they came from.

**One PR for three issues on purpose.** They are one concern (the reading surface), they land in the same four files, and two of them touch adjacent lines of `read.css`. Split into three, the middle one would be a merge conflict with itself.

## `fix(reader): a document has one width, and it stretches` — closes #155

`.fx-read > *` was capped at `--read-measure` (72ch); tables, code fences and figures were let out to `max-width: 100%`. Two widths, and on a 1440px screen that was prose at ~660px next to a table at ~1100px — a block 1.7x the width of the paragraph above it reads as a different document.

**The first attempt was wrong and is corrected in the third commit.** Capping the column meant a `max-width` on `.fx-read` — which is the element with `overflow: auto`, so the cap took the **scrollbar** with it and parked it in the middle of the page. Sizing a scroll container is how you move a scrollbar, not how you size a document. It also still left two widths wearing one name (prose at 72ch inside a column at 96ch).

So: `--read-measure` is `100%`, every top-level block takes it, `.fx-read` carries no max-width at all, and there are **no exceptions left** — the `.md-tbl-wrap`/`.md-pre` escapes are redundant against it and the `:has(> .md-img)` figure escape is deleted. That escape's argument (#103: a diagram capped at 72ch renders its 15px labels at ~10px) is answered rather than overruled — a figure now gets the full width every other block gets, which is more than the escape gave it. `.md-img` keeps its own `max-width: 100%`, which is what stops a 1280px screenshot widening its column.

Long lines on a very wide screen are the cost, paid knowingly: the alternative here was two widths that did not agree. `--read-measure` is still a token, so a theme that wants a measure back sets one value. `--read-wide` came and went inside this branch and is not in the final diff.

## `fix(reader): backlinks were below the scroller` — closes #153, #154

**Backlinks were docked to the pane.** `Reader.tsx` rendered `<Backlinks>` as a *sibling* of `<FileView>` inside `.rd-body`; the element with `overflow: auto` is `.fx-read`, two levels down. The panel was laid out below the scroll container — permanently in view at every scroll position. Nothing about it was `position: sticky`, which is why it did not read as a layout bug. Its own comment said "AFTER the document, never beside it"; that was the right intent, and "after" and "below" are different places.

`FileContent` now takes a `footer` node rendered as the last block inside the rendered markdown. A prop is smaller than moving the scroller, and it keeps `Toc`'s `scrollerOf()` walk (which finds the scroller by computed `overflow-y`, deliberately not by class) resolving to the same element. Only the markdown branch takes one — an image, a PDF and a download card have no end to be after.

**Edit was the only worded button in a strip of glyphs.** `Editor.tsx:704` states the rule where it is enforced, and the editor's own Edit control one click away is `.fx-hbtn` with this exact `Pencil`. Still a `<Link>`; the destination, the `editor` role gate and the file's `writable` check are untouched.

## How this was confirmed

`npm run typecheck` clean, `apps/portal-next/checks/run.sh` **247 pass · 0 fail**.

Then rebuilt `portal-next` and measured the live page in Chromium (Playwright) — geometry rather than a screenshot, because all three claims are about geometry. On `docs/guide/roles.md`, 2200px viewport, 1672px pane:

```
  readMaxWidth         none          (the scroller is not sized)
  scrollbarAtPaneEdge  true          scroller right 1968 == pane right 1968
  distinctBlockWidths  [1616]        heading, paragraph, table, list, pre,
                                     backlinks - one width, no outlier
```

On `docs/plans/reading-first.md`, same viewport, for the backlinks fix:

```
  backlinksInsideScroller  true
  backlinks top, scrollTop 0 -> 400:  3999 -> 3599   (moves with the document)

  editTag "A"   editClass "fx-hbtn rd-edit"
  editLabel "Edit this file"   editText ""
```

`/files/edit` re-checked because `.fx-read` is shared: preview renders, headings intact, **0** stray `.rd-backlinks` in the editor. **0** console errors or warnings across the session.

## Not in this PR

The other seven issues from the review — #149 #150 #151 #152 #156 #157 #158. Sequence is in the plan's §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
