### PR TITLE
feat(reader): reading size is a setting, and the scope is a control

### DIFF
--- a/apps/portal-next/web/src/index.css
+++ b/apps/portal-next/web/src/index.css
@@ -197,6 +197,15 @@
      The measure is in `ch`, so raising the size keeps the line at 72 characters
      and simply makes the column physically wider - which is the point. */
   --read-fs: 16px;
+  /* The PANELS beside the document - index rows, outline entries, breadcrumbs.
+     They were ~30 literal values in read.css set at the app's CONTROL size, on a
+     surface whose whole argument is that a document is not a dashboard, and
+     every one of them is now a ratio of this.
+     Two tokens rather than one because they answer different questions: raising
+     --read-fs widens the column (the measure is in `ch`) and does nothing to the
+     rails; raising this makes the index legible without reflowing a word of
+     prose. Both are settable per browser - see pages/files/reading.ts. */
+  --rd-ui-fs: 12.5px;
   --read-lh: 1.65;
   --read-gap: 15px;      /* between blocks, tracks --read-fs */
   --read-h1: 27px;

--- a/apps/portal-next/web/src/lib/contract.ts
+++ b/apps/portal-next/web/src/lib/contract.ts
@@ -148,6 +148,10 @@ export const STRUCTURAL = new Set([
   // them, so "required" was never the right answer.
   '--read-measure', '--read-fs', '--read-lh', '--read-gap',
   '--read-h1', '--read-h2', '--read-h3', '--read-h4',
+  // The panels beside the document. Same family, same argument: it is a LENGTH,
+  // a colour rule cannot measure it and the theme editor cannot offer a swatch
+  // for it, so demanding it of every theme was never the right answer.
+  '--rd-ui-fs',
 ]);
 
 /** What a theme owes, derived from the base palette rather than listed: every

--- a/apps/portal-next/web/src/pages/Settings.css
+++ b/apps/portal-next/web/src/pages/Settings.css
@@ -238,3 +238,48 @@
    inside either: it is a fact about the directory, and putting it in the "write
    the file" card would have implied the editor's output does not land there. */
 .settings-page .make-count { margin-top: 11px; }
