### PR TITLE
feat(reader): Files opens on the guide, and the index is a tree

### DIFF
--- a/apps/portal-next/checks/run.sh
+++ b/apps/portal-next/checks/run.sh
@@ -46,6 +46,9 @@ mv "$OUT/titles.js" "$OUT/titles.mjs"
 (cd "$WEB" && npx tsc src/pages/files/start.ts --ignoreConfig \
   --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
 mv "$OUT/start.js" "$OUT/start-mod.mjs"
+(cd "$WEB" && npx tsc src/pages/files/guide.ts --ignoreConfig \
+  --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
+mv "$OUT/guide.js" "$OUT/guide-mod.mjs"
 (cd "$WEB" && npx tsc src/lib/contract.ts --ignoreConfig \
   --module esnext --target es2022 --moduleResolution bundler --outDir "$OUT" >/dev/null)
 mv "$OUT/contract.js" "$OUT/contract.mjs"

--- a/apps/portal-next/checks/start-table.mjs
+++ b/apps/portal-next/checks/start-table.mjs
@@ -28,6 +28,8 @@ import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { DOCS_ROOT, DOC_SHELF, frontPageOf, mergeRecent, parseRecents, RECENTS_MAX, titlePathOf } from './start-mod.mjs';
 import { titleOf } from './titles.mjs';
+import { GUIDE_DIR, GUIDE_ROOT } from './files-routes.mjs';
+import { GUIDE_ORDER, guideRank, sortGuide } from './guide-mod.mjs';
 
 // TOLD where the repository is, not inferred from this file's own location.
 // run.sh copies the checks into a temp directory beside the compiled modules, so
@@ -209,4 +211,58 @@ check(
 );
 
 console.log(bad ? `\n${bad} FAILED` : '\nall good');
+
+// ── 4. THE GUIDE'S ORDER AND THE GUIDE'S FOLDER DESCRIBE EACH OTHER ─────────
+//
+// GUIDE_ORDER is the reading order of docs/guide - the fourth copy of a list
+// that already existed in docs/guide/index.md, README.md and each page's
+// `## Next` footer, and the only one a program can check. It has two failure
+// modes and both are silent in the browser:
+//
+//   · a page NAMED here that is not on disk       - a row that opens "No such
+//                                                   file", exactly like §1
+//   · a page ON DISK that is not named here       - it still renders, at the
+//                                                   BOTTOM, alphabetically,
+//                                                   after everything ordered.
+//                                                   Nothing is missing, so
+//                                                   nobody notices it is last.
+//
+// So the check runs in BOTH directions. The second is the one worth having: it
+// is what turns "somebody added a guide page and forgot the manifest" into a
+// red line rather than a page quietly filed at the end.
+console.log('');
+console.log('── the guide, ordered ──────────────────────────────────');
+
+check('GUIDE_ROOT is the root the shelf uses', GUIDE_ROOT, DOCS_ROOT);
+
+const guideDir = join(REPO, GUIDE_DIR);
+if (!existsSync(guideDir)) {
+  check(`${GUIDE_DIR} exists`, false, true);
+} else {
+  const onDisk = readdirSync(guideDir).filter((f) => f.endsWith('.md')).sort();
+  for (const name of GUIDE_ORDER) {
+    check(`GUIDE_ORDER names a file that exists: ${name}`, existsSync(join(guideDir, name)), true);
+  }
+  const missing = onDisk.filter((f) => !GUIDE_ORDER.includes(f));
+  check(`every .md in ${GUIDE_DIR} is in GUIDE_ORDER`, missing, []);
+  check('GUIDE_ORDER has no duplicates', GUIDE_ORDER.length, new Set(GUIDE_ORDER).size);
+  check('the guide opens on its index', GUIDE_ORDER[0], 'index.md');
+}
+
+// An unranked page sorts LAST, not first. `Infinity` is what does that, and the
+// spelling matters: -1 from indexOf would have sorted it to the front, ahead of
+// the index page.
+check('an unlisted page ranks last', guideRank('docs/guide/zzz.md') === Infinity, true);
+check('rank is read from the basename, not the path',
+  guideRank('anything/at/all/installing.md'), GUIDE_ORDER.indexOf('installing.md'));
+// The argument is never sorted in place: the listing handed in is the same array
+// the panel renders from, and reordering a caller's state behind its back is the
+// kind of bug that only shows up as a list that scrambles on re-render.
+const src = [{ p: 'docs/guide/themes.md' }, { p: 'docs/guide/index.md' }];
+const sorted = sortGuide(src, (x) => x.p);
+check('sortGuide puts the index first', sorted.map((x) => x.p),
+  ['docs/guide/index.md', 'docs/guide/themes.md']);
+check('sortGuide does not sort its argument', src.map((x) => x.p),
+  ['docs/guide/themes.md', 'docs/guide/index.md']);
+
 process.exit(bad ? 1 : 0);

--- a/apps/portal-next/web/src/App.tsx
+++ b/apps/portal-next/web/src/App.tsx
@@ -13,6 +13,7 @@ import { Reader } from './pages/files/Reader';
 import { ControlShell } from './pages/control/ControlShell';
 import { Control } from './pages/control/Control';
 import { LEGACY_PATHS, legacyTarget } from './pages/control/redirects';
+import { GUIDE_PATH } from './pages/files/routes';
 
 // Multi-page, one shared poll (lifted into <DataProvider> in main.tsx). The
 // AppShell is the persistent layout (one topbar - the global sidebar was
@@ -60,7 +61,14 @@ export function App() {
             route paths and the two link builders live in pages/files/routes.ts
             with a truth table over them, because a builder that drops `path` is
             a link that answers 200 and quietly goes somewhere else. */}
-        <Route path="files" element={<Reader />} />
+        {/* GUIDE is a third destination, not a third page - same Reader, one
+            prop (#149). A BARE /files redirects into it, and a /files that
+            carries `?root=` or `?path=` does not: every deep link written before
+            this, every recents row and every Edit round trip still lands where
+            it always did. `FilesLanding` is that one rule, and it is one rule
+            precisely so nobody has to remember it twice. */}
+        <Route path="files" element={<FilesLanding />} />
+        <Route path="files/guide" element={<Reader mode="guide" />} />
         <Route path="files/edit" element={<Files />} />
 
         {/* The retired URLs. Built from the table rather than listed again here,
@@ -108,4 +116,30 @@ function NotFound() {
       </div>
     </div>
   );
+}
+
+/**
+ * What a bare `/files` is (#149).
+ *
+ * The nav's Files entry points at `/files` with no query, and that now means
+ * "the manual" - opening the section on somebody's private notes root was the
+ * complaint #94 was filed about and Start only softened it. A REDIRECT rather
+ * than rendering the guide at this path, so there is one URL per destination
+ * and the address bar always says which one you are in.
+ *
+ * THE QUERY IS THE TEST, and it is the whole of the rule: `/files?root=notes` or
+ * `/files?path=x` is a link somebody already holds - a bookmark, a recents row,
+ * the editor's way back - and redirecting it into the guide would break every
+ * one of them while still answering 200. `?in=` counts too: a scoped index is a
+ * URL the shelf writes. Anything else on the query is not ours, and a bare
+ * `?utm_source=` should not be what keeps somebody out of the guide, so only
+ * these three are consulted.
+ *
+ * `replace`, so Back leaves the section rather than bouncing off `/files`.
+ */
+function FilesLanding() {
+  const { search } = useLocation();
+  const q = new URLSearchParams(search);
+  const asked = q.get('root') || q.get('path') || q.get('in');
+  return asked ? <Reader /> : <Navigate to={GUIDE_PATH} replace />;
 }

--- a/apps/portal-next/web/src/pages/files/DocIndex.tsx
+++ b/apps/portal-next/web/src/pages/files/DocIndex.tsx
@@ -10,17 +10,23 @@
 //     anyone who came looking for a path. The Explorer shows the filename
 //     because the Explorer is a view of a filesystem; this is a view of a
 //     library.
-//   · IT IS PROSE FIRST. Markdown, rst and txt, grouped by folder. Everything
-//     else - 117 code files and 42 configs in the stacks root alone - is behind
-//     one "All files" toggle. The reader is NOT lied to about what is there;
-//     the order is by what the page is for, and the count of what is hidden is
-//     printed next to the switch that reveals it.
-//   · IT IS FLAT INSIDE A ROOT. Folder, then its documents, then the next
-//     folder - no chevrons, no expand state, no lazy children. That works here
-//     and does not work in the Explorer for one measurable reason: prose is
-//     ~84 files across the two documentation roots, and a tree exists to make
-//     3,500 files navigable. Turning on "All files" is the case where that
-//     stops being true, so that is exactly where the row cap lives.
+//   · IT IS PROSE FIRST. Markdown, rst and txt. Everything else - 117 code
+//     files and 42 configs in the stacks root alone - is behind one "All files"
+//     toggle. The reader is NOT lied to about what is there; the order is by
+//     what the page is for, and the count of what is hidden is printed next to
+//     the switch that reveals it.
+//   · IT IS A TREE (#150). It was flat inside a root - a folder heading, then
+//     its documents, then the next folder - on the argument that prose is ~84
+//     files and a tree exists to make 3,500 navigable. That was right for a
+//     panel listing four roots of loose prose and wrong for everything else: it
+//     cannot express nesting past one level, and the moment "All files" is on it
+//     hits its own row cap. `docs/brand/foundations` and `docs/brand/patterns`
+//     were two sibling headings identical for their first eleven characters.
+//
+//     THE TREE IS buildTree() FROM tree.ts, the one the Explorer renders. A
+//     second tree here is how two panels come to disagree about a folder they
+//     both list, and the property that makes it scale - a closed directory puts
+//     NOTHING in the DOM - is exactly the property this panel needs.
 //
 // A ROOT IS LOADED WHEN IT IS OPENED, not on mount. /tree is capped at 4,000
 // entries per root (portal-files/app.py MAX_LISTING) and there are four roots,
@@ -29,11 +35,12 @@
 // arrival; the others are one click.
 
 import { useEffect, useMemo, useRef } from 'react';
-import { ChevronRight, FileText, Layers, Lock } from 'lucide-react';
+import { ChevronRight, FileText, Folder, FolderOpen, Layers, Lock } from 'lucide-react';
 import { fmtBytes, type FileRoot, type TreeFile } from '../../lib/files';
 import { FileIcon } from './icons';
-import { folderLabel, isProse, stemOf, titleOf } from './titles';
-import { tailPath } from './tree';
+import { isProse, stemOf, titleOf } from './titles';
+import { buildTree, type Node } from './tree';
+import { sortGuide } from './guide';
 
 /** What one root's listing is doing. Held by the Reader, one per root. */
 export interface RootTree {
@@ -43,60 +50,98 @@ export interface RootTree {
   err: string | null;
 }
 
-/** Rows drawn for one root before the list gives up and says so.
+/** Files fed to the tree for one root before the panel gives up and says so.
  *
  *  Only reachable with "All files" on: prose tops out at 69 files in the largest
  *  root. It is the same refusal the Explorer's search results make at 250 and
  *  the tree listing makes at 4,000 - a list that silently stops is how someone
- *  concludes a file is not there. */
-const MAX_ROWS = 400;
-
-interface Folder { dir: string; files: TreeFile[] }
+ *  concludes a file is not there.
+ *
+ *  It caps the ENTRIES fed to the tree rather than the ROWS rendered, which the
+ *  flat list used to do. A tree renders only what is open, so a row cap would
+ *  cut a different set of files every time a folder was toggled. */
+const MAX_FILES = 1200;
 
 /** Lowercase, and every separator run collapsed to one space - so `a-b_c.md`
  *  and "A b c" compare equal. Used only to decide whether a row's title and its
  *  filename are the same string wearing different punctuation. */
 const fold = (s: string) => s.toLowerCase().replace(/[-_.\s]+/g, ' ').trim();
 
-/** Group a root's files by their directory, keeping the service's path order.
- *  `entries` arrives sorted by path, so directories come out in path order and
- *  the files inside one are already alphabetical - no second sort, and the
- *  ordering matches the tree the Explorer draws from the same bytes. */
-function foldersOf(entries: TreeFile[], prose: boolean): { folders: Folder[]; total: number } {
-  const at = new Map<string, Folder>();
-  const folders: Folder[] = [];
-  let total = 0;
-  for (const e of entries) {
-    if (e.dir === true) continue;
-    if (prose && !isProse(e.path)) continue;
-    total++;
-    if (total > MAX_ROWS) continue;
-    const cut = e.path.lastIndexOf('/');
-    const dir = cut === -1 ? '' : e.path.slice(0, cut);
-    let f = at.get(dir);
-    if (!f) { f = { dir, files: [] }; at.set(dir, f); folders.push(f); }
-    f.files.push(e);
-  }
-  return { folders, total };
+/** The key an expand/collapse state is held under. Both halves, because `home`
+ *  aliases every other root: the same relative directory exists in two open
+ *  sections, and keying on the directory alone would open both at once. */
+export const dirKey = (root: string, dir: string) => `${root} ${dir}`;
+
+/** Every directory on the way down to `path`, as expand keys. Used to open the
+ *  route to the document the URL names, so following a link three folders deep
+ *  leaves the index showing where you are rather than a collapsed root. */
+export function openTo(root: string, path: string): string[] {
+  const out: string[] = [];
+  let at = path.indexOf('/');
+  while (at !== -1) { out.push(dirKey(root, path.slice(0, at))); at = path.indexOf('/', at + 1); }
+  return out;
 }
 
-function DocRow({ entry, root, current, onOpen }: {
-  entry: TreeFile; root: string; current: string; onOpen: (root: string, path: string) => void;
+/**
+ * The entries this panel will draw, as a tree.
+ *
+ * `strip` removes a leading folder from every path BEFORE the tree is built,
+ * which is what stops the guide rendering as `docs` > `guide` > seven files: the
+ * listing is fetched scoped (`?path=docs/guide`) but the service still returns
+ * root-relative paths, so without this the panel spends two levels of indent
+ * redrawing the folder you are already in.
+ *
+ * THE STRIPPED PATH IS A DISPLAY AND EXPAND-STATE KEY AND NOTHING ELSE. Every
+ * node in the returned tree - including `node.entry.path`, which is a rewritten
+ * copy - carries the SHORT path, so nothing here may be handed to anything that
+ * opens a file. The caller puts the prefix back (`realPath` below), which it can
+ * do exactly because the prefix is one known string. Read from `entry.path`
+ * instead and a guide row opens `?path=index.md`, which is a real file in
+ * neither place - caught exactly that way.
+ */
+function treeOf(
+  entries: TreeFile[], prose: boolean, strip: string,
+): { root: Node; total: number; hidden: number } {
+  const cut = strip ? `${strip.replace(/\/+$/, '')}/` : '';
+  const keep: TreeFile[] = [];
+  let total = 0;
+  let hidden = 0;
+  for (const e of entries) {
+    if (e.dir === true) continue;
+    if (prose && !isProse(e.path)) { hidden++; continue; }
+    total++;
+    if (total > MAX_FILES) continue;
+    keep.push(cut && e.path.startsWith(cut) ? { ...e, path: e.path.slice(cut.length) } : e);
+  }
+  return { root: buildTree(keep), total, hidden };
+}
+
+/** A node's path as the SERVICE knows it - the prefix treeOf took off, put back.
+ *  This is the only path that may be opened, put in a URL, or compared against
+ *  the open document. */
+const realPath = (node: Node, strip: string) =>
+  (strip ? `${strip.replace(/\/+$/, '')}/${node.path}` : node.path);
+
+function DocRow({ node, root, current, depth, strip, onOpen }: {
+  node: Node; root: string; current: string; depth: number; strip: string;
+  onOpen: (root: string, path: string) => void;
 }) {
-  const on = entry.path === current;
-  const denied = entry.readable === false;
-  const name = entry.path.slice(entry.path.lastIndexOf('/') + 1);
-  const prose = isProse(entry.path);
+  const entry = node.entry;
+  // The TRUE path - what opens, and what the URL carries. NEVER `entry.path`:
+  // treeOf rewrote that one too. See realPath.
+  const real = realPath(node, strip);
+  const on = real === current;
+  const denied = entry?.readable === false;
+  const name = node.name;
+  const prose = isProse(name);
   // A title is a CLAIM about what the file is for, and it is only honest for
   // prose. `compose.yml` prettified to "Compose" would be inventing a document.
-  const label = prose ? titleOf(entry.path) : name;
+  const label = prose ? titleOf(name) : name;
   // The filename under the title, and only when the title is not already the
   // filename. Compared with the separators FOLDED, which is the whole point:
   // "Tailnet performance" and `tailnet-performance.md` are the same string with
   // different punctuation, and printing both put a second line under most rows
-  // that carried no information at all. What survives the fold is a title the
-  // filename genuinely does not spell - a dated incident note, mostly - and
-  // those are exactly the rows where the filename is worth showing.
+  // that carried no information at all.
   const sub = prose && fold(stemOf(name)) !== fold(label) ? name : '';
 
   return (
@@ -104,16 +149,19 @@ function DocRow({ entry, root, current, onOpen }: {
       <button
         type="button"
         className={`rd-doc${on ? ' on' : ''}${denied ? ' denied' : ''}`}
-        // Both halves, because `home` mirrors the other roots: the same
-        // relative path exists in two open sections, and a lookup on the path
-        // alone would scroll to whichever rendered first.
+        style={{ paddingLeft: `${8 + depth * 13}px` }}
+        // Both halves, because `home` mirrors the other roots: the same relative
+        // path exists in two open sections, and a lookup on the path alone would
+        // scroll to whichever rendered first.
         data-root={root}
-        data-path={entry.path}
+        data-path={real}
         aria-current={on ? 'true' : undefined}
         aria-disabled={denied || undefined}
         disabled={denied}
-        onClick={() => onOpen(root, entry.path)}
-        title={denied ? `${entry.path} - this session may not read it` : `${root}/${entry.path} · ${fmtBytes(entry.size)}`}
+        onClick={() => onOpen(root, real)}
+        title={denied
+          ? `${real} - this session may not read it`
+          : `${root}/${real}${entry ? ` · ${fmtBytes(entry.size)}` : ''}`}
       >
         {denied
           ? <Lock size={13} className="rd-doc-ico" aria-hidden="true" />
@@ -129,8 +177,84 @@ function DocRow({ entry, root, current, onOpen }: {
   );
 }
 
+/** One level of the tree. Recursive, and a CLOSED directory renders nothing -
+ *  the property tree.ts's header calls out, and the reason this scales to "All
+ *  files" on a 3,500-entry root with no virtualiser. */
+function TreeRows({ nodes, depth, root, current, open, onToggle, onOpen, order, strip }: {
+  nodes: Node[];
+  depth: number;
+  root: string;
+  /** The open document's TRUE path, to mark the row that is it. */
+  current: string;
+  /** The prefix treeOf removed, so rows can put it back. '' when none was. */
+  strip: string;
+  open: ReadonlySet<string>;
+  onToggle: (key: string) => void;
+  onOpen: (root: string, path: string) => void;
+  /** Reorder the FILES at each level. The guide has a reading order; every other
+   *  listing keeps buildTree's directories-then-alphabetical, which is what
+   *  every file explorer does and what makes a deep path predictable to scan. */
+  order?: (nodes: Node[]) => Node[];
+}) {
+  const dirs = nodes.filter((n) => n.dir);
+  const plain = nodes.filter((n) => !n.dir);
+  const files = order ? order(plain) : plain;
+  return (
+    <ul className="rd-list">
+      {dirs.map((n) => {
+        const key = dirKey(root, n.path);
+        const isOpen = open.has(key);
+        return (
+          <li key={n.path} className="rd-li">
+            <button
+              type="button"
+              className="rd-dir"
+              style={{ paddingLeft: `${8 + depth * 13}px` }}
+              aria-expanded={isOpen}
+              onClick={() => onToggle(key)}
+              title={`${n.path} - ${n.files.toLocaleString()} document${n.files === 1 ? '' : 's'}`}
+            >
+              <ChevronRight size={12} className={`rd-chev${isOpen ? ' open' : ''}`} aria-hidden="true" />
+              {isOpen
+                ? <FolderOpen size={13} className="rd-dir-ico" aria-hidden="true" />
+                : <Folder size={13} className="rd-dir-ico" aria-hidden="true" />}
+              <span className="rd-dir-name">{n.name}</span>
+              <span className="rd-dir-n tnum">{n.files.toLocaleString()}</span>
+            </button>
+            {isOpen && n.children.length > 0 && (
+              <TreeRows
+                nodes={n.children}
+                depth={depth + 1}
+                root={root}
+                current={current}
+                open={open}
+                onToggle={onToggle}
+                onOpen={onOpen}
+                order={order}
+                strip={strip}
+              />
+            )}
+          </li>
+        );
+      })}
+      {files.map((n) => (
+        <DocRow
+          key={n.path}
+          node={n}
+          root={root}
+          current={current}
+          depth={depth}
+          strip={strip}
+          onOpen={onOpen}
+        />
+      ))}
+    </ul>
+  );
+}
+
 function RootSection({
-  root, tree, open, onToggle, allFiles, current, currentRoot, onOpen, onRetry, onScope,
+  root, tree, open, onToggle, allFiles, current, currentRoot, onOpen, onRetry, dirs, onToggleDir,
+  strip = '',
 }: {
   root: FileRoot;
   tree: RootTree | undefined;
@@ -141,20 +265,17 @@ function RootSection({
   currentRoot: string;
   onOpen: (root: string, path: string) => void;
   onRetry: (root: string) => void;
-  /** Narrow the listing to one folder, the way `cd` narrows what `ls` shows.
-   *  '' is the whole root again. */
-  onScope: (root: string, dir: string) => void;
+  dirs: ReadonlySet<string>;
+  onToggleDir: (key: string) => void;
+  /** A folder prefix to remove from every path before the tree is built - see
+   *  treeOf. Set while this root is the scoped one, so a scoped listing does not
+   *  redraw the folder the breadcrumb above already names. */
+  strip?: string;
 }) {
   const entries = tree?.entries ?? [];
-  const { folders, total } = useMemo(
-    () => foldersOf(entries, !allFiles),
-    [entries, allFiles],
-  );
-  // What the toggle would ADD, stated on the toggle's own row rather than left
-  // for the reader to infer from a number that changed.
-  const hidden = useMemo(
-    () => (allFiles ? 0 : entries.filter((e) => e.dir !== true && !isProse(e.path)).length),
-    [entries, allFiles],
+  const { root: node, total, hidden } = useMemo(
+    () => treeOf(entries, !allFiles, strip),
+    [entries, allFiles, strip],
   );
 
   return (
@@ -165,7 +286,7 @@ function RootSection({
           <span className="rd-root-name mono">{root.key}</span>
           {root.readOnly && <Lock size={10} className="rd-root-ro" aria-label="read-only" />}
           {open && !tree?.loading && (
-            <span className="rd-root-n tnum">{total > MAX_ROWS ? `${MAX_ROWS}+` : total}</span>
+            <span className="rd-root-n tnum">{total > MAX_FILES ? `${MAX_FILES}+` : total}</span>
           )}
         </button>
       </h3>
@@ -186,45 +307,19 @@ function RootSection({
           </div>
         ) : (
           <>
-            {folders.map((f) => (
-              <div className="rd-folder" key={f.dir || '.'}>
-                {/* Truncated from the LEFT, via the same helper the Explorer's
-                    search hits use, and for the same measured reason: the tail
-                    of a folder path is what distinguishes it, and CSS's
-                    text-overflow can only cut the end. `docs/brand/foundations`
-                    and `docs/brand/patterns` are identical for the first
-                    eleven characters. */}
-                {/* A BUTTON, because it is the "cd into this" control.
-                    Scoping is what makes a big root usable: ~ is 3,200 entries
-                    and 360ms, any one folder inside it is a handful and 9ms, and
-                    the service now walks from the folder rather than filtering a
-                    full listing. The label is unchanged, so nothing moves - it
-                    just became something you can press. */}
-                <button
-                  type="button"
-                  className="rd-folder-h mono"
-                  title={`Only show ${root.key}/${f.dir}`}
-                  onClick={() => onScope(root.key, f.dir)}
-                  disabled={!f.dir}
-                >
-                  {tailPath(folderLabel(f.dir, root.key), 32)}
-                </button>
-                <ul className="rd-list">
-                  {f.files.map((e) => (
-                    <DocRow
-                      key={e.path}
-                      entry={e}
-                      root={root.key}
-                      current={root.key === currentRoot ? current : ''}
-                      onOpen={onOpen}
-                    />
-                  ))}
-                </ul>
-              </div>
-            ))}
-            {total > MAX_ROWS && (
+            <TreeRows
+              nodes={node.children}
+              depth={0}
+              root={root.key}
+              current={root.key === currentRoot ? current : ''}
+              open={dirs}
+              onToggle={onToggleDir}
+              onOpen={onOpen}
+              strip={strip}
+            />
+            {total > MAX_FILES && (
               <p className="rd-more">
-                {(total - MAX_ROWS).toLocaleString()} more in this root - use the search above.
+                {(total - MAX_FILES).toLocaleString()} more in this root - use the search above.
               </p>
             )}
             {/* The listing cap, carried through from /tree. The Explorer says
@@ -247,9 +342,84 @@ function RootSection({
   );
 }
 
+/**
+ * The guide's own index (#149, #150). One root, drawn as no root at all.
+ *
+ * No section header, no chevron, no lock glyph, no count - there is nothing to
+ * choose between, and a root selector on a manual makes it a filesystem browser
+ * that happens to be showing a manual. The scope is stripped off the paths so
+ * the panel does not spend two levels of indent redrawing the folder you are
+ * already in, and the files are in the guide's READING order rather than
+ * alphabetical: these pages end in `## Next`, and configuring-before-installing
+ * is backwards.
+ *
+ * Prose only, and NOT behind a toggle: `docs/guide` holds markdown and nothing
+ * else, so an "All files" switch here is a control that can only ever do
+ * nothing.
+ */
+function GuideIndex({ root, tree, strip, current, onOpen, onRetry, dirs, onToggleDir }: {
+  root: string;
+  tree: RootTree | undefined;
+  strip: string;
+  current: string;
+  onOpen: (root: string, path: string) => void;
+  onRetry: (root: string) => void;
+  dirs: ReadonlySet<string>;
+  onToggleDir: (key: string) => void;
+}) {
+  const { root: node, total } = useMemo(
+    () => treeOf(tree?.entries ?? [], true, strip),
+    [tree, strip],
+  );
+  // Ranked on the node's own (stripped) name, which is all guideRank reads -
+  // it takes the basename off whatever it is given, so the prefix is irrelevant
+  // here and putting it back first would be work for no answer.
+  const order = useMemo(() => (ns: Node[]) => sortGuide(ns, (n) => n.path), []);
+
+  if (!tree || tree.loading) {
+    return (
+      <div className="rd-skel" aria-hidden="true">
+        {Array.from({ length: 7 }, (_, i) => <span className="skel" key={i} />)}
+      </div>
+    );
+  }
+  if (tree.err) {
+    return (
+      <div className="rd-msg">
+        <p>{tree.err}</p>
+        <button type="button" className="btn ghost sm" onClick={() => onRetry(root)}>Retry</button>
+      </div>
+    );
+  }
+  if (!total) {
+    // The guide is files in THIS repository, so an empty listing means the
+    // `stacks` root is not mounted or the folder moved - a fact worth stating
+    // rather than an empty panel to stare at. Same refusal Start makes when
+    // DOCS_ROOT is absent: draw nothing rather than rows that all 404.
+    return (
+      <div className="rd-msg">
+        <p>The guide is not in this checkout - <span className="mono">{strip}</span> is empty or missing.</p>
+      </div>
+    );
+  }
+  return (
+    <TreeRows
+      nodes={node.children}
+      depth={0}
+      root={root}
+      current={current}
+      open={dirs}
+      onToggle={onToggleDir}
+      onOpen={onOpen}
+      order={order}
+      strip={strip}
+    />
+  );
+}
+
 export function DocIndex({
   roots, trees, openRoots, onToggleRoot, allFiles, onAllFiles,
-  currentRoot, currentPath, onOpen, onRetry, onScope, scope,
+  currentRoot, currentPath, onOpen, onRetry, dirs, onToggleDir, guide, scope = '', onScope,
 }: {
   roots: FileRoot[];
   trees: Record<string, RootTree | undefined>;
@@ -261,13 +431,24 @@ export function DocIndex({
   currentPath: string;
   onOpen: (root: string, path: string) => void;
   onRetry: (root: string) => void;
-  /** Narrow the listing to one folder, the way `cd` narrows what `ls` shows.
-   *  '' is the whole root again. */
-  onScope: (root: string, dir: string) => void;
+  /** Which directories are expanded, keyed by `dirKey(root, dir)`. Held by the
+   *  Reader, because following a cross-document link has to open the route down
+   *  to the new file and that is the Reader's event, not this panel's. */
+  dirs: ReadonlySet<string>;
+  onToggleDir: (key: string) => void;
+  /** Present in GUIDE mode, and its presence IS the mode: one root, one folder,
+   *  no chooser. Absent is the reader over every root. The caller resolves the
+   *  scoped listing into `trees[guide.root]` before handing it over, because the
+   *  composite key the Reader stores it under is the Reader's business. */
+  guide?: { root: string; dir: string };
   /** The folder currently scoped into, root-relative, '' for the whole root.
-   *  Only DocIndex needs it - it draws the breadcrumb; RootSection is handed
-   *  the callback and nothing else. */
-  scope: string;
+   *  Browse mode only - the guide is permanently scoped and has no way out of
+   *  its own folder by design. */
+  scope?: string;
+  /** Narrow the listing to one folder, the way `cd` narrows what `ls` shows.
+   *  '' is the whole root again. Reached from Start's shelf (the plans folder
+   *  card) and left by the breadcrumb below. */
+  onScope?: (root: string, dir: string) => void;
 }) {
   const box = useRef<HTMLDivElement | null>(null);
 
@@ -279,7 +460,7 @@ export function DocIndex({
   // `nearest` is doing real work - it is a no-op when the row is already on
   // screen, so browsing the list by hand is never yanked out from under the
   // pointer. The frame's wait is for the row itself: a root that has just been
-  // opened has not rendered its listing yet.
+  // opened, or a folder that has just been expanded, has not rendered yet.
   useEffect(() => {
     if (!currentPath) return;
     const raf = requestAnimationFrame(() => {
@@ -288,7 +469,27 @@ export function DocIndex({
         ?.scrollIntoView({ block: 'nearest' });
     });
     return () => cancelAnimationFrame(raf);
-  }, [currentRoot, currentPath, trees, allFiles]);
+  }, [currentRoot, currentPath, trees, allFiles, dirs]);
+
+  if (guide) {
+    return (
+      <div className="rd-index rd-index-guide" ref={box}>
+        <div className="rd-index-h">
+          <span className="rd-index-title">The guide</span>
+        </div>
+        <GuideIndex
+          root={guide.root}
+          tree={trees[guide.root]}
+          strip={guide.dir}
+          current={currentPath}
+          onOpen={onOpen}
+          onRetry={onRetry}
+          dirs={dirs}
+          onToggleDir={onToggleDir}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="rd-index" ref={box}>
@@ -308,13 +509,12 @@ export function DocIndex({
         </label>
       </div>
 
-      {/* THE WAY BACK. Only rendered while scoped, because a breadcrumb reading
-          just the root name is furniture - and the whole argument of this panel
-          is that the rarer case must not tax the common one.
-
-          Each segment is a step back UP, which is what a breadcrumb means, and
-          the last one is not a link: you are already there. */}
-      {scope && (
+      {/* THE WAY BACK OUT OF A FOLDER. Only rendered while scoped, because a
+          breadcrumb reading just the root name is furniture - and the whole
+          argument of this panel is that the rarer case must not tax the common
+          one. Each segment is a step back UP, which is what a breadcrumb means,
+          and the last one is not a link: you are already there. */}
+      {scope && onScope && (
         <nav className="rd-crumbs" aria-label="Folder">
           <button type="button" onClick={() => onScope(currentRoot, '')}>
             {currentRoot}
@@ -346,7 +546,11 @@ export function DocIndex({
           currentRoot={currentRoot}
           onOpen={onOpen}
           onRetry={onRetry}
-          onScope={onScope}
+          dirs={dirs}
+          onToggleDir={onToggleDir}
+          // Only the scoped root strips its prefix, and only while it IS the
+          // scoped one - the other sections are listing whole roots.
+          strip={scope && r.key === currentRoot ? scope : ''}
         />
       ))}
     </div>

--- a/apps/portal-next/web/src/pages/files/Reader.tsx
+++ b/apps/portal-next/web/src/pages/files/Reader.tsx
@@ -26,7 +26,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { ChevronLeft, GitCommitHorizontal, Pencil } from 'lucide-react';
+import { BookOpen, ChevronLeft, FolderTree, GitCommitHorizontal, Pencil } from 'lucide-react';
 import {
   isAuthError, listRoots, listTree, relDate,
   type FileRead, type FileRoot,
@@ -35,14 +35,14 @@ import { ErrState } from '../../components/states';
 import { Tooltip } from '../../components/Tooltip';
 import { useMe } from '../../components/UserMenu';
 import { hasRole } from '../../lib/me';
-import { DocIndex, type RootTree } from './DocIndex';
+import { DocIndex, openTo, type RootTree } from './DocIndex';
 import { FileView } from './FileView';
 import { SearchView } from './Search';
 import { SignInCard } from './SignInCard';
 import { Start } from './Start';
 import { Toc, useHeadings } from './Toc';
 import { frontPageOf, noteRecent, readRecents, type Recent } from './start';
-import { defaultRoot, filesHref } from './routes';
+import { GUIDE_DIR, GUIDE_ROOT, defaultRoot, filesHref, type FilesMode } from './routes';
 import { baseName, dirName, resolveWikiIn } from './tree';
 import { fetchLinks, type LinkIndex } from '../../lib/files';
 
@@ -63,14 +63,28 @@ import './read.css';
 
 const LOADING: RootTree = { entries: [], truncated: false, loading: true, err: null };
 
-export function Reader() {
+export function Reader({ mode = 'read' }: {
+  /** Which of the section's two reading destinations this is (routes.ts).
+   *
+   *  'guide' is Bothy's own manual: one root, one folder, and no control that
+   *  offers to leave either. It is a MODE and not a second page - same Reader,
+   *  same FileView, same renderer, same outline. What changes is what the side
+   *  panel is pointed at, which is the whole of docs/plans/the-guide-and-the-
+   *  reader.md §1: a manual carrying a root selector is a filesystem browser
+   *  that happens to be showing a manual. */
+  mode?: Extract<FilesMode, 'read' | 'guide'>;
+} = {}) {
   const [params, setParams] = useSearchParams();
-  const urlRoot = params.get('root') || '';
+  const guide = mode === 'guide';
+  // In guide mode both of these come from the ROUTE, not the query - filesHref
+  // does not write them and filesTarget does not read them, so a hand-typed
+  // `?root=notes` on /files/guide is ignored rather than half-honoured.
+  const urlRoot = guide ? GUIDE_ROOT : (params.get('root') || '');
   const path = params.get('path') || '';
   // The folder the index is narrowed to. In the URL rather than in state so
   // that a scoped view is a thing you can send someone, and so Back steps out
   // of a folder the way it stepped in.
-  const scope = (params.get('in') || '').replace(/^\/+|\/+$/g, '');
+  const scope = guide ? GUIDE_DIR : (params.get('in') || '').replace(/^\/+|\/+$/g, '');
   const { me } = useMe();
 
   const [roots, setRoots] = useState<FileRoot[]>([]);
@@ -89,6 +103,25 @@ export function Reader() {
   const [openRoots, setOpenRoots] = useState<Set<string>>(new Set());
   const [allFiles, setAllFiles] = useState(false);
   const [tick, setTick] = useState(0);
+
+  // ── which folders are expanded (#150) ─────────────────────────────────────
+  //
+  // Here rather than in DocIndex, because the event that has to open one is the
+  // READER's: following a cross-document link three folders deep must reveal the
+  // route down to the new file, and the panel does not know a link was followed.
+  //
+  // NOT persisted. Pane widths and collapsed service groups are, and the
+  // difference is that those are a layout you arranged; this is where you
+  // happen to be in a tree, and restoring it a day later would reopen folders
+  // for a document you are no longer reading.
+  const [dirs, setDirs] = useState<Set<string>>(new Set());
+  const toggleDir = useCallback((key: string) => {
+    setDirs((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  }, []);
 
   // The `#heading` of a followed cross-document link. State and NOT the URL:
   // main.tsx mounts a HashRouter, so the whole route already lives after a `#`
@@ -128,6 +161,22 @@ export function Reader() {
   const docBox = useRef<HTMLDivElement | null>(null);
   const root = urlRoot;
 
+  // ── the guide opens on the guide, without exception (#149) ────────────────
+  //
+  // `/files/guide` with no `?path=` lands on the manual's own front page rather
+  // than on an interstitial. There is no Start surface in this mode on purpose:
+  // docs/guide/index.md IS an index, and a landing page in front of an index
+  // page is a chooser in front of a chooser.
+  //
+  // `replace`, so Back leaves the guide instead of bouncing off the bare URL -
+  // the same treatment the default-root write already gets.
+  useEffect(() => {
+    if (!guide || path) return;
+    const next = new URLSearchParams();
+    next.set('path', `${GUIDE_DIR}/index.md`);
+    setParams(next, { replace: true });
+  }, [guide, path, setParams]);
+
   useEffect(() => {
     if (!root || root in graph) return;
     const ac = new AbortController();
@@ -153,6 +202,11 @@ export function Reader() {
         setNeedsAuth(false);
         setRootsErr(null);
         if (!r.roots.length) return;
+        // GUIDE MODE NEVER REWRITES THE URL. Its root is the route's, and
+        // `defaultRoot` exists to answer "no usable ?root=" - a question
+        // /files/guide does not ask. Left in, it would write `?root=notes` onto
+        // the guide's URL on every arrival.
+        if (guide) { setOpenRoots((prev) => (prev.size ? prev : new Set([GUIDE_ROOT]))); return; }
         const known = r.roots.some((x) => x.key === urlRoot);
         // Why this is not roots[0], and why absent `readOnly` means writable,
         // live with the rule in routes.ts - the reader is one of two callers and
@@ -176,7 +230,7 @@ export function Reader() {
     // `urlRoot` is read but is deliberately not a dependency: the default-root
     // write is a one-shot that would otherwise re-fire on its own result.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tick]);
+  }, [tick, guide]);
 
   // ── the front page (issue #94) ────────────────────────────────────────────
   //
@@ -261,8 +315,18 @@ export function Reader() {
 
   const openDoc = useCallback((r: string, p: string, at = '') => {
     const next = new URLSearchParams();
-    next.set('root', r);
+    // Guide URLs carry no `?root=` - filesHref makes that decision and this has
+    // to make the same one, or opening a document would rewrite /files/guide
+    // into a URL the route does not recognise.
+    if (!guide) next.set('root', r);
     if (p) next.set('path', p);
+    // THE FOLDER SCOPE SURVIVES OPENING A FILE (#152). It did not: this built a
+    // fresh URLSearchParams and dropped `?in=`, so narrowing the index to a
+    // folder and then clicking anything in it snapped the index back to the
+    // whole root. `onScope` already preserves `path` for the symmetric reason -
+    // narrowing the index changes what you are BROWSING, not what you are
+    // reading - and the same reasoning was never applied the other way.
+    if (!guide && scope && r === root) next.set('in', scope);
     setParams(next);
     setFrag(at);
     setPane('doc');
@@ -270,7 +334,7 @@ export function Reader() {
     // opens too - otherwise following a search result into `notes` leaves the
     // index showing a root the document is not in.
     setOpenRoots((prev) => (prev.has(r) ? prev : new Set(prev).add(r)));
-  }, [setParams]);
+  }, [setParams, guide, scope, root]);
 
   // Back to Start, keeping the root. The top nav's own Files link already goes
   // there from anywhere in the app (it points at a bare `/files`); this is the
@@ -301,6 +365,28 @@ export function Reader() {
     });
   }, []);
 
+  // ── reveal the route down to the open document (#150) ─────────────────────
+  //
+  // On the PATH, not on the click. Doing it inside openDoc covered following a
+  // link and missed the case that matters more: ARRIVING on a deep link, where
+  // the folders are all shut and the open document has no row in the index at
+  // all - `?path=docs/ARCHITECTURE.md` marked nothing, because `docs` was
+  // closed. Measured exactly that way.
+  //
+  // Additive, never subtractive: a folder you opened by hand stays open when you
+  // move to a document somewhere else, because collapsing the tree under
+  // somebody as they navigate is the index taking the page back.
+  useEffect(() => {
+    if (!root || !path) return;
+    setDirs((prev) => {
+      const want = openTo(root, path);
+      if (want.every((k) => prev.has(k))) return prev;
+      const next = new Set(prev);
+      for (const k of want) next.add(k);
+      return next;
+    });
+  }, [root, path]);
+
   const headings = useHeadings(docBox, `${root}\0${path}`);
   const last = file?.history?.[0] ?? null;
 
@@ -326,6 +412,9 @@ export function Reader() {
   const index = (
     <DocIndex
       roots={roots}
+      // The scoped listing lives under a composite key, which is this page's
+      // business and not the panel's - so it is resolved into the plain root key
+      // before it crosses the boundary.
       trees={scope ? { ...trees, [root]: trees[`${root}\u0000${scope}`] } : trees}
       openRoots={openRoots}
       onToggleRoot={toggleRoot}
@@ -335,8 +424,11 @@ export function Reader() {
       currentPath={path}
       onOpen={openDoc}
       onRetry={retryRoot}
-      scope={scope}
-      onScope={(r, dir) => {
+      dirs={dirs}
+      onToggleDir={toggleDir}
+      guide={guide ? { root: GUIDE_ROOT, dir: GUIDE_DIR } : undefined}
+      scope={guide ? '' : scope}
+      onScope={guide ? undefined : (r, dir) => {
         // The scope goes in the URL, and the open document is kept: narrowing
         // the index is a change to what you are BROWSING, not to what you are
         // reading, and closing the document because you opened a folder would
@@ -369,13 +461,34 @@ export function Reader() {
               own SearchView rather than a second one. The index rides in its
               `idle` slot, so the two share one scroll container and results
               replace the index instead of pushing it off the screen. */}
-          <aside className="rd-side" aria-label="Documents">
+          <aside className="rd-side" aria-label={guide ? 'The guide' : 'Documents'}>
+            {/* ── the one control that changes mode ────────────────────────
+                Guide mode has no root picker (the-guide-and-the-reader.md §1),
+                and this is not one: it is a DESTINATION, the same shape as the
+                reader's Edit button. One link out of the manual, one link back
+                into it, and nothing in either panel that half-offers the other
+                mode's roots. */}
+            <div className="rd-mode">
+              {guide ? (
+                <Link className="rd-mode-btn" to={filesHref('read', GUIDE_ROOT)}>
+                  <FolderTree size={13} aria-hidden="true" /> Browse all files
+                </Link>
+              ) : (
+                <Link className="rd-mode-btn" to={filesHref('guide', '')}>
+                  <BookOpen size={13} aria-hidden="true" /> The Bothy guide
+                </Link>
+              )}
+            </div>
             <SearchView
               roots={roots}
-              // '*' - every root that does not alias another, which is the
-              // service's own token. A reader looking for a sentence does not
-              // know which root it is in; that is the question search answers.
-              root="*"
+              // In the guide, the one root the guide is in - paired with
+              // `within`, which confines the walk to its folder. Everywhere
+              // else '*': every root that does not alias another, the service's
+              // own token. A reader looking for a sentence does not know which
+              // root it is in; that is the question search answers.
+              root={guide ? GUIDE_ROOT : '*'}
+              within={guide ? GUIDE_DIR : ''}
+              controls={guide ? 'minimal' : 'full'}
               onOpen={(r, p) => openDoc(r, p)}
               onNeedsAuth={() => setTick((t) => t + 1)}
               idle={index}
@@ -514,6 +627,10 @@ export function Reader() {
                   />
                 </div>
               </>
+            ) : guide ? (
+              // One frame, at most: the effect above has already asked for the
+              // front page. A skeleton here would flash on every arrival.
+              null
             ) : (
               <Start
                 roots={roots}

--- a/apps/portal-next/web/src/pages/files/Search.tsx
+++ b/apps/portal-next/web/src/pages/files/Search.tsx
@@ -85,7 +85,7 @@ function Marked({ text, col, len }: { text: string; col: number; len: number }) 
 }
 
 export function SearchView({
-  roots, root, onOpen, onNeedsAuth, idle,
+  roots, root, onOpen, onNeedsAuth, idle, controls = 'full', within = '',
 }: {
   roots: FileRoot[];
   /** The root the EXPLORER is browsing. The search starts scoped to it, because
@@ -105,6 +105,24 @@ export function SearchView({
    *  panel two scrollbars. This is the one line that lets one component be both,
    *  and it is why the reader does not fork this file. */
   idle?: React.ReactNode;
+  /** How much of the options row to draw (#151).
+   *
+   *  'full' is the IDE's: the root select, the glob box and the case toggle.
+   *  'minimal' is the search box and the case toggle, side by side, and nothing
+   *  else - which is what the GUIDE panel gets. Those two controls are not
+   *  hidden there to save space; they have no question to answer. "every root"
+   *  is meaningless where there is one folder, and a hand-typed fnmatch pattern
+   *  cannot narrow seven documents usefully.
+   *
+   *  A PROP AND NOT A FORK. The debounce in this file is the fix for a
+   *  self-sustaining search loop (see `runRef` below), it is invisible from the
+   *  outside, and it would have to be got right twice. */
+  controls?: 'full' | 'minimal';
+  /** Confine every search to one folder inside `root`, root-relative. The
+   *  service already walks from a folder rather than filtering a full listing
+   *  (`/search?path=`, app.py), so this is a scope and not a filter - a document
+   *  outside it is not searched rather than searched and dropped. */
+  within?: string;
 }) {
   const [q, setQ] = useState('');
   const [scope, setScope] = useState<string>(root);
@@ -130,7 +148,11 @@ export function SearchView({
     inFlight.current = ac;
     setBusy(true);
     setErr(null);
-    searchFiles(scope, query.trim(), { glob: glob.trim() || undefined, caseSensitive }, ac.signal)
+    searchFiles(
+      scope, query.trim(),
+      { path: within || undefined, glob: glob.trim() || undefined, caseSensitive },
+      ac.signal,
+    )
       .then((r) => { if (!ac.signal.aborted) { setRes(r); setBusy(false); } })
       .catch((e) => {
         if (ac.signal.aborted) return;
@@ -138,7 +160,7 @@ export function SearchView({
         if (isAuthError(e)) { onNeedsAuth(); return; }
         setErr(e instanceof Error ? e.message : 'the search did not answer');
       });
-  }, [scope, glob, caseSensitive, onNeedsAuth]);
+  }, [scope, within, glob, caseSensitive, onNeedsAuth]);
 
   // `run` reaches the timer through a REF, and it is not in the dependency list.
   //
@@ -165,7 +187,7 @@ export function SearchView({
     const t = setTimeout(() => runRef.current(q), DEBOUNCE_MS);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [q, scope, glob, caseSensitive]);
+  }, [q, scope, within, glob, caseSensitive]);
 
   useEffect(() => () => inFlight.current?.abort(), []);
 
@@ -174,16 +196,36 @@ export function SearchView({
 
   const short = q.trim().length > 0 && q.trim().length < MIN_CHARS;
 
+  // One control, two placements. In the guide it rides INSIDE the search box,
+  // beside the input, because it is the only option left and a 24px toggle alone
+  // on a row of its own is a row of empty rail. Written once so the two cannot
+  // drift into different buttons.
+  const caseToggle = (
+    <Tooltip label={caseSensitive ? 'Matching case' : 'Ignoring case'} align="end">
+      <button
+        type="button"
+        className={`fx-sr-toggle ${caseSensitive ? 'on' : ''}`}
+        aria-pressed={caseSensitive}
+        aria-label="Match case"
+        onClick={() => setCaseSensitive((v) => !v)}
+      >
+        <CaseSensitive size={14} />
+      </button>
+    </Tooltip>
+  );
+
   return (
     <div className="fx-sr">
-      <div className="fx-filter">
+      <div className={`fx-filter${controls === 'minimal' ? ' fx-filter-min' : ''}`}>
         <SearchIcon size={13} aria-hidden />
         <input
           ref={boxRef}
           type="search"
           value={q}
-          placeholder={`Search file contents (${MIN_CHARS}+ characters)`}
-          aria-label="Search file contents"
+          placeholder={controls === 'minimal'
+            ? `Search the guide (${MIN_CHARS}+ characters)`
+            : `Search file contents (${MIN_CHARS}+ characters)`}
+          aria-label={controls === 'minimal' ? 'Search the guide' : 'Search file contents'}
           onChange={(e) => setQ(e.target.value)}
           onKeyDown={(e) => { if (e.key === 'Enter') run(q); }}
         />
@@ -193,8 +235,10 @@ export function SearchView({
             <X size={13} />
           </button>
         )}
+        {controls === 'minimal' && caseToggle}
       </div>
 
+      {controls === 'full' && (
       <div className="fx-sr-opts">
         <label className="fx-sr-scope">
           <span className="fx-sr-lbl">in</span>
@@ -214,18 +258,9 @@ export function SearchView({
             onChange={(e) => setGlob(e.target.value)}
           />
         </div>
-        <Tooltip label={caseSensitive ? 'Matching case' : 'Ignoring case'}>
-          <button
-            type="button"
-            className={`fx-sr-toggle ${caseSensitive ? 'on' : ''}`}
-            aria-pressed={caseSensitive}
-            aria-label="Match case"
-            onClick={() => setCaseSensitive((v) => !v)}
-          >
-            <CaseSensitive size={14} />
-          </button>
-        </Tooltip>
+        {caseToggle}
       </div>
+      )}
 
       <div className="fx-sr-status" aria-live="polite">
         {busy ? 'Searching…'

--- a/apps/portal-next/web/src/pages/files/guide.ts
+++ b/apps/portal-next/web/src/pages/files/guide.ts
@@ -1,0 +1,56 @@
+// ── the guide, as an ordered thing ───────────────────────────────────────────
+//
+// docs/guide/ is a MANUAL, and a manual has an order. The service lists it in
+// path order, which reads configuring -> files -> index -> installing -> roles
+// -> the-console -> themes: alphabetical, and backwards for a set of pages that
+// end in `## Next`.
+//
+// THE ORDER LIVED IN THREE PLACES BEFORE THIS FILE, and they already disagreed:
+// the "Where to start" table in docs/guide/index.md, the table in README.md
+// (which also hard-codes a COUNT - "Seven pages" - the exact rotting sentence
+// start.ts warns about), and the `## Next` footer of each page. The reader's
+// index is the fourth. One list, and checks/start-table.mjs asserts it against
+// the folder on disk in both directions, so a page added without a line here is
+// a red check rather than a page nobody can find.
+//
+// IMPORTS NOTHING, for the same reason routes.ts, titles.ts and start.ts do
+// not: it is compiled and run by checks/run.sh with a bare `tsc`, no bundler and
+// no test runner.
+
+/** Basenames of docs/guide/*.md in READING order, index first.
+ *
+ *  Basenames rather than paths: the folder is GUIDE_DIR (routes.ts) and writing
+ *  it out seven times would be seven copies of one fact. */
+export const GUIDE_ORDER: readonly string[] = [
+  'index.md',
+  'installing.md',
+  'configuring.md',
+  'the-console.md',
+  'roles.md',
+  'files.md',
+  'themes.md',
+];
+
+/** Where `path` sits in the reading order. `Infinity` for anything the list does
+ *  not name, which sorts it to the end ALPHABETICALLY rather than dropping it -
+ *  a page that exists and is not in the manifest must still be reachable, or the
+ *  manifest becomes a way to hide documents. The check is what stops it staying
+ *  that way. */
+export function guideRank(path: string): number {
+  const at = GUIDE_ORDER.indexOf(path.slice(path.lastIndexOf('/') + 1));
+  return at === -1 ? Infinity : at;
+}
+
+/** The guide's own order, then alphabetical for anything unranked.
+ *
+ *  A COPY is sorted, never the argument: the listing this is called with is the
+ *  same array the index renders from, and sorting it in place would reorder a
+ *  caller's state behind its back. */
+export function sortGuide<T>(items: readonly T[], pathOf: (item: T) => string): T[] {
+  return [...items].sort((a, b) => {
+    const ra = guideRank(pathOf(a));
+    const rb = guideRank(pathOf(b));
+    if (ra !== rb) return ra - rb;
+    return pathOf(a).localeCompare(pathOf(b), undefined, { numeric: true });
+  });
+}

--- a/apps/portal-next/web/src/pages/files/read.css
+++ b/apps/portal-next/web/src/pages/files/read.css
@@ -49,7 +49,11 @@
 .bothy-files.bothy-read .fx-sr-no { display: none; }
 .bothy-files.bothy-read .fx-sr-line { padding-left: 26px; }
 
-.bothy-files .rd-index { padding: 0 0 14px; }
+/* ONE GUTTER FOR THE RAIL (#151). Every row in this panel used to pick its own
+   horizontal padding - 10px here, 12px there, 8px on the document row - and
+   with ellipsised text that put the last legible character of a long title four
+   pixels from a border. One value, and the rows share a left edge. */
+.bothy-files .rd-index { --rd-gut: 12px; padding: 0 0 14px; }
 /* Sticky, because the index lives inside the search view's scrolling result
    area (that is what puts search at the TOP of the panel rather than behind an
    icon) - and without this the All files switch scrolls away after ten rows,
@@ -57,7 +61,7 @@
 .bothy-files .rd-index-h {
   position: sticky; top: 0; z-index: 2;
   display: flex; align-items: center; gap: 8px;
-  padding: 6px 10px 7px; border-bottom: 1px solid var(--line);
+  padding: 6px var(--rd-gut) 7px; border-bottom: 1px solid var(--line);
   background: var(--bg-2);
 }
 .bothy-files .rd-index-title {
@@ -88,7 +92,7 @@
   appearance: none; cursor: pointer; width: 100%; text-align: left;
   display: flex; align-items: center; gap: 6px;
   border: 0; background: transparent; font: inherit; color: var(--fg);
-  padding: 0 10px; height: 28px;
+  padding: 0 var(--rd-gut); height: 28px;
 }
 .bothy-files .rd-root-btn:hover { background: var(--surface-2); }
 .bothy-files .rd-root-name { font-size: 11.5px; font-weight: 700; }
@@ -102,14 +106,33 @@
   .bothy-files .rd-chev { transition: none; }
 }
 
-.bothy-files .rd-folder { padding-bottom: 4px; }
-/* The folder, in mono, small and quiet. It is an ADDRESS - the one piece of
-   filesystem left in a panel of titles - so it is typeset as one rather than as
-   a heading competing with the documents under it. */
-.bothy-files .rd-folder-h {
-  margin: 8px 0 2px; padding: 0 10px;
-  font-size: 10.5px; color: var(--fg-subtle);
+/* ── a folder in the tree (#150) ─────────────────────────────────────────────
+   The flat list's mono `.rd-folder-h` heading is GONE with the list it headed.
+   It was an address, typeset as one, because in a flat list a folder was a
+   label. In a tree it is a CONTROL - the thing you press to see inside - so it
+   is a row like the documents under it, at the same rhythm and the same indent
+   step, and the chevron is what says it opens.
+
+   The indent itself is inline (`paddingLeft` in DocIndex) and not a class per
+   level: the depth is data, and a stylesheet cannot hold an unbounded number of
+   them. `--rd-gut` is its base, so the tree starts on the rail's own left edge
+   like everything else. */
+.bothy-files .rd-dir {
+  appearance: none; cursor: pointer; width: 100%; text-align: left;
+  display: flex; align-items: center; gap: 6px;
+  border: 0; background: transparent; font: inherit; color: var(--fg-muted);
+  padding: 2px var(--rd-gut) 2px 8px; min-height: 24px; min-width: 0;
+}
+.bothy-files .rd-dir:hover { background: var(--surface-2); color: var(--fg); }
+.bothy-files .rd-dir-ico { flex: none; color: var(--fg-subtle); }
+.bothy-files .rd-dir-name {
+  font-size: 12px; min-width: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* The count is the one number worth carrying: it is what tells you whether a
+   closed folder is worth opening. Quiet, and last. */
+.bothy-files .rd-dir-n {
+  margin-left: auto; flex: none; font-size: 10px; color: var(--fg-subtle);
 }
 .bothy-files .rd-list { list-style: none; margin: 0; padding: 0; }
 .bothy-files .rd-li { margin: 0; }
@@ -121,7 +144,7 @@
   display: flex; align-items: center; gap: 8px;
   border: 0; border-left: 2px solid transparent; background: transparent;
   font: inherit; color: var(--fg-muted);
-  padding: 3px 10px 3px 8px; min-height: 26px; min-width: 0;
+  padding: 3px var(--rd-gut) 3px 8px; min-height: 26px; min-width: 0;
 }
 .bothy-files .rd-doc:hover { background: var(--surface-2); color: var(--fg); }
 .bothy-files .rd-doc-ico { flex: none; color: var(--fg-subtle); }
@@ -156,6 +179,23 @@
 .bothy-files .rd-more.warn { color: var(--st-warn-fg); }
 .bothy-files .rd-skel { display: grid; gap: 6px; padding: 8px 10px 12px; }
 .bothy-files .rd-skel .skel { height: 16px; }
+
+/* ── the one control that changes mode ───────────────────────────────────────
+   A DESTINATION, not a picker - the same shape as the reader's Edit control.
+   It sits above the search box because it changes what everything below it is
+   about, which is the same argument the "All files" toggle wins on. */
+.bothy-files .rd-mode {
+  flex: none; padding: 8px 12px 6px; border-bottom: 1px solid var(--line);
+}
+.bothy-files .rd-mode-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11.5px; font-weight: 600; color: var(--accent-fg);
+  text-decoration: none; border-radius: var(--r-xs); padding: 2px 5px; margin-left: -5px;
+}
+.bothy-files .rd-mode-btn:hover { background: var(--accent-bg); }
+.bothy-files .rd-mode-btn:focus-visible { outline: 2px solid var(--ring); outline-offset: 1px; }
+.bothy-files .rd-mode-btn svg { flex: none; color: var(--fg-subtle); }
+.bothy-files .rd-mode-btn:hover svg { color: var(--accent-fg); }
 
 /* ── the document ────────────────────────────────────────────────────────── */
 .bothy-files .rd-main { min-width: 0; min-height: 0; display: flex; flex-direction: column; }
@@ -491,7 +531,7 @@
    common one. */
 .bothy-files .rd-crumbs {
   display: flex; flex-wrap: wrap; align-items: center;
-  gap: 2px; padding: 6px 12px 8px;
+  gap: 2px; padding: 6px var(--rd-gut) 8px;
   font-size: 11.5px; color: var(--fg-subtle);
   border-bottom: 1px solid var(--line);
 }
@@ -503,17 +543,8 @@
 .bothy-files .rd-crumbs b { color: var(--fg); font-weight: 700; padding: 0 2px; }
 .bothy-files .rd-crumb-sep { color: var(--fg-subtle); opacity: .6; }
 
-/* The folder heading became the "cd into this" control. It keeps the exact look
-   it had as a <p> - nothing moved, it just became pressable - and only gains an
-   affordance on hover, because a list of folders that all look like buttons is
-   noisier than the list it replaced. */
-.bothy-files .rd-folder-h {
-  display: block; width: 100%; text-align: left;
-  border: 0; background: none; padding: 0; margin: 0 0 4px;
-  font: inherit; font-size: 10px; letter-spacing: .04em; text-transform: uppercase;
-  color: var(--fg-subtle); cursor: pointer; border-radius: var(--r-xs);
-}
-.bothy-files .rd-folder-h:hover:not(:disabled) { color: var(--accent-fg); }
-/* The root's own top level has no folder to descend into. */
-.bothy-files .rd-folder-h:disabled { cursor: default; }
-.bothy-files .rd-folder-h:focus-visible { outline: 2px solid var(--ring); outline-offset: 1px; }
+/* The `.rd-folder-h` "cd into this" control is GONE. It existed because the flat
+   list had no other way into a folder; a tree's folder row IS that way in, and
+   two controls meaning "look inside this" one pixel apart is worse than either.
+   Scoping survives - Start's plans card writes `?in=`, and the breadcrumb above
+   is still the way back out. */

--- a/apps/portal-next/web/src/pages/files/routes.ts
+++ b/apps/portal-next/web/src/pages/files/routes.ts
@@ -1,14 +1,19 @@
-// ── the two Files URLs, in one place ─────────────────────────────────────────
+// ── the three Files URLs, in one place ───────────────────────────────────────
 //
-// Files is one nav entry and two destinations (docs/plans/reading-first.md §2):
+// Files is one nav entry and three destinations (docs/plans/reading-first.md §2,
+// docs/plans/the-guide-and-the-reader.md §1):
 //
-//   /files        READ  the default. A document, and how to find one.
+//   /files/guide  GUIDE Bothy's own manual. What a bare /files redirects to.
+//   /files        READ  the reader, over any root. Every deep link still lands.
 //   /files/edit   WORK  the IDE, unchanged, at a route.
 //
-// Both carry the SAME `?root=&path=`, which is the whole reason every deep link
-// written before the split still resolves - and the reason this file exists.
-// Three places now build one of those URLs (the reader's Edit button, the
-// editor's way back, and the router itself), and a builder that drops `path` is
+// READ and WORK carry the SAME `?root=&path=`, which is the whole reason every
+// deep link written before the split still resolves - and the reason this file
+// exists. GUIDE carries `?path=` alone, because its root is the route's; that is
+// the one asymmetry here and filesHref says why at the line that makes it.
+// Several places now build one of these URLs (the reader's Edit button, the
+// editor's way back, the guide's way out, and the router itself), and a builder
+// that drops `path` is
 // the same defect the redirect table was written to prevent: a link that answers
 // 200, renders a plausible page, and quietly goes somewhere else. Nobody reports
 // that. So the builder and the parser are ONE module with a truth table over it
@@ -21,18 +26,34 @@
 
 export const READ_PATH = '/files';
 export const EDIT_PATH = '/files/edit';
+export const GUIDE_PATH = '/files/guide';
 
-/** Which of the two the reader is in. */
-export type FilesMode = 'read' | 'edit';
+/** The root Bothy's own repository is mounted as, and the folder its manual
+ *  lives in. They are HERE, in the module that owns Files URLs, because in guide
+ *  mode they ARE the URL: `/files/guide?path=x` carries no `?root=` and no
+ *  `?in=` precisely because both are implied, and a builder that implied one
+ *  value while the page assumed another is the class of defect this module's
+ *  truth table exists to catch.
+ *
+ *  `GUIDE_ROOT` must equal `DOCS_ROOT` in start.ts, which names the same mount
+ *  for the shelf. checks/start-table.mjs asserts that, and asserts that
+ *  GUIDE_ORDER and the folder on disk still describe each other. */
+export const GUIDE_ROOT = 'stacks';
+export const GUIDE_DIR = 'docs/guide';
 
-/** `null` for a path that is not one of ours at all. Note that `/files/edit` has
- *  to be tested BEFORE `/files`, which is why this is a function rather than a
- *  map: `/files` is a prefix of `/files/edit`. */
+/** Which of the three the section is in. */
+export type FilesMode = 'read' | 'edit' | 'guide';
+
+/** `null` for a path that is not one of ours at all. Every comparison is EXACT
+ *  and the two sub-paths are tested first, which is why this is a function
+ *  rather than a prefix match: `/files` is a prefix of both `/files/edit` and
+ *  `/files/guide`, and a prefix match would answer 'read' for all three. */
 export function filesMode(pathname: string): FilesMode | null {
   // A trailing slash is the same page; a pasted link often carries one. Same
   // normalisation as pages/control/redirects.ts, for the same reason.
   const p = pathname.replace(/\/+$/, '') || '/';
   if (p === EDIT_PATH) return 'edit';
+  if (p === GUIDE_PATH) return 'guide';
   if (p === READ_PATH) return 'read';
   return null;
 }
@@ -49,10 +70,16 @@ export function filesMode(pathname: string): FilesMode | null {
  */
 export function filesHref(mode: FilesMode, root: string, path = ''): string {
   const q = new URLSearchParams();
-  if (root) q.set('root', root);
+  // GUIDE MODE CARRIES NO `?root=`. There is one root it can be about and the
+  // route says which; writing it out would invite a `/files/guide?root=notes`
+  // that the page has to ignore, and a URL with a parameter the page ignores is
+  // a URL that lies. `root` is still in the signature so all three modes have
+  // one builder - the alternative was a second function and a caller deciding
+  // which to use, which is how a `path` gets dropped.
+  if (root && mode !== 'guide') q.set('root', root);
   if (path) q.set('path', path);
   const s = q.toString();
-  const base = mode === 'edit' ? EDIT_PATH : READ_PATH;
+  const base = mode === 'edit' ? EDIT_PATH : mode === 'guide' ? GUIDE_PATH : READ_PATH;
   return s ? `${base}?${s}` : base;
 }
 
@@ -67,7 +94,11 @@ export function filesTarget(
   const mode = filesMode(pathname);
   if (!mode) return null;
   const q = new URLSearchParams(search.replace(/^\?/, ''));
-  return { mode, root: q.get('root') ?? '', path: q.get('path') ?? '' };
+  // The guide's root is the route's, not the query's - see filesHref. Reading it
+  // from `?root=` here would let a hand-typed one through and make the two
+  // halves of the same module disagree about what /files/guide is.
+  const root = mode === 'guide' ? GUIDE_ROOT : (q.get('root') ?? '');
+  return { mode, root, path: q.get('path') ?? '' };
 }
 
 /** The minimum a root has to look like to be chosen between. Written out here

--- a/apps/portal-next/web/src/pages/files/search.css
+++ b/apps/portal-next/web/src/pages/files/search.css
@@ -15,6 +15,14 @@
 .bothy-files .fx-sr-opts {
   flex: none; display: flex; align-items: center; gap: 6px; margin: 0 8px 6px;
 }
+/* THE GUIDE'S SEARCH BOX (#151). The options ROW is not rendered at all there -
+   "every root" has nothing to choose between in one folder and a hand-typed
+   fnmatch cannot narrow seven documents - so the case toggle rides inside the
+   box beside the input, which is the "side by side" the row never achieved at
+   296px. The toggle keeps its own rule; only the padding around it changes, so
+   the button does not sit on the frame. */
+.bothy-files .fx-filter-min { padding-right: 3px; }
+.bothy-files .fx-filter-min .fx-sr-toggle { margin-left: 2px; }
 .bothy-files .fx-sr-scope {
   display: inline-flex; align-items: center; gap: 5px; min-width: 0;
 }


### PR DESCRIPTION
Step 3–4 of `docs/plans/the-guide-and-the-reader.md` §9. Three issues in one PR because they are the same panel and two of them cannot be tested apart — guide mode *is* the tree plus the minimal controls.

## `/files` is the guide — closes #149

`/files` landed on `defaultRoot()`, the first **writable** root, which on this box is `notes`. #94 fixed a worse version of this and Start softened the ambush without answering the destination: the manual was still one card out of seven.

```
/files/guide  GUIDE  the manual. What a bare /files redirects to.
/files        READ   the reader, over any root. Unchanged.
/files/edit   WORK   the IDE. Unchanged.
```

**The query is the test**, and `FilesLanding` in `App.tsx` is the one place it is written: `/files` with no `?root=`, `?path=` or `?in=` redirects; `/files` carrying any of them renders the reader exactly as before. Every bookmark, recents row and Edit round trip still lands where it did.

Guide mode is a **mode**, not a page — same `Reader`, same `FileView`, same renderer, same outline, one prop. Its root and folder come from the route: `filesHref` does not write `?root=` for it and `filesTarget` does not read one, so `/files/guide?root=notes` is ignored rather than half-honoured. No Start surface either — `docs/guide/index.md` *is* an index, and a landing page in front of an index page is a chooser in front of a chooser.

## The index is a tree — closes #150

`DocIndex` was flat inside a root. That was right for four roots of loose prose and wrong for everything else: it cannot nest past one level, and `docs/brand/foundations` and `docs/brand/patterns` were two sibling headings identical for eleven characters.

It uses **`buildTree()` from `tree.ts`** — the Explorer's — rather than growing a second one, so the two panels cannot disagree about a folder they both list, and a closed directory still puts nothing in the DOM.

The route to the open document is revealed **on the path, not on the click**. Doing it in `openDoc` covered following a link and missed the case that matters more: arriving on a deep link with every folder shut, where `?path=docs/ARCHITECTURE.md` marked nothing.

In the guide, files are ordered by `GUIDE_ORDER` (`guide.ts`) rather than alphabetically — these pages end in `## Next`, and configuring-before-installing is backwards. That manifest is the fourth copy of a list that already lived in `docs/guide/index.md`, `README.md` and the `## Next` footers, and the only one a program can check: `checks/start-table.mjs` now asserts it against the folder on disk **in both directions**, so a page added without a line in it is a red check rather than a page quietly filed last.

**One bug found and fixed inside this branch, worth naming.** The guide's listing is fetched scoped, so `docs/guide/` is stripped from every path before the tree is built — and that rewrite reaches `entry.path` too. Reading from there made a guide row open `?path=index.md`, a file in neither place. Caught in the browser, not in review. `realPath()` puts the prefix back and is now the only path allowed near a URL.

## The panel's controls fit it — closes #151

The guide's rail gets the search box and the case toggle **side by side inside one frame**, and nothing else. "every root" has nothing to choose between in one folder and a hand-typed fnmatch cannot narrow seven documents — neither is hidden to save space, they have no question to answer. Search is scoped with `/search?path=`, which the service already implements, so **no service change**.

A prop on `SearchView`, not a fork: the debounce in that file is the fix for a self-sustaining search loop, invisible from outside, and it would have to be got right twice.

One gutter for the whole rail too — rows picked their own 10/12/8px padding, which with ellipsised text put the last legible character four pixels from a border.

## Also

`openDoc` now carries `?in=` — **half of #152**. It built a fresh `URLSearchParams` and dropped the folder scope, so narrowing the index and then clicking anything in it snapped back to the whole root. `onScope` already preserves `path` for the symmetric reason. #152 stays open for the header scope control.

## How this was confirmed

`typecheck` clean; `checks/run.sh` **247 pass · 0 fail**, including 15 new assertions under "the guide, ordered". Rebuilt `portal-next` and drove it in Chromium (Playwright); **0** console errors or warnings.

Guide mode, from a bare `/files`:

```
  url                        #/files/guide?path=docs%2Fguide%2Findex.md
  panelTitle                 "The guide"
  modeLink                   "Browse all files"
  rootChevrons 0   rootSelect 0   globBox 0   allFilesToggle 0
  caseToggleInsideSearchBox  true      searchAndAaSameRow  true
  rows  Index, Installing, Configuring, The console, Roles, Files, Themes
        (reading order, not alphabetical)
  click Themes -> #/files/guide?path=docs%2Fguide%2Fthemes.md, H1 "Themes",
        row marked
```

Browse mode, on a three-deep deep link:

```
  #/files?root=stacks&path=docs/brand/foundations/colour.md
  openDirs        docs (8px) > brand (21px) > foundations (34px)
  markedCurrent   docs/brand/foundations/colour.md  at 47px
  rootSections    home, notes, projects, stacks
  rootSelect 1    glob 1    allFiles 1    modeLink "The Bothy guide"
```

## Not in this PR

#152 (the header scope control), #156, #157, #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