+
+/* ── reading size (#156) ─────────────────────────────────────────────────────
+   Two rows, each: what it is, the control, and a SAMPLE at the size the control
+   is currently set to. The sample is not decoration - "12.5px" is a number
+   nobody thinks in, and the only honest way to show what a size does is to
+   render something at it. */
+.set-reading { display: grid; gap: 18px; margin-top: 14px; }
+.set-read-row {
+  display: grid; gap: 8px 16px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+}
+.set-read-lbl { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.set-read-name { font-size: 13px; font-weight: 600; color: var(--fg); }
+.set-read-hint { font-size: 12px; line-height: 1.45; color: var(--fg-subtle); }
+.set-read-ctl { display: flex; align-items: center; gap: 4px; }
+/* A box rather than a bare glyph: these two sit next to a Reset that has one,
+   and three controls in a row with only one border reads as two of them being
+   decoration. */
+.set-read-btn {
+  width: 26px; height: 26px; border-radius: var(--r-sm);
+  border: 1px solid var(--line); background: var(--surface-2); color: var(--fg-muted);
+}
+.set-read-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--fg); }
+.set-read-btn:disabled { opacity: var(--disabled-opacity); cursor: default; }
+/* Fixed width, tabular figures. Without both, the row shifts sideways every time
+   the number gains a digit or a decimal - which is on every other press. */
+.set-read-v {
+  min-width: 52px; text-align: center;
+  font-size: 12.5px; font-weight: 600; color: var(--fg);
+}
+/* Full width, under both columns, so the sample has room to be a sentence at
+   24px rather than four words and an ellipsis. */
+.set-read-sample {
+  grid-column: 1 / -1; margin: 0;
+  padding: 9px 12px; border: 1px solid var(--line); border-radius: var(--r-sm);
+  background: var(--surface-1); color: var(--fg-muted); line-height: 1.5;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+@media (max-width: 620px) {
+  /* The control drops under the label rather than squeezing it: at this width
+     the label is the half that has to stay readable. */
+  .set-read-row { grid-template-columns: minmax(0, 1fr); }
+}

--- a/apps/portal-next/web/src/pages/Settings.tsx
+++ b/apps/portal-next/web/src/pages/Settings.tsx
@@ -48,7 +48,7 @@
 // to a new theme end at the same .css file in the same directory, which is the
 // fact the two of them together are there to say.
 
-import { Ban, Circle, CircleCheck, Code2, LogIn, Pencil, Plus } from 'lucide-react';
+import { Ban, Circle, CircleCheck, Code2, LogIn, Minus, Pencil, Plus } from 'lucide-react';
 import { ROLES, ROLE_MEANING, signInHref, type Me, type Role } from '../lib/me';
 import { useMe } from '../components/UserMenu';
 import { useTheme } from '../lib/theme';
@@ -57,6 +57,9 @@ import { ThemeSwatch } from '../components/ThemeSwatch';
 import { Link } from 'react-router-dom';
 import { Skeleton } from '../components/states';
 import './Settings.css';
+import {
+  READING_DEFAULT, READING_LIMITS, READING_STEP, useReading, type Reading,
+} from './files/reading';
 
 export function Settings() {
   const { me, loading } = useMe();
@@ -113,6 +116,7 @@ export function Settings() {
       >
         <Theme />
         <MakeATheme />
+        <Reading />
       </Group>
 
       <Group
@@ -150,6 +154,97 @@ function Group({ id, title, lede, children }: {
         <p className="set-group-lede">{lede}</p>
       </header>
       {children}
+    </section>
+  );
+}
+
+/**
+ * How big a document is, and how big the panels around it are (#156).
+ *
+ * TWO numbers, because they answer different questions. Raising the document
+ * widens the reading column (`--read-measure` is `100%`, but the type inside it
+ * grows) and does nothing to the rails; raising the panels makes the index and
+ * the outline legible without reflowing a word of prose. One control would tie
+ * them together and neither would land where anyone wanted it.
+ *
+ * IT IS HERE FOR THE SAME REASON THE THEME IS, and it is the same kind of thing:
+ * one key in localStorage in this browser, no server, no write path, no audit
+ * trail. The read-only rule this page states is about a SERVER-side preference
+ * store, which is still #157's open question - not about the browser remembering
+ * how big you like your type. The Stores table below says out loud that it does
+ * not follow you to another device.
+ *
+ * The sample is not decoration. These are two numbers with no unit anybody
+ * thinks in, and "12.5px" means nothing until you have seen a row at it - so the
+ * control shows the thing it changes, at the size it will be.
+ */
+function Reading() {
+  const [reading, setReading] = useReading();
+  const rows: { key: keyof Reading; label: string; hint: string }[] = [
+    { key: 'doc', label: 'Document text', hint: 'The rendered page in Files - prose, tables and code.' },
+    { key: 'ui', label: 'Panel text', hint: 'The document index on the left and the outline on the right.' },
+  ];
+
+  return (
+    <section className="panel">
+      <h3>Reading size</h3>
+      <p className="set-lede">
+        The type in Files. A document is not a dashboard, and the size that suits a
+        14-inch laptop is not the one that suits a 27-inch monitor - so this is a
+        setting rather than a number somebody picked once.
+      </p>
+      <div className="set-reading">
+        {rows.map(({ key, label, hint }) => {
+          const v = reading[key];
+          const { min, max } = READING_LIMITS[key];
+          const step = READING_STEP[key];
+          return (
+            <div className="set-read-row" key={key}>
+              <div className="set-read-lbl">
+                <span className="set-read-name">{label}</span>
+                <span className="set-read-hint">{hint}</span>
+              </div>
+              <div className="set-read-ctl" role="group" aria-label={label}>
+                <button
+                  type="button"
+                  className="icon-btn set-read-btn"
+                  onClick={() => setReading({ [key]: v - step })}
+                  disabled={v <= min}
+                  aria-label={`Smaller ${label.toLowerCase()}`}
+                >
+                  <Minus size={14} />
+                </button>
+                {/* `aria-live` so a screen reader hears the new size, which is
+                    the only feedback a non-visual user gets from a control whose
+                    whole effect is visual. */}
+                <span className="set-read-v tnum" aria-live="polite">{v}px</span>
+                <button
+                  type="button"
+                  className="icon-btn set-read-btn"
+                  onClick={() => setReading({ [key]: v + step })}
+                  disabled={v >= max}
+                  aria-label={`Larger ${label.toLowerCase()}`}
+                >
+                  <Plus size={14} />
+                </button>
+                <button
+                  type="button"
+                  className="btn ghost sm"
+                  onClick={() => setReading({ [key]: READING_DEFAULT[key] })}
+                  disabled={v === READING_DEFAULT[key]}
+                >
+                  Reset
+                </button>
+              </div>
+              <p className="set-read-sample" style={{ fontSize: `${v}px` }}>
+                {key === 'doc'
+                  ? 'The quick brown fox jumps over the lazy dog.'
+                  : 'Tailnet troubleshooting'}
+              </p>
+            </div>
+          );
+        })}
+      </div>
     </section>
   );
 }
@@ -471,6 +566,18 @@ const STORES = [
     why: 'Per browser is the right home for these, not a limitation. A pane width is a fact about the '
       + 'screen you are sitting at; carrying it to a phone would be the bug. They are changed where '
       + 'they are used - the theme button in the topbar, the panes themselves - rather than here.',
+  },
+  {
+    what: 'How big the type in Files is - the document, and the panels beside it',
+    where: 'This browser',
+    store: 'localStorage',
+    elsewhere: 'Not there. Another browser, another device or a cleared profile reads at the default '
+      + 'sizes, which are the ones this box shipped with.',
+    why: 'The right size for a page of prose depends on the screen you are sitting at, not on who you '
+      + 'are - a 14-inch laptop and a 27-inch monitor want different numbers from the same person. '
+      + 'That is the same test the theme and the pane widths pass, so it is kept in the same place '
+      + 'and admitted to in the same sentence. If a per-user store is ever built, this is one of the '
+      + 'first things that would move into it.',
   },
   {
     what: 'Which service groups you have collapsed',

--- a/apps/portal-next/web/src/pages/files/Reader.tsx
+++ b/apps/portal-next/web/src/pages/files/Reader.tsx
@@ -43,6 +43,8 @@ import { Start } from './Start';
 import { Toc, useHeadings } from './Toc';
 import { frontPageOf, noteRecent, readRecents, type Recent } from './start';
 import { GUIDE_DIR, GUIDE_ROOT, defaultRoot, filesHref, type FilesMode } from './routes';
+import { readingVars, useReading } from './reading';
+import { ScopePicker } from './ScopePicker';
 import { baseName, dirName, resolveWikiIn } from './tree';
 import { fetchLinks, type LinkIndex } from '../../lib/files';
 
@@ -86,6 +88,10 @@ export function Reader({ mode = 'read' }: {
   // of a folder the way it stepped in.
   const scope = guide ? GUIDE_DIR : (params.get('in') || '').replace(/^\/+|\/+$/g, '');
   const { me } = useMe();
+  // The two font sizes, per browser (#156). On THIS element and not on :root -
+  // see readingVars. Read-only here: the controls that change it live in
+  // Settings, beside the rest of what this browser remembers.
+  const [reading] = useReading();
 
   const [roots, setRoots] = useState<FileRoot[]>([]);
   const [needsAuth, setNeedsAuth] = useState(false);
@@ -443,7 +449,7 @@ export function Reader({ mode = 'read' }: {
   );
 
   return (
-    <div className="bothy-files bothy-read" data-pane={pane}>
+    <div className="bothy-files bothy-read" data-pane={pane} style={readingVars(reading)}>
       {needsAuth ? (
         <div className="fx-gate"><SignInCard what="read the box" onRetry={() => setTick((t) => t + 1)} /></div>
       ) : rootsErr ? (
@@ -474,9 +480,35 @@ export function Reader({ mode = 'read' }: {
                   <FolderTree size={13} aria-hidden="true" /> Browse all files
                 </Link>
               ) : (
-                <Link className="rd-mode-btn" to={filesHref('guide', '')}>
-                  <BookOpen size={13} aria-hidden="true" /> The Bothy guide
-                </Link>
+                <>
+                  <Link className="rd-mode-btn" to={filesHref('guide', '')}>
+                    <BookOpen size={13} aria-hidden="true" /> The Bothy guide
+                  </Link>
+                  {/* WHERE YOU ARE LOOKING (#152). Browse mode only - the guide
+                      is one folder of one root by design, and a scope picker on
+                      it would be the root selector this mode exists to not
+                      have. Fed the open root's listing for completions, which is
+                      the array the tree beside it is already built from: no
+                      request, no endpoint, no index. */}
+                  <ScopePicker
+                    roots={roots}
+                    root={root}
+                    scope={scope}
+                    entries={(scope ? trees[`${root}\u0000${scope}`] : trees[root])?.entries ?? []}
+                    onGo={(r, dir) => {
+                      const next = new URLSearchParams();
+                      next.set('root', r);
+                      if (dir) next.set('in', dir);
+                      // The open document is kept when it is still in the root
+                      // you are scoping - narrowing the index is a change to
+                      // what you are BROWSING, not to what you are reading.
+                      if (path && r === root) next.set('path', path);
+                      setParams(next);
+                      setOpenRoots((prev) => (prev.has(r) ? prev : new Set(prev).add(r)));
+                      setPane('index');
+                    }}
+                  />
+                </>
               )}
             </div>
             <SearchView

--- a/apps/portal-next/web/src/pages/files/ScopePicker.tsx
+++ b/apps/portal-next/web/src/pages/files/ScopePicker.tsx
@@ -1,0 +1,209 @@
+// ── where you are looking ────────────────────────────────────────────────────
+//
+// One control in the panel header, and it replaces two things that were not
+// controls at all (#152):
+//
+//   · CHOOSING A ROOT MEANT SCROLLING. The roots were section headers
+//     interleaved with their own contents, so "go to `projects`" was "scroll
+//     past everything in `notes`". They were the only thing in a panel of titles
+//     that behaved like a tab strip, and they sat at the panel's edge.
+//   · REACHING A FOLDER MEANT FINDING IT. `docs/brand/foundations` was: expand
+//     `stacks`, scroll, expand `docs`, expand `brand`, click. There was nowhere
+//     to type a path.
+//
+// It is assembly, not new chrome. `.fx-rootchip` is the group Explorer.tsx
+// already draws (including the Lock on a read-only root, which is the only
+// warning that every file in it will turn out to have no Edit button) and
+// `.fx-hbtn` is the app's icon button. What is new is the path box.
+//
+// ── THE COMPLETIONS COST NOTHING ────────────────────────────────────────────
+//
+// They are drawn from the listing the panel ALREADY HOLDS - the same
+// `TreeFile[]` the tree is built from - so there is no request, no endpoint and
+// no index. The consequence is worth stating rather than hiding: a root that has
+// not been opened has no listing, so it offers no completions, and typing a path
+// into it still works because Enter does not require one. Suggesting nothing is
+// honest; suggesting from a stale copy would not be.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronDown, CornerDownLeft, FolderTree, Lock } from 'lucide-react';
+import type { FileRoot, TreeFile } from '../../lib/files';
+
+/** Directories offered at once. The list is a shortcut, not a browser - the tree
+ *  below is the browser - so it stops at the point where reading it costs more
+ *  than typing one more character. */
+const MAX_HINTS = 8;
+
+/** Every directory in a listing, root-relative, deduplicated.
+ *
+ *  Built from the FILE paths rather than from directory entries, because the
+ *  service's `dir` field is the entry's parent path rather than a boolean on the
+ *  live service (tree.ts says so at length) - so the paths are the reliable
+ *  half, and the ancestors of every file are exactly the set of directories that
+ *  contain anything. */
+function dirsOf(entries: readonly TreeFile[]): string[] {
+  const out = new Set<string>();
+  for (const e of entries) {
+    if (e.dir === true) continue;
+    let at = e.path.indexOf('/');
+    while (at !== -1) { out.add(e.path.slice(0, at)); at = e.path.indexOf('/', at + 1); }
+  }
+  return [...out].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+}
+
+export function ScopePicker({ roots, root, scope, entries, onGo }: {
+  roots: FileRoot[];
+  /** The root being browsed. */
+  root: string;
+  /** The folder narrowed to, root-relative, '' for the whole root. */
+  scope: string;
+  /** The open root's listing, for completions. Empty is a legal state - see the
+   *  header: a root nobody has opened has nothing to suggest. */
+  entries: readonly TreeFile[];
+  /** Go there. `dir` is '' for the whole root. */
+  onGo: (root: string, dir: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(scope);
+  const box = useRef<HTMLDivElement | null>(null);
+  const input = useRef<HTMLInputElement | null>(null);
+
+  // The draft follows the real scope while the popover is SHUT. Reopening on a
+  // half-typed path from three folders ago is the popover remembering something
+  // the user abandoned; while it is open the draft is theirs.
+  useEffect(() => { if (!open) setDraft(scope); }, [open, scope]);
+  useEffect(() => { if (open) input.current?.select(); }, [open]);
+
+  // Close on Escape and on a click outside. `pointerdown` rather than `click`,
+  // so pressing a control elsewhere on the page does not first have to survive a
+  // popover that is still open on top of it.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      if (!box.current?.contains(e.target as globalThis.Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('pointerdown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('pointerdown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const hints = useMemo(() => {
+    const all = dirsOf(entries);
+    const q = draft.replace(/^\/+/, '').toLowerCase();
+    // No query is the TOP LEVEL rather than the first eight of everything: an
+    // alphabetical slice of a deep tree offers `.claude`, `.github` and six
+    // folders inside `apps`, none of which is where anybody starts.
+    const pool = q ? all.filter((d) => d.toLowerCase().includes(q)) : all.filter((d) => !d.includes('/'));
+    return pool.slice(0, MAX_HINTS);
+  }, [entries, draft]);
+
+  const go = (r: string, dir: string) => {
+    onGo(r, dir.replace(/^\/+|\/+$/g, ''));
+    setOpen(false);
+  };
+
+  const label = scope ? `${root}/${scope}` : root;
+
+  return (
+    <div className="rd-scope" ref={box}>
+      <button
+        type="button"
+        className="rd-scope-btn"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => setOpen((v) => !v)}
+        title={`Looking in ${label} - choose a root or a folder`}
+      >
+        <FolderTree size={13} aria-hidden="true" />
+        <span className="rd-scope-lbl mono">{label}</span>
+        <ChevronDown size={12} className="rd-scope-chev" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div className="rd-scope-pop" role="dialog" aria-label="Where to look">
+          {roots.length > 1 && (
+            <>
+              <p className="rd-scope-h">Root</p>
+              <div className="fx-roots" role="group" aria-label="Root">
+                {roots.map((r) => (
+                  <button
+                    key={r.key}
+                    type="button"
+                    className={`fx-rootchip ${r.key === root ? 'on' : ''}`}
+                    aria-pressed={r.key === root}
+                    // Changing root clears the folder: a path inside `stacks` is
+                    // almost never a path inside `notes`, and carrying it over
+                    // would scope the new root to a folder it does not have.
+                    onClick={() => go(r.key, '')}
+                    title={r.readOnly ? `${r.label || r.key} - read-only` : (r.label || r.key)}
+                  >
+                    {r.key}
+                    {r.readOnly && <Lock size={10} className="fx-rootro" aria-label="read-only" />}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+
+          <p className="rd-scope-h">Folder</p>
+          <div className="fx-filter rd-scope-path">
+            <input
+              ref={input}
+              type="text"
+              value={draft}
+              placeholder="docs/guide"
+              aria-label={`Folder inside ${root}`}
+              spellCheck={false}
+              autoComplete="off"
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') { e.preventDefault(); go(root, draft); }
+                // Stop Escape reaching the page's own handlers, which would
+                // close something behind the popover as well.
+                if (e.key === 'Escape') e.stopPropagation();
+              }}
+            />
+            <button
+              type="button"
+              className="rd-scope-go"
+              aria-label={`Go to ${draft || root}`}
+              onClick={() => go(root, draft)}
+            >
+              <CornerDownLeft size={13} />
+            </button>
+          </div>
+
+          {hints.length > 0 && (
+            <ul className="rd-scope-hints">
+              {hints.map((d) => (
+                <li key={d}>
+                  <button type="button" className="mono" onClick={() => go(root, d)}>{d}</button>
+                </li>
+              ))}
+            </ul>
+          )}
+          {/* Said out loud rather than left as an empty list, because "no
+              suggestions" and "this root has not been listed yet" look identical
+              and only one of them means the path is wrong. */}
+          {!hints.length && (
+            <p className="rd-scope-none">
+              {entries.length
+                ? <>No folder in <span className="mono">{root}</span> matches that. Enter still goes there.</>
+                : <>Nothing listed for <span className="mono">{root}</span> yet - type a folder and press Enter.</>}
+            </p>
+          )}
+
+          {scope && (
+            <button type="button" className="btn ghost sm rd-scope-all" onClick={() => go(root, '')}>
+              Show all of {root}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/portal-next/web/src/pages/files/read.css
+++ b/apps/portal-next/web/src/pages/files/read.css
@@ -65,7 +65,7 @@
   background: var(--bg-2);
 }
 .bothy-files .rd-index-title {
-  font-size: 11px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
+  font-size: calc(var(--rd-ui-fs) * 0.88); font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
   color: var(--fg-subtle);
 }
 /* The toggle that changes what the list CLAIMS to be. Left visible rather than
@@ -73,7 +73,7 @@
    reader has to be able to see which one they are looking at. */
 .bothy-files .rd-all {
   margin-left: auto; display: inline-flex; align-items: center; gap: 5px;
-  font-size: 11px; color: var(--fg-muted); cursor: pointer; user-select: none;
+  font-size: calc(var(--rd-ui-fs) * 0.88); color: var(--fg-muted); cursor: pointer; user-select: none;
 }
 .bothy-files .rd-all input { margin: 0; accent-color: var(--accent); }
 .bothy-files .rd-all svg { color: var(--fg-subtle); }
@@ -95,10 +95,10 @@
   padding: 0 var(--rd-gut); height: 28px;
 }
 .bothy-files .rd-root-btn:hover { background: var(--surface-2); }
-.bothy-files .rd-root-name { font-size: 11.5px; font-weight: 700; }
+.bothy-files .rd-root-name { font-size: calc(var(--rd-ui-fs) * 0.92); font-weight: 700; }
 .bothy-files .rd-root-ro { color: var(--st-off-fg); }
 .bothy-files .rd-root-n {
-  margin-left: auto; font-size: 10px; font-family: var(--mono); color: var(--fg-subtle);
+  margin-left: auto; font-size: calc(var(--rd-ui-fs) * 0.8); font-family: var(--mono); color: var(--fg-subtle);
 }
 .bothy-files .rd-chev { flex: none; color: var(--fg-subtle); transition: transform .12s ease; }
 .bothy-files .rd-chev.open { transform: rotate(90deg); }
@@ -126,13 +126,13 @@
 .bothy-files .rd-dir:hover { background: var(--surface-2); color: var(--fg); }
 .bothy-files .rd-dir-ico { flex: none; color: var(--fg-subtle); }
 .bothy-files .rd-dir-name {
-  font-size: 12px; min-width: 0;
+  font-size: calc(var(--rd-ui-fs) * 0.96); min-width: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 /* The count is the one number worth carrying: it is what tells you whether a
    closed folder is worth opening. Quiet, and last. */
 .bothy-files .rd-dir-n {
-  margin-left: auto; flex: none; font-size: 10px; color: var(--fg-subtle);
+  margin-left: auto; flex: none; font-size: calc(var(--rd-ui-fs) * 0.8); color: var(--fg-subtle);
 }
 .bothy-files .rd-list { list-style: none; margin: 0; padding: 0; }
 .bothy-files .rd-li { margin: 0; }
@@ -150,13 +150,13 @@
 .bothy-files .rd-doc-ico { flex: none; color: var(--fg-subtle); }
 .bothy-files .rd-doc-text { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
 .bothy-files .rd-doc-title {
-  font-size: 12.5px; line-height: 1.25;
+  font-size: var(--rd-ui-fs); line-height: 1.25;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 /* The filename under the title, for anyone who arrived knowing the path. Only
    rendered when it differs from the title, so most rows are one line. */
 .bothy-files .rd-doc-name {
-  font-family: var(--mono); font-size: 10px; color: var(--fg-subtle);
+  font-family: var(--mono); font-size: calc(var(--rd-ui-fs) * 0.8); color: var(--fg-subtle);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 /* The open document. A left BAR and a background, never colour alone -
@@ -186,16 +186,82 @@
    about, which is the same argument the "All files" toggle wins on. */
 .bothy-files .rd-mode {
   flex: none; padding: 8px 12px 6px; border-bottom: 1px solid var(--line);
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
 }
 .bothy-files .rd-mode-btn {
   display: inline-flex; align-items: center; gap: 6px;
-  font-size: 11.5px; font-weight: 600; color: var(--accent-fg);
+  font-size: calc(var(--rd-ui-fs) * 0.92); font-weight: 600; color: var(--accent-fg);
   text-decoration: none; border-radius: var(--r-xs); padding: 2px 5px; margin-left: -5px;
 }
 .bothy-files .rd-mode-btn:hover { background: var(--accent-bg); }
 .bothy-files .rd-mode-btn:focus-visible { outline: 2px solid var(--ring); outline-offset: 1px; }
 .bothy-files .rd-mode-btn svg { flex: none; color: var(--fg-subtle); }
 .bothy-files .rd-mode-btn:hover svg { color: var(--accent-fg); }
+
+/* ── where you are looking (#152) ────────────────────────────────────────────
+   A chip that reads the current location and opens a popover. It sits in the
+   header because that is where "what is this panel about" belongs - the roots
+   used to be section headings interleaved with their own contents, so choosing
+   one meant scrolling past the last one's files. */
+.bothy-files .rd-scope { position: relative; margin-left: auto; }
+.bothy-files .rd-scope-btn {
+  appearance: none; cursor: pointer; display: inline-flex; align-items: center; gap: 5px;
+  max-width: 190px; padding: 2px 5px;
+  border: 1px solid var(--line); border-radius: var(--r-sm);
+  background: var(--surface-2); color: var(--fg-muted);
+  font: inherit; font-size: calc(var(--rd-ui-fs) * 0.84);
+}
+.bothy-files .rd-scope-btn:hover { border-color: var(--line-strong); color: var(--fg); }
+.bothy-files .rd-scope-btn[aria-expanded='true'] {
+  border-color: var(--accent); color: var(--fg); background: var(--accent-bg);
+}
+.bothy-files .rd-scope-btn svg { flex: none; color: var(--fg-subtle); }
+/* Truncated at the FRONT, so `docs/brand/foundations` keeps the segment that
+   distinguishes it - the same reason tailPath() exists for the search hits.
+   `direction: rtl` with the text isolated is the CSS-only way to move an
+   ellipsis to the left edge; `bdi` would need a wrapper element for one line. */
+.bothy-files .rd-scope-lbl {
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  direction: rtl; text-align: left;
+}
+.bothy-files .rd-scope-chev { margin-left: auto; }
+
+.bothy-files .rd-scope-pop {
+  position: absolute; top: calc(100% + 5px); right: 0; z-index: 30;
+  width: 274px; max-height: 60vh; overflow: auto;
+  padding: 9px 10px 10px;
+  background: var(--surface-1); border: 1px solid var(--line-strong);
+  border-radius: var(--r-md); box-shadow: var(--shadow-md);
+}
+.bothy-files .rd-scope-h {
+  margin: 0 0 5px;
+  font-size: 10px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase;
+  color: var(--fg-subtle);
+}
+.bothy-files .rd-scope-pop .fx-roots { margin: 0 0 12px; }
+.bothy-files .rd-scope-path { margin: 0; }
+.bothy-files .rd-scope-path input { font-family: var(--mono); font-size: 11.5px; }
+.bothy-files .rd-scope-go {
+  appearance: none; cursor: pointer; flex: none; display: grid; place-items: center;
+  width: 20px; height: 20px; border: 0; border-radius: var(--r-xs);
+  background: transparent; color: var(--fg-subtle);
+}
+.bothy-files .rd-scope-go:hover { color: var(--accent-fg); background: var(--surface-3); }
+
+.bothy-files .rd-scope-hints { list-style: none; margin: 8px 0 0; padding: 0; }
+.bothy-files .rd-scope-hints li { margin: 0; }
+.bothy-files .rd-scope-hints button {
+  appearance: none; cursor: pointer; width: 100%; text-align: left;
+  border: 0; background: transparent; border-radius: var(--r-xs);
+  font: inherit; font-family: var(--mono); font-size: 11px; color: var(--fg-muted);
+  padding: 3px 6px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.bothy-files .rd-scope-hints button:hover { background: var(--surface-2); color: var(--fg); }
+.bothy-files .rd-scope-none {
+  margin: 8px 0 0; font-size: 11px; line-height: 1.45; color: var(--fg-subtle);
+}
+.bothy-files .rd-scope-all { margin-top: 10px; width: 100%; }
 
 /* ── the document ────────────────────────────────────────────────────────── */
 .bothy-files .rd-main { min-width: 0; min-height: 0; display: flex; flex-direction: column; }
@@ -367,6 +433,19 @@
 .bothy-files .rd-crumb-root:hover { color: var(--accent-fg); }
 .bothy-files .rd-crumb-root:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }
 
+/* ── the panels' own scale ───────────────────────────────────────────────────
+   Every font-size in this file above and below is a RATIO of --rd-ui-fs
+   (index.css), not a literal. That is what makes the size settable at all: it
+   was thirty separate numbers, so "make the index bigger" had thirty edits and
+   no single thing to change. The ratios are the sizes that were there, divided
+   by 12.5 - the base is the document ROW, because every other panel rule was
+   already below it and a base picked from the smallest would need ratios above
+   one to say "this one is bigger".
+
+   The reader's root element carries the value (readingVars in reading.ts), NOT
+   `:root` - a document scale written globally would resize the Settings page
+   that changes it. */
+
 /* ── the outline ─────────────────────────────────────────────────────────── */
 .bothy-files .rd-toc {
   min-width: 0; min-height: 0; overflow: auto;
@@ -374,7 +453,7 @@
 }
 .bothy-files .rd-toc-h {
   margin: 0 0 8px 10px;
-  font-size: 10.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase;
+  font-size: calc(var(--rd-ui-fs) * 0.84); font-weight: 700; letter-spacing: .05em; text-transform: uppercase;
   color: var(--fg-subtle);
 }
 .bothy-files .rd-toc-list { list-style: none; margin: 0; padding: 0; }
@@ -382,7 +461,7 @@
 .bothy-files .rd-toc-a {
   appearance: none; cursor: pointer; width: 100%; text-align: left;
   border: 0; border-left: 2px solid var(--line); background: transparent;
-  font: inherit; font-size: 11.5px; line-height: 1.35; color: var(--fg-subtle);
+  font: inherit; font-size: calc(var(--rd-ui-fs) * 0.92); line-height: 1.35; color: var(--fg-subtle);
   padding: 4px 6px 4px 10px;
   display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
@@ -532,12 +611,12 @@
 .bothy-files .rd-crumbs {
   display: flex; flex-wrap: wrap; align-items: center;
   gap: 2px; padding: 6px var(--rd-gut) 8px;
-  font-size: 11.5px; color: var(--fg-subtle);
+  font-size: calc(var(--rd-ui-fs) * 0.92); color: var(--fg-subtle);
   border-bottom: 1px solid var(--line);
 }
 .bothy-files .rd-crumbs button {
   padding: 1px 4px; border: 0; background: none; border-radius: var(--r-xs);
-  font: inherit; font-size: 11.5px; color: var(--accent-fg); cursor: pointer;
+  font: inherit; font-size: calc(var(--rd-ui-fs) * 0.92); color: var(--accent-fg); cursor: pointer;
 }
 .bothy-files .rd-crumbs button:hover { background: var(--accent-bg); }
 .bothy-files .rd-crumbs b { color: var(--fg); font-weight: 700; padding: 0 2px; }

--- a/apps/portal-next/web/src/pages/files/reading.ts
+++ b/apps/portal-next/web/src/pages/files/reading.ts
@@ -1,0 +1,157 @@
+// ── how big a document is, and how big the panels around it are ──────────────
+//
+// Two numbers, and they are deliberately two.
+//
+//   · the DOCUMENT     - `--read-fs`, 16px by default. index.css argues for it:
+//                        "14.5px is a good size for a control that sits beside a
+//                        chart and a tiring one for a page of prose you actually
+//                        read".
+//   · the PANELS       - `--rd-ui-fs`. The index rows, the outline entries, the
+//                        breadcrumbs. They were ~11.5px, set at the app's
+//                        control size, on a surface whose whole argument is that
+//                        a document is not a dashboard.
+//
+// They are two because they answer different questions. Raising the document
+// widens the column (the measure is in `ch`) and does nothing to the rails;
+// raising the panels makes the index legible without reflowing a word of prose.
+// One number would force the two to move together and neither would land.
+//
+// ── WHY localStorage, AND WHY THAT IS NOT A PLACEHOLDER ─────────────────────
+//
+// docs/plans/control-and-settings.md §6b draws the line: theme, pane widths and
+// collapsed groups belong to the BROWSER; identity and roles belong to the USER;
+// and only "default root, default landing page, favourites" needs a store that
+// does not exist. A text size passes the browser test outright - it is a fact
+// about the screen you are sitting at, not about you, and the same size is wrong
+// on a 14" laptop and a 27" monitor.
+//
+// So this ships now, honestly, beside `bothy-files-panes-v1` and
+// `bothy-read-recent-v1`, and Settings says in the same sentence it says for
+// those that it does not follow you to another device. #157 is the separate
+// question of a per-user store; if that is answered yes this moves into it and
+// the key below becomes the fallback - the same migration the theme would make.
+//
+// AND IT IS NOT A WRITE PATH. reading-first.md §7 is about writing to the BOX.
+// This writes two numbers to the browser you are sitting at and reaches no
+// server, which is the same thing the theme picker has always done.
+//
+// IMPORTS NOTHING except React, so the pure half below can be compiled and run
+// by checks/run.sh with a bare `tsc`.
+
+import { useCallback, useEffect, useState } from 'react';
+
+/** Versioned, so a shape change is a reset rather than a crash on somebody's
+ *  three-week-old localStorage. Same convention as `bothy-files-panes-v1`. */
+export const READING_KEY = 'bothy-reading-v1';
+
+export interface Reading {
+  /** The rendered document, in px. */
+  doc: number;
+  /** The index and the outline, in px. */
+  ui: number;
+}
+
+/** Today's values, so nobody who never opens Settings sees anything move.
+ *
+ *  `doc` is index.css's `--read-fs`. `ui` is 12.5px, which is what `.rd-doc-title`
+ *  was - the largest of the panel sizes, chosen as the base because every other
+ *  panel rule is expressed as a ratio BELOW it and a base picked from the
+ *  smallest would have needed ratios above 1 to say "this one is bigger". */
+export const READING_DEFAULT: Reading = { doc: 16, ui: 12.5 };
+
+/** The band each is allowed into.
+ *
+ *  Bounded rather than free, and not to be tidy: `--read-measure` is `100%` and
+ *  the panels are fixed-width rails, so a 40px index row does not wrap into a
+ *  taller row - it ellipsises every title down to two words. The ceiling is the
+ *  size at which the rail still says something. The floor is the size below
+ *  which raising it was the point. */
+export const READING_LIMITS = {
+  doc: { min: 13, max: 24 },
+  ui: { min: 11, max: 18 },
+} as const;
+
+/** One step of the +/- controls. Half a pixel on the panels because the range is
+ *  seven pixels wide and whole steps would make it a four-position switch. */
+export const READING_STEP = { doc: 1, ui: 0.5 } as const;
+
+export function clampReading(key: keyof Reading, v: number): number {
+  const { min, max } = READING_LIMITS[key];
+  if (!Number.isFinite(v)) return READING_DEFAULT[key];
+  // Rounded to a half pixel, which is the finest step either control offers.
+  // Without it a hand-edited 16.333 reaches the stylesheet and every derived
+  // size inherits a fraction nobody chose.
+  return Math.max(min, Math.min(max, Math.round(v * 2) / 2));
+}
+
+/**
+ * Whatever is in the store, made safe.
+ *
+ * Every field re-checked rather than trusted, for the reason `parseRecents` in
+ * start.ts gives at length: this value is hand-editable, it survives deploys,
+ * and it is fed straight into a CSS custom property. A stored `{doc: "huge"}`
+ * would otherwise reach the stylesheet as `font-size: huge` and be silently
+ * dropped by the browser, which renders as the setting not working.
+ */
+export function parseReading(raw: string | null): Reading {
+  if (!raw) return READING_DEFAULT;
+  let j: unknown;
+  try { j = JSON.parse(raw); } catch { return READING_DEFAULT; }
+  if (!j || typeof j !== 'object') return READING_DEFAULT;
+  const r = j as Record<string, unknown>;
+  return {
+    doc: clampReading('doc', typeof r.doc === 'number' ? r.doc : READING_DEFAULT.doc),
+    ui: clampReading('ui', typeof r.ui === 'number' ? r.ui : READING_DEFAULT.ui),
+  };
+}
+
+/** The two custom properties, as a style object for the reader's root element.
+ *
+ *  ON THE ELEMENT, not on `:root`. The document scale belongs to the reading
+ *  surface: written to `:root` it would resize the Settings page that changes it
+ *  and every panel elsewhere in the app that happens to inherit, which is a
+ *  preference reaching a great deal further than its own name claims. */
+export function readingVars(r: Reading): Record<string, string> {
+  return { '--read-fs': `${r.doc}px`, '--rd-ui-fs': `${r.ui}px` };
+}
+
+function read(): Reading {
+  try { return parseReading(localStorage.getItem(READING_KEY)); } catch { return READING_DEFAULT; }
+}
+
+/**
+ * The stored size, and a setter that stores.
+ *
+ * Never throws: private mode, a disabled store and a quota error all mean "the
+ * defaults", which is a state every caller already renders.
+ *
+ * It listens for `storage` as well, so the Settings page changing the size is
+ * reflected in a reader open in another tab. That event does not fire in the tab
+ * that WROTE the value, which is why the setter also updates its own state -
+ * the two halves are not redundant, they cover different tabs.
+ */
+export function useReading(): [Reading, (next: Partial<Reading>) => void] {
+  const [reading, setReading] = useState<Reading>(read);
+
+  const update = useCallback((next: Partial<Reading>) => {
+    setReading((prev) => {
+      const merged: Reading = {
+        doc: clampReading('doc', next.doc ?? prev.doc),
+        ui: clampReading('ui', next.ui ?? prev.ui),
+      };
+      try { localStorage.setItem(READING_KEY, JSON.stringify(merged)); } catch { /* not fatal */ }
+      return merged;
+    });
+  }, []);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== READING_KEY) return;
+      setReading(parseReading(e.newValue));
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  return [reading, update];
+}


### PR DESCRIPTION
Steps 5–6 of `docs/plans/the-guide-and-the-reader.md` §9.

> Replaces #161, which GitHub closed automatically when #160 merged and its base branch was deleted. Same branch, rebased onto `main`, same single commit — re-verified after the rebase (typecheck clean, 247 pass · 0 fail).

## Reading size is a setting — closes #156

The outline was 11.5px and the index rows 12.5px, set at the app's **control** size, on a surface whose whole argument is that a document is not a dashboard. And "bigger" is a different number on a 14" laptop and a 27" monitor.

**Two tokens, because they answer different questions.** `--read-fs` is the document; `--rd-ui-fs` is the panels beside it. Raising the document reflows prose and does nothing to the rails; raising the panels makes the index legible without touching a word of prose. One number would tie them together and neither would land.

Every `font-size` in `read.css` is now a **ratio** of `--rd-ui-fs` rather than a literal — that is what makes it settable at all. It was thirty separate numbers, so "make the index bigger" had thirty edits and nothing to change.

Applied to the **reader's root element**, not `:root`: a document scale written globally would resize the Settings page that changes it.

**The store is `localStorage`, and that is not a placeholder.** `control-and-settings.md` §6b draws the line — theme, pane widths and collapsed groups belong to the *browser*; identity and roles to the *user*; only default root / landing page / favourites need a store that does not exist. A text size passes the browser test outright. So `bothy-reading-v1` sits beside `bothy-files-panes-v1` and `bothy-read-recent-v1`, and the Stores table answers "on another device" in the same sentence it answers it for those. **#157 stays the separate question**; if it is answered yes, this is among the first things that moves.

Every field is re-checked on read, for the reason `parseRecents` gives: the value is hand-editable, survives deploys, and is fed straight into a CSS custom property — a stored `{doc: "huge"}` reaches the stylesheet, gets dropped by the browser, and reads as the setting not working.

The Settings control shows a **sample at the size it is set to**. "12.5px" is a number nobody thinks in.

## Where you are looking is a control — closes #152

Choosing a root meant scrolling: the roots were section headers interleaved with their own contents, so "go to `projects`" was "scroll past everything in `notes`". Reaching `docs/brand/foundations` meant expanding three folders, and there was nowhere to type a path.

One chip in the panel header opening a popover: the roots as the `fx-rootchip` group `Explorer.tsx` already draws (Lock glyph included — it is the only warning that every file in a read-only root will turn out to have no Edit button), plus a path box with completions.

**The completions cost nothing** — they are the directories of the listing the panel already holds. No request, no endpoint, no index. The consequence is stated rather than hidden: a root nobody has opened offers nothing, and the empty state says *which* of the two it is, because "no folder matches" and "this root has not been listed yet" look identical and only one means the path is wrong.

Browse mode only. A scope picker on the guide would be the root selector that mode exists in order not to have. Changing root clears the folder: a path inside `stacks` is almost never a path inside `notes`.

## How this was confirmed

`typecheck` clean; `checks/run.sh` **247 pass · 0 fail** (`--rd-ui-fs` joins the `--read-*` family in `STRUCTURAL`, for the reason already written there — it is a length, and demanding it of every theme was never right). Rebuilt `portal-next`, drove it in Chromium; **0** console errors or warnings.

```
scope picker   stacks -> type "brand" ->
                 docs/brand, docs/brand/foundations, docs/brand/patterns,
                 docs/brand/quality, docs/brand/reference
               pick one -> ?in=docs%2Fbrand
                 chip        "stacks/docs/brand"
                 breadcrumb  stacks / docs / brand
                 tree        foundations, patterns, quality, reference

scope survives opening a file (the other half of #152, #160 had the first):
               ?root=stacks&path=docs%2Fbrand%2Ffoundations%2Fbrand-core.md
                             &in=docs%2Fbrand

reading size   default    doc 16px   row 12.5px   toc 11.5px    prose 16px
               at 20/16   doc 20px   row 16px     toc 14.72px   prose 20px
               Settings   +/- writes {"doc":18,"ui":12.5}; Reset -> 16px
                          samples render at the size they name
                          cross-tab `storage` event applies it live
```

## Not in this PR

#157 (the per-user store decision — no code) and #158 (eight new guide pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
