### PR TITLE
docs(guide): the eight pages the guide was missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,17 +142,30 @@ done.
 
 ## The guide
 
-Seven pages, written for somebody who has **not** read the source. Everything
-below this line in the README is reference material for somebody who has.
+Written for somebody who has **not** read the source. Everything below this line
+in the README is reference material for somebody who has.
+
+No count here on purpose - the guide grows, and a number in this sentence is the
+fastest-rotting thing on the page. [The guide index](docs/guide/index.md) is the
+list, and `apps/portal-next/checks/start-table.mjs` asserts that it and the
+folder on disk still describe each other.
 
 | If you want to | Read |
 |---|---|
 | get it running on a machine that has never had it | [Installing Bothy](docs/guide/installing.md) |
+| know what `bothy up` does, and where it looks for your checkout | [The `bothy` command](docs/guide/the-cli.md) |
 | know which YAML is load-bearing, and what happens when you save it | [The files you will actually edit](docs/guide/configuring.md) |
 | use the thing - Overview, Control, the three verbs | [Operating it from the console](docs/guide/the-console.md) |
 | read, search and edit the box's own files from a browser | [Bothy Files](docs/guide/files.md) |
+| know why Settings mostly does not change anything | [Settings](docs/guide/settings.md) |
 | understand `viewer`, `editor`, `operator` and the role nobody holds | [Roles](docs/guide/roles.md) |
 | pick a theme, or write one | [Themes](docs/guide/themes.md) |
+| add a container this repository runs | [Adding a service to the stack](docs/guide/services.md) |
+| make a project of your own visible, including while it is off | [Declaring a project](docs/guide/projects.md) |
+| know what is scraped, and for how long it is kept | [Monitoring](docs/guide/monitoring.md) |
+| know what is backed up, what is not, and how to restore it | [Backups](docs/guide/backups.md) |
+| move to a newer version without losing data | [Upgrading](docs/guide/upgrading.md) |
+| work out why something is broken | [When something is wrong](docs/guide/troubleshooting.md) |
 | all of it, in order | [the guide index](docs/guide/index.md) |
 
 ![Bothy Files: the document tree on the left, this README rendered in the centre with its screenshots inline, and the page outline on the right.](docs/assets/files.png)

--- a/apps/portal-next/web/src/pages/files/guide.ts
+++ b/apps/portal-next/web/src/pages/files/guide.ts
@@ -22,13 +22,25 @@
  *  Basenames rather than paths: the folder is GUIDE_DIR (routes.ts) and writing
  *  it out seven times would be seven copies of one fact. */
 export const GUIDE_ORDER: readonly string[] = [
+  // Getting it running.
   'index.md',
   'installing.md',
+  'the-cli.md',
   'configuring.md',
+  // Using it.
   'the-console.md',
-  'roles.md',
   'files.md',
+  'settings.md',
+  'roles.md',
   'themes.md',
+  // Putting your own things on it.
+  'services.md',
+  'projects.md',
+  // Keeping it running.
+  'monitoring.md',
+  'backups.md',
+  'upgrading.md',
+  'troubleshooting.md',
 ];
 
 /** Where `path` sits in the reading order. `Infinity` for anything the list does

--- a/docs/guide/backups.md
+++ b/docs/guide/backups.md
@@ -1,0 +1,121 @@
+# Backups
+
+Three things are backed up nightly, and they were each chosen because losing
+them is unrecoverable rather than inconvenient.
+
+| Artifact | What it carries |
+|---|---|
+| the Postgres dump | Keycloak's realm, users, clients and roles, **and** the dev database |
+| the Grafana database | dashboards, users, settings |
+| `.env` | every credential on the box - gitignored, and existing in exactly one place on earth |
+
+That third one is the one people forget. `.env` is not in git by design, so if
+the disk goes, the file goes with it and every generated secret goes with that.
+
+## When it runs, and where it lands
+
+`stacks-backup.timer` runs `scripts/backup.sh` at **03:00 daily**, keeping the
+newest **14** of each. On demand:
+
+```sh
+just backup            # or: bothy backup
+```
+
+The destination is `$BACKUP_ROOT`, which defaults to `~/backups`, with one
+directory per artifact. Everything is written `umask 077` and the directories
+are `chmod 700` on every run - the Postgres dump is `pg_dumpall`, so it contains
+Keycloak's user table and therefore the password hashes for every account on the
+box. That was being written world-readable until it was noticed.
+
+## Why it is `pg_dumpall` and must stay that way
+
+Keycloak's data lives in its own `keycloak` database inside the same Postgres
+server, created against the running instance. A named-database list would never
+have grown a `keycloak` entry on its own, and the identity provider for the
+whole box would have been silently un-backed-up.
+
+**Do not narrow this to a list of databases.** `pg_dumpall` picks up any new
+database with no edit to the script.
+
+## The script is deliberately not `set -e`
+
+One failed service must not skip the others. It used to abort on the first
+failure, which is how a single bad Postgres dump left everything else
+un-backed-up for six days without anything looking wrong.
+
+Three other pieces of scar tissue, all in the same script:
+
+- **It waits for Postgres to accept connections** before dumping. The timer is
+  `Persistent=true`, so a schedule missed while the box was off fires at the
+  next boot - which is exactly when Postgres is still initialising.
+- **It verifies every artifact is non-empty** before keeping it. An empty
+  artifact is worse than none: rotation counts it, and it would eventually evict
+  a good backup with a worthless one.
+- **It exits non-zero if any step failed**, so the timer's own success signal
+  means something.
+
+The reason all three exist together: for six days it produced 20-byte empty
+dumps while reporting success. A failed `pg_dumpall` still leaves behind a
+perfectly valid gzip of nothing.
+
+## `just doctor` checks age and size, not existence
+
+Directly because of the above. A file named like a backup is not a backup, and
+existence is the one property a broken backup still has. `doctor` also knows how
+long the box has been up, which is what separates *the timer is broken* from
+*the timer has not come round yet*.
+
+## Restoring
+
+Postgres, from a dump:
+
+```sh
+gunzip -c ~/backups/postgres/pg-<timestamp>.sql.gz \
+  | docker exec -i postgres psql -U "$POSTGRES_USER"
+```
+
+`pg_dumpall` output includes the `CREATE DATABASE` statements, so this restores
+Keycloak's database as well as the dev one. Expect Keycloak to need a restart
+afterwards.
+
+Grafana is a file copy while the container is **stopped**:
+
+```sh
+docker compose -f monitoring/compose.yml stop grafana
+docker cp ~/backups/grafana/grafana-<timestamp>.db grafana:/var/lib/grafana/grafana.db
+docker compose -f monitoring/compose.yml start grafana
+```
+
+`.env` is a copy back into the repository root, followed by bringing the stack
+up again - nothing in it is live until then:
+
+```sh
+cp ~/backups/env/env-<timestamp> ~/stacks/.env
+just up
+```
+
+## What is not covered, and is not pretended to be
+
+- **Backups sit on the same disk they protect.** Copying them off the box is not
+  solved. If the disk dies, so do the backups - this is a real limitation, not
+  an oversight waiting to be found.
+- **Docker volumes other than those three are not backed up.** Prometheus and
+  Loki data are deliberately excluded: they are large, they are observations
+  rather than state, and a box that loses them has lost history rather than
+  configuration.
+- **The repository is not backed up**, because it is in git. What is *not* in
+  git - `.env`, and anything you edited and did not commit - is the gap, and
+  only the first of those is covered here.
+
+## Before an upgrade
+
+An upgrade preserves volumes and that claim is tested in CI ([Upgrading](upgrading.md)
+explains how). Take a backup anyway before one you are unsure about: it costs
+one command, and the failure mode it protects against is the one nobody plans
+for.
+
+## Related
+
+- [Upgrading](upgrading.md) - what an upgrade does and does not touch
+- [Troubleshooting](troubleshooting.md) - `just doctor`, and reading its backup section
+- [`README.md`](../../README.md) - the shorter version, beside the rest of the repository map

--- a/docs/guide/configuring.md
+++ b/docs/guide/configuring.md
@@ -246,4 +246,5 @@ just doctor     # containers, Prometheus targets, disk, backup freshness
 ## Next
 
 - [Operating it from the console](the-console.md)
+- [Adding a service to the stack](services.md) - the checklist for a new container
 - [Roles](roles.md)

--- a/docs/guide/files.md
+++ b/docs/guide/files.md
@@ -254,4 +254,6 @@ honest reason to build one. See [Roles](roles.md).
 
 - [Themes](themes.md) - the theme editor writes its file through this tier
 - [The files you will actually edit](configuring.md) - what those cautions are warning about
+- [Settings](settings.md) - the reading size, and where this browser's other preferences live
+- [When something is wrong](troubleshooting.md) - the repair paths when an edit breaks something
 - [`apps/portal-files/policy.toml`](../../apps/portal-files/policy.toml) - the policy itself, which is the reference for all of the above

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -13,14 +13,42 @@ a fact lives in a file, these pages name the file.
 
 ## Where to start
 
+The pages are in reading order. Nobody needs all of them; the four groups are
+the four reasons somebody opens this directory.
+
+### Getting it running
+
 | If you want to | Read |
 |---|---|
 | get it running on a machine that has never had it | [Installing Bothy](installing.md) |
+| know what `bothy up` actually does, and where it looks for your checkout | [The `bothy` command](the-cli.md) |
 | know which YAML is load-bearing, and what happens when you save it | [The files you will actually edit](configuring.md) |
+
+### Using it
+
+| If you want to | Read |
+|---|---|
 | use the thing - Overview, Control, the three verbs | [Operating it from the console](the-console.md) |
 | read, search and edit the box's own files from a browser | [Bothy Files](files.md) |
+| know why Settings mostly does not change anything | [Settings](settings.md) |
 | understand `viewer`, `editor`, `operator` and the role nobody holds | [Roles](roles.md) |
 | pick a theme, or write one | [Themes](themes.md) |
+
+### Putting your own things on it
+
+| If you want to | Read |
+|---|---|
+| add a container this repository runs | [Adding a service to the stack](services.md) |
+| make a project of your own visible, including while it is off | [Declaring a project](projects.md) |
+
+### Keeping it running
+
+| If you want to | Read |
+|---|---|
+| know what is scraped, what is kept, and for how long | [Monitoring](monitoring.md) |
+| know what is backed up, what is not, and how to restore it | [Backups](backups.md) |
+| move to a newer version without losing data | [Upgrading](upgrading.md) |
+| work out why something is broken | [When something is wrong](troubleshooting.md) |
 
 ## What is documented elsewhere, and why it stays there
 

--- a/docs/guide/installing.md
+++ b/docs/guide/installing.md
@@ -276,5 +276,6 @@ list.
 
 ## Next
 
+- [The `bothy` command](the-cli.md) - what `init` did, and what the CLI does after it
 - [The files you will actually edit](configuring.md)
 - [Operating it from the console](the-console.md)

--- a/docs/guide/monitoring.md
+++ b/docs/guide/monitoring.md
@@ -1,0 +1,108 @@
+# Monitoring
+
+Every container on this box is covered - logs and metrics - with **no
+per-service setup**. That is not a claim about how thorough the configuration
+is; it is a consequence of how two of the three collectors find their targets.
+
+## Why it covers everything for free
+
+| Signal | Collector | Coverage |
+|---|---|---|
+| Logs | `promtail`, via Docker service discovery, into Loki | every running container, any stack or project. Labels: `container`, `stack` (the compose project), `stream` |
+| Container metrics | `cadvisor` into Prometheus | CPU, memory, network and filesystem, every container |
+| Host metrics | `node-exporter` | |
+| App metrics | `postgres-exporter` | |
+| The edge | Traefik's own Prometheus metrics | request rate, latency and error rate per router, service and entrypoint |
+
+`promtail` and `cadvisor` discover through the Docker socket rather than a
+hand-kept target list. **A container you start is covered the moment it starts**,
+and a container you delete stops being scraped without anyone editing anything.
+
+Traefik's metrics are on an **internal** entrypoint with no host port -
+Prometheus reaches it by name over `devnet`. That is why a new service only has
+to join `devnet` to be visible; see [Adding a service](services.md).
+
+## What you get in Grafana
+
+Grafana auto-provisions the Prometheus and Loki datasources, five dashboards,
+and three alert rules:
+
+| Alert | Fires when |
+|---|---|
+| Instance down | a Prometheus target stops answering |
+| Host memory high | host memory above 90% |
+| Host disk almost full | a filesystem above 85% full |
+
+Everything is provisioned from files under `monitoring/provisioning/`, so a
+dashboard edited in the Grafana UI is **not** persisted the way a provisioned
+one is. Edit the file.
+
+## Retention, and the two limits that matter
+
+**Prometheus: 15 days, and 3 GB, whichever comes first.**
+
+The size ceiling is the interesting half, and it exists because of a real
+incident. `retention.time` alone means the volume grows as
+`cardinality x 15 days` - bounded by how much things happen to emit rather than
+by anything anyone chose. cAdvisor ran with no flags, produced 4,147 series of
+which ~400 were reachable, and that is most of why the volume reached 1.8 GB.
+
+Time-based retention was working correctly the whole time. The defect was never
+that old data stayed; it was that nothing capped how big fifteen days could
+**be**. If the size limit ever bites, it means something started emitting far
+more than before, and losing the oldest hours is the right answer.
+
+**Loki: 168 hours (7 days).** Loki ships with no retention whatsoever - the
+stock configuration defines neither a limit nor a compactor that would enforce
+one - so both stanzas had to be added. Everything else in `loki-config.yml` is
+the image default, verbatim, which is deliberate: it makes the diff against
+upstream exactly "the retention block".
+
+## A scrape job for something that does not run is not harmless
+
+Two jobs were removed when their services were, and the reasoning is worth
+carrying into anything you add:
+
+- `redis-exporter` and `kafka-exporter` came out when those services did.
+- The `docker-daemon` job came out because nothing in the repository read a
+  single `engine_daemon_*` series, and because the daemon setting that produces
+  them is opt-in - so the target sat permanently down on any box that had not
+  been hand-edited.
+
+A permanently-down target does not just add noise. It destroys the usefulness of
+the only question worth asking of a target list: **are all targets up?** Once
+the answer is routinely "no, but that one is fine", nobody reads it again.
+
+So: **deleting a service means deleting its scrape job in the same change.** The
+same rule applies to backup steps, and this repository has broken that one twice
+- see [Backups](backups.md).
+
+## Reaching it
+
+Prometheus and Grafana publish their own host ports; `just urls` prints the
+table for the box you are on. Neither is behind single sign-on. Prometheus
+carries HTTP basic auth on **all** endpoints as its boundary, and Grafana its
+own login, both on the shared `DEV_LOGIN_*` credential from `.env`.
+
+> [!warning] "SSO is running" does not mean "this is behind SSO"
+> Only three tiers are. Grafana, Prometheus and Keycloak's own console each
+> carry a separate login, and the tailnet is the rest of the control. See
+> [Roles](roles.md).
+
+## What to look at first
+
+- **`just doctor`** covers Prometheus targets alongside containers, ports,
+  routes, DNS and disk, and is the fastest way to see that a collector has
+  stopped. [Troubleshooting](troubleshooting.md) reads its output.
+- **Logs for one container** are a Loki query on the `container` label, and
+  because promtail discovers by socket, the label is the container's real name
+  with no configuration anywhere.
+- **The Overview in the console** reads the same Prometheus - the CPU, memory
+  and network panels are queries, not a second collector.
+
+## Related
+
+- [Adding a service to the stack](services.md) - what joining `devnet` gets you
+- [Backups](backups.md) - what is and is not preserved (metrics are not)
+- [Troubleshooting](troubleshooting.md) - `just doctor`, and what its sections mean
+- [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) - the collectors in their full context

--- a/docs/guide/projects.md
+++ b/docs/guide/projects.md
@@ -1,0 +1,168 @@
+# Declaring a project
+
+Bothy discovers two things by itself: **Traefik routers** and **Docker
+containers**. That leaves two blind spots, and a declaration is how you fill
+them.
+
+- **A project that is switched off has nothing to discover.** It does not show
+  as "off" - it disappears from the box entirely.
+- **A project made of host processes is invisible even while running.** A
+  `just dev` or `tilt up` harness on ordinary ports is neither a container nor,
+  unless somebody hand-wrote a route, a Traefik service.
+
+Underneath both is the real gap: discovery records **observed facts, never
+intent**. It sees "not running" and cannot tell *somebody stopped this* from
+*this crashed*.
+
+## It is `project.dev.yml`, and it is YAML
+
+Not TOML. The two `.toml` files on the box - `apps/portal-files/policy.toml` and
+`apps/bothy-config/policy.toml` - are **access policy** for those services and
+have nothing to do with declaring a project. Do not conflate them; they are
+covered in [The files you will actually edit](configuring.md).
+
+`project.dev.yml` lives at a repository root. The project owns it, it travels
+with a re-clone, and deleting it only removes the project from the console.
+**Nothing at runtime reads it** - only the collector does.
+
+```yaml
+name: Shvil TV
+kind: project              # project | stack | infra
+description: Five-service HLS pipeline.
+start: just up             # shown on the card when the project is off
+ports_file: .dev-ports.env # optional: KEY=VALUE source for ${VAR} below
+
+services:
+  - name: tv-player-web
+    host_port: ${TV_PLAYER_WEB_PORT}   # probed, and identified
+    type: web
+    ui: true                           # offer a link when it is up
+  - name: redis
+    container: mpeg-redis              # docker-inspected
+```
+
+### Top-level keys
+
+| Key | Meaning |
+|---|---|
+| `key` | stable id. Defaults to the directory name. |
+| `name` | display name. Defaults to the directory name; also what it sorts by. |
+| `kind` | `project` (default), `stack` or `infra` |
+| `description` | one line, optional |
+| `start` | the shell command shown on the card when the project is off |
+| `ports_file` | a `KEY=VALUE` file, used to resolve `${VAR}` in service values |
+| `log_stream` | maps to a Loki `{host_service="..."}` stream, for host processes |
+| `services` | the list below |
+
+### Per-service keys
+
+| Key | Meaning |
+|---|---|
+| `name` | defaults to `"service"` |
+| `description` | optional |
+| `type` | `web`, `database`, `cache`, `queue`, `storage`, `observability`, `runtime` (default), `edge` |
+| `ui` | offer a link when it is up |
+| `container` | a container name, inspected with `docker inspect` |
+| `host_port` | a port, or `${VAR}` resolved through `ports_file` |
+| `log_filter` | narrows a shared host log stream |
+
+A service may declare `container`, `host_port`, or both. **`container` wins for
+state**; `host_port` still supplies the UI link.
+
+`ports_file` is the key worth knowing about: a harness that picks free ports at
+runtime writes them to a file, and the collector follows that file rather than
+probing a stale address.
+
+## A port is an address, not an identity
+
+This is the most important thing on the page, because the obvious implementation
+is wrong and Bothy shipped it once.
+
+Deciding a declared host service is up by TCP-connecting to its port **cannot
+fail in the way it claims to**. It answers *is anything listening*, and that
+answer used to be reported as *is my service listening*. On 2026-08-12 the stack
+published Keycloak on 8083, a stopped project declared a service on 8083, the
+connect succeeded, and the console told its user in good faith that a service
+nobody had started was running.
+
+So the probe now **identifies the listener**. Strongest evidence first:
+
+1. **Is the port published by a container?** It matches if the container is
+   named by this declaration, or its compose working directory is inside the
+   project root, or its compose project matches the project's key, directory or
+   name. Match → `up`. Positively somebody else → `collision`.
+2. **Is a host process holding it?** `ss -ltnp` gives the PID for processes the
+   collector's own user owns - which is what a dev harness is - and then
+   `/proc/<pid>/{cmdline,exe,cwd}` has to name the project root or the service.
+   Match → `up`. Positively located elsewhere → `collision`.
+3. **Neither could name it** → `unverified`.
+
+Rung 3 is the honest floor. **`unverified` is a statement about the collector's
+knowledge, not about your service, and it is never a pass.** A listener owned by
+another user is invisible to an unprivileged `ss`, and guessing "collision"
+there would be the same class of error as the `up` it replaced.
+
+The same reasoning is applied one layer up: if Docker itself is unreachable, a
+declared container reports `unverified` rather than "does not exist" - an empty
+container list because Docker never answered is not evidence of absence.
+
+## The states you will see
+
+| State | Meaning |
+|---|---|
+| `up` | running, and healthy if it has a healthcheck |
+| `starting` | the healthcheck says starting |
+| `stopped` | exited cleanly, created, paused, or a declared port with nothing listening |
+| `stuck` | exited non-zero, restart loop, unhealthy, or OOM-killed |
+| `collision` | the port is held by something **provably not this service** |
+| `unverified` | something is listening, or Docker is unreachable, and it could not be identified |
+| `unknown` | declared, nothing observable either way |
+
+The project as a whole rolls up to `live`, `degraded`, `stopped`, `stuck` or
+`unknown`. In that rollup `collision` folds in with `stopped` - a port held by
+somebody else is positive evidence this service is *not* running - and
+`unverified` folds in with `unknown`.
+
+**`stopped` is a state, not an alert.** Only `stuck` and `degraded` are alerts,
+and a squatted port never manufactures one. This is why a box with several
+deliberately-idle projects can still read as healthy.
+
+A colliding service also carries a `collision` object naming the culprit - the
+port, whether a container or a process holds it, its name, its compose project,
+its PID - because the state alone is not actionable.
+
+## How it runs
+
+```
+~/projects/**/project.dev.yml  ->  collect.py  ->  portal-next/data/projects.json
+      (intent)                   (host truth)            (rendered)
+```
+
+`~/projects` is scanned three levels deep, because repositories are grouped
+rather than flat. The collector runs **on the host** - that is what lets it read
+`/proc` and container exit codes, neither of which a static page in a container
+can do - on a user systemd timer, every 30 seconds. The console polls its own
+data every 10 seconds, so a project starting or stopping surfaces while you are
+still looking at the page.
+
+```sh
+systemctl --user status portal-collector.timer
+python3 apps/portal-collector/collect.py    # run once by hand; prints a table on a tty
+```
+
+`projects.json` is written atomically, because the console must never read a
+half-written file. A **missing** `projects.json` is a supported state: nothing
+extra renders, and the absence is never reported as a warning.
+
+## A declaration beats discovery
+
+For the same container, the declaration wins. Containers started with
+`docker run` and no compose labels are filed by discovery under unmanaged infra;
+the declaration knows better, and keeping both copies would double-count them in
+every total.
+
+## Related
+
+- [Adding a service to the stack](services.md) - the other half: things Bothy itself runs
+- [Operating it from the console](the-console.md) - where a declared project appears, and what you may do to it
+- [`apps/portal-collector/README.md`](../../apps/portal-collector/README.md) - the reference for all of the above

--- a/docs/guide/roles.md
+++ b/docs/guide/roles.md
@@ -210,4 +210,5 @@ credential.
 
 - [Operating it from the console](the-console.md) - what `operator` unlocks
 - [Bothy Files](files.md) - what `viewer` and `editor` unlock
+- [Settings](settings.md) - where your roles are shown, and why that panel changes nothing
 - [`SECURITY.md`](../../SECURITY.md) - the threat model, and the case for and against a `shell` role that does something

--- a/docs/guide/services.md
+++ b/docs/guide/services.md
@@ -1,0 +1,147 @@
+# Adding a service to the stack
+
+This is for something **Bothy itself runs** - a container in this repository's
+compose files. For something you run in `~/projects`, see
+[Declaring a project](projects.md); the two are different mechanisms and mixing
+them up double-counts everything.
+
+## The rule that comes first
+
+**Access is `IP:port`. There is no name layer.** A browser-facing service
+publishes a host port and is reached at `http://<node-ip>:<port>`.
+
+A `Host()` rule in Traefik will register happily and then **match nothing,
+forever**, because there is no name for it to match on. That failure is silent:
+the router appears in the router table, `docker ps` looks right, and the URL
+simply never resolves. It is the single most expensive mistake available here.
+
+## A container a browser reaches
+
+Pick a free port, publish it, join `devnet`, and add it to `just urls`:
+
+```yaml
+services:
+  myapp:
+    image: myorg/myapp
+    networks: [default, devnet]      # BOTH - see the warning below
+    ports:
+      - "8099:8080"                  # HOST:CONTAINER. Check the port is free first.
+    labels:
+      # Optional. Discovery works with zero labels.
+      - dev.portal.name=My App
+      - dev.portal.desc=What it does.
+
+networks:
+  devnet:
+    external: true
+```
+
+> [!warning] Listing `networks:` silently drops the service off the compose default network
+> Always write `[default, devnet]`. With `[devnet]` alone the service loses its
+> own database, and nothing warns you.
+
+Then, in order:
+
+| Step | Why |
+|---|---|
+| Run `just urls` and `docker ps --format '{{.Ports}}'` **before** choosing the number | Ports are a flat namespace with no allocator. This check is the cost of the model and there is no way around it |
+| Add the port to the `urls` recipe in the `justfile` | `just urls` is the only inventory. A service missing from it is a service nobody finds |
+| Give it a login | It is on the tailnet with nothing in front of it. Use the shared `DEV_LOGIN_*` credential from `.env`, the way Grafana, Prometheus and the rest do |
+| **Do not** write a `Host()` rule | See above |
+| **Do not** attach the SSO middlewares | They are defined and attached to nothing on purpose. Attaching one router at a time is a rollout plan, not a per-service decision |
+
+## A container nothing browses
+
+Publish nothing. Join `devnet` and let other containers reach it by service
+name. This is the correct default for exporters, sidecars and proxies -
+`bothy-socket-proxy`, `oauth2-proxy`, `portal-files` and every `*-exporter` do
+exactly this.
+
+## A database
+
+Bind loopback explicitly and route nothing:
+
+```yaml
+ports:
+  - "127.0.0.1:5432:5432"
+```
+
+Containers reach it by name over `devnet`; humans reach it over an SSH tunnel.
+A bare `5432:5432` publishes it to the whole tailnet.
+
+## A host process
+
+Reach it on its own port - Tilt at `<node-ip>:10350`, and so on. There is no
+routing to set up.
+
+> [!warning] The process must bind `0.0.0.0`
+> `127.0.0.1` is reachable only from this box - not from a container, and not
+> from any other device on the tailnet. For Tilt that is
+> `tilt up --host=0.0.0.0 --port=10350`. This is the usual cause of a connection
+> refused from a laptop that can otherwise reach the box.
+
+## How the console finds it, with no list to maintain
+
+You do not register a service anywhere. Classification comes from where its
+compose file lives, which a container carries as a label:
+
+| Where the compose file is | Filed as |
+|---|---|
+| under `apps/` in this repository - Bothy's own tiers | **infra** |
+| elsewhere in this repository | **stack** (`edge` is **infra**, by name - it is not under `apps/`) |
+| anywhere else | **project** |
+| missing entirely | **unmanaged / infra** |
+
+**Infra is a place on disk, not a list of names.** It used to be five project
+names in the source and the list had already gone stale. A name test is also
+unsafe, because compose project names are global to the Docker daemon and belong
+to whoever claimed one first - a checkout at `~/projects/portal` was being
+declared part of Bothy.
+
+### The polish labels
+
+Everything above works with **zero labels**. If the page ever *needs* a label to
+be correct, the defaults are wrong and the defaults are the bug.
+
+| Label | Effect |
+|---|---|
+| `dev.portal.project` | display name for the whole compose project - one label fixes every breadcrumb, panel title and card |
+| `dev.portal.name` | this service's display name |
+| `dev.portal.icon` | emoji |
+| `dev.portal.desc` | card body text |
+| `dev.portal.group` / `.groupKind` | force which panel it lands in. **Display only** |
+| `dev.portal.hidden=true` | drop from Services. Still listed in Ports and Routes |
+| `dev.portal.path` | deep link, e.g. `/targets` |
+| `dev.portal.order` | sort order within a panel |
+
+`dev.portal.group` being display-only is load-bearing. Every node carries two
+group fields: `system` is **what a service is** (derived, and no label can move
+it), `group` is **where it is shown**. That separation is what lets you regroup
+the page without 404-ing the bookmark somebody took of the old URL, or
+reshuffling the accent colours - the colour is hashed from the identity, not
+from the display group.
+
+## The checklist
+
+| | |
+|---|---|
+| A free port | checked against `just urls` and `docker ps` **first** |
+| Listed in `just urls` | otherwise it is invisible |
+| On `devnet` | as `[default, devnet]`, so Prometheus and the console see it |
+| A login | the shared `DEV_LOGIN_*` credential. Nothing else is guarding it |
+| Loopback if it is a database | `127.0.0.1:PORT:PORT`, never a bare `PORT:PORT` |
+| No `Host()` rule | there is no name layer to match |
+| No SSO middleware | defined, deliberately unattached |
+| Verified | on its **own port**, checking the bytes as well as the status code |
+
+That last line is not pedantry. The console answers **every** unrouted request
+on port 80 with its own page, from any address - so a 200 from `http://<node-ip>/`
+proves nothing about your service. Check the port you published, and check that
+what came back is yours.
+
+## Related
+
+- [Declaring a project](projects.md) - for things you run outside this repository
+- [The files you will actually edit](configuring.md) - what applies a saved change, and when
+- [Monitoring](monitoring.md) - what a service on `devnet` gets for free
+- [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) - the request path and the networks, in full

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -1,0 +1,99 @@
+# Settings, and what deliberately is not there
+
+Settings is mostly a **read-only** page, and that is the design rather than a
+stage it is passing through. It is worth understanding why, because "why can I
+not change this here" is the question the page exists to answer.
+
+## The word "settings" collapses three different things
+
+| Thing | Belongs to | Where it lives |
+|---|---|---|
+| theme, pane widths, collapsed groups, reading size | the **browser** | this browser's local storage |
+| identity, roles, where the session came from | the **user** | the session token, changed in the realm |
+| a default root, a landing page, favourites | the **user** | nowhere yet - no store exists |
+
+Almost every complaint about the page dissolves once those three are apart. A
+pane width is a fact about the screen you are sitting at; carrying it to your
+phone would be the bug, not the feature. Your roles are a fact about your
+account; changing them here would mean this page could grant itself privileges.
+
+## The three groups on the page
+
+**You.** Who the session says you are, which roles you hold, what each one
+permits, and where the session came from. All of it arrives with the token.
+
+The one rule to carry out of the roles panel: **it is a description of a token,
+not a permission check**. A role missing from that list has never stopped a
+request. It explains, in advance, the 403 that would have come back. What the
+interface hides is never what the API enforces - see [Roles](roles.md).
+
+**Appearance.** The theme picker, the two ways to make a theme, and the reading
+size. These write to this browser and nowhere else.
+
+**Where these are kept.** One row per store, each answering the question a
+reader actually arrives with: *does this follow me to another device?* The
+answers differ, which is the whole reason the stores are worth telling apart.
+
+## Reading size
+
+Two numbers, under Appearance:
+
+- **Document text** - the rendered page in Files: prose, tables and code.
+- **Panel text** - the document index on the left and the outline on the right.
+
+They are separate because they answer different questions. Raising the document
+reflows prose and does nothing to the rails; raising the panels makes the index
+legible without touching a word of prose. One control would tie them together
+and neither would land where you wanted it.
+
+Each shows a sample at the size it is set to, because "12.5px" is a number
+nobody thinks in. Both are stored per browser, and the Stores table says so.
+
+## Why there is no "coming soon" form
+
+The page does not render a greyed-out control labelled *not yet*. A control that
+cannot work is a promise the page has no way to keep, and a sentence saying why
+is both shorter and true.
+
+The reason those preferences have nowhere to live is not that nobody has got
+round to it. **A store is a write path, and a write path is a threat model, an
+audit trail and a boundary.** It is worth paying for when there is a preference
+somebody actually wants kept - and the page exists partly to make that moment
+obvious when it arrives.
+
+Four features are waiting on that one decision: group naming and ordering,
+favourites, a default root, and a default landing page. The argument is written
+up in [`docs/plans/control-and-settings.md`](../plans/control-and-settings.md)
+§6b, and it is genuinely open rather than rhetorical.
+
+## What a form here would be allowed to change
+
+If a settings form is ever built for the **system** rather than the browser, two
+constraints are already fixed and are worth knowing before you propose one:
+
+- **Never render environment values.** `.env` holds real secrets, which is why
+  the file service refuses it by name. A compiler over it may show **keys and
+  whether they are set** - `POSTGRES_PASSWORD  set`, `ALERT_EMAIL_TO  not set` -
+  and never the value. A settings page that printed `.env` to any tailnet viewer
+  would undo a control that already exists.
+- **Do not parse compose to build it.** The declaration layer already exists and
+  is already reconciled against host truth ([Declaring a project](projects.md)),
+  and a compose file is not a form - it is a program, with `privileged`,
+  arbitrary mounts and arbitrary commands. A UI that round-trips compose is a UI
+  that can write arbitrary code onto the box.
+
+## What is not stored anywhere
+
+- **Which documents you have read** is kept in this browser, newest first, and
+  nowhere else.
+- **Your favourites** do not exist, per the above.
+- **Nothing on this page is written to the box** except a theme you author,
+  which is a real `.css` file and is shared by every browser that reaches it -
+  the choice of theme is per browser, the theme itself is not.
+
+## Related
+
+- [Roles](roles.md) - what each role permits, and where that is actually enforced
+- [Themes](themes.md) - the picker, and writing your own
+- [Operating it from the console](the-console.md) - the rest of the interface
+- [`docs/plans/control-and-settings.md`](../plans/control-and-settings.md) - the argument, in full

--- a/docs/guide/the-cli.md
+++ b/docs/guide/the-cli.md
@@ -1,0 +1,128 @@
+# The `bothy` command
+
+`bothy` is the half of Bothy you can have before you have a checkout. It
+installs one, and after that it is a dispatcher: a small shell script that finds
+your checkout and hands most of what you type to that checkout's `justfile`.
+
+Knowing which half you are in matters, because it is the difference between a
+command that works anywhere and one that needs to find a box first.
+
+## Two kinds of subcommand
+
+**Native.** Implemented in `scripts/bothy` itself, and the reason the script
+exists at all.
+
+| Command | What it does |
+|---|---|
+| `bothy init [dir]` | check prerequisites, clone, install `just`, record where the checkout is, and bring it up. Default directory is `~/bothy`. |
+| `bothy download` | pre-fetch every image and dependency, so a later `up` needs no network |
+| `bothy upgrade` | pull the checkout and apply it, preserving your data |
+| `bothy self-update` | replace the `bothy` on your `PATH` with the checkout's copy |
+| `bothy version` | what this checkout is - version, commit, whether it is modified, and where it lives |
+| `bothy doctor --pre` | check prerequisites **before** a checkout exists |
+| `bothy help` | the usage text |
+
+**Dispatched.** Everything else is handed straight to `just` inside your
+checkout. `bothy up` is `just up` run in the right directory:
+
+```
+up   down   doctor   verify   backup   logs <svc>   ps   urls   psql
+files-check   portability   bootstrap   nuke
+```
+
+Three of these have friendlier names, and both spellings work:
+
+| You type | It runs |
+|---|---|
+| `bothy status` | `just ps` |
+| `bothy diagnostics` | `just doctor` |
+| `bothy check` | `just verify` |
+
+Anything not in either list is refused by name, with the usage text - a
+dispatcher that passed unknown words through would be a way to run arbitrary
+recipes by typo.
+
+> [!warning] `bothy nuke` deletes every data volume
+> It is in the dispatch table because it is in the justfile, not because it is
+> safe. There is no confirmation flag here; the recipe is the thing that asks.
+
+## How it finds your checkout
+
+Every dispatched command has to `cd` somewhere first. Three sources, in order,
+and the first one that names a real Bothy checkout wins:
+
+1. **`$BOTHY_HOME`**, an explicit override. This is the one to set for a second
+   checkout, or in CI. If it is set and is *not* a Bothy checkout, the command
+   fails there rather than falling through - an override that is silently
+   ignored is worse than one that stops.
+2. **The path recorded by `init`**, in `~/.config/bothy/config` (or
+   `$XDG_CONFIG_HOME/bothy/config`). One line: `BOTHY_HOME=/path/to/checkout`.
+3. **Walking up from the current directory.** Standing anywhere inside a
+   checkout, `bothy` finds it.
+
+With none of the three, the command stops and says to run `bothy init` or set
+`BOTHY_HOME`. It does not guess.
+
+## What `init` actually does
+
+In order, and it stops at the first thing it cannot do:
+
+1. **Prerequisites.** `docker`, `git`, `curl`, `python3`, `openssl`, and
+   `docker compose` as a working subcommand. Missing ones are listed by name.
+2. **Clone**, unless the directory is already a Bothy checkout - in which case
+   it is reused. A directory that exists, is not empty, and is not a checkout is
+   refused rather than written into.
+3. **`just`**, if it is not already there, into `~/.local/bin` via its official
+   installer, pinned to that directory rather than run as root. If
+   `~/.local/bin` is not on your `PATH`, `init` says so; nothing later will.
+4. **Record** the path in the config file above.
+5. **`.env` and secrets**, then bring the stack up.
+
+`bothy doctor --pre` is step 1 on its own, and it is the only subcommand that
+works with no checkout anywhere - which is the point of it. Run it before you
+clone anything.
+
+## `upgrade` and `self-update` are different things
+
+This is the single most confusing thing about the CLI and it is worth being
+blunt about:
+
+- **`bothy upgrade` updates the box.** It pulls the checkout and re-applies it.
+- **`bothy self-update` updates this script.** It copies `scripts/bothy` from
+  the checkout over the `bothy` on your `PATH`.
+
+They are separate because the `bothy` you run is a **copy**. The installer puts
+`scripts/bothy` into `~/.local/bin/bothy`; `upgrade` pulls the repository. So
+after an upgrade the checkout has a new CLI and the one you are running is
+whatever was current the day you installed - which matters for a dispatcher,
+because it resolves subcommands against a justfile it may no longer match.
+
+`self-update` overwrites the file **this process was started from**, resolved
+through symlinks, rather than an assumed `~/.local/bin/bothy`: overwriting a
+path you did not choose is worse than refusing. If you are already running the
+checkout's copy it says so and does nothing.
+
+See [Upgrading](upgrading.md) for what `upgrade` does to your data.
+
+## Reading `bothy version`
+
+```
+bothy version
+```
+
+prints the version, the short commit, whether the working tree is modified, and
+the checkout path. The `(modified)` marker is the useful one: it is what
+distinguishes two boxes claiming the same version, and the first thing to check
+when a box behaves unlike its version number says it should.
+
+## When to use `just` instead
+
+Nothing about `bothy` is required. Inside a checkout, `just up` and `bothy up`
+are the same command, and `just --list` shows every recipe including the ones
+the dispatch table does not name. The CLI earns its place in exactly two
+situations: before the checkout exists, and when you are not standing in it.
+
+## Next
+
+- [Upgrading](upgrading.md) - what `upgrade` touches, and what it deliberately does not
+- [Installing Bothy](installing.md) - the longer version of `init`, and the manual path

--- a/docs/guide/the-console.md
+++ b/docs/guide/the-console.md
@@ -183,5 +183,7 @@ request; it explains, in advance, the 403 that would have come back.
 
 ## Next
 
-- [Roles](roles.md) - who may do which of the above
 - [Bothy Files](files.md) - the reading and editing tier
+- [Settings](settings.md) - and why most of it is read-only
+- [Roles](roles.md) - who may do which of the above
+- [Declaring a project](projects.md) - how a project of yours gets a card here

--- a/docs/guide/themes.md
+++ b/docs/guide/themes.md
@@ -181,3 +181,4 @@ reclassified as structural, where they belonged.
 - [`docs/brand/reference/tokens.md`](../brand/reference/tokens.md) - the token reference
 - [`docs/brand/foundations/colour.md`](../brand/foundations/colour.md) - the palette, and what each colour job is for
 - [Bothy Files](files.md) - the tier the theme editor saves through
+- [Settings](settings.md) - the picker's home, and what else lives in this browser

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,0 +1,144 @@
+# When something is wrong
+
+Start with one command:
+
+```sh
+just doctor          # or: bothy doctor
+```
+
+It covers containers, published ports, Traefik routes, Prometheus targets, DNS,
+disk, memory and backup freshness. **The failing line is often not the one you
+expect**, which is why it reports on all of them rather than the one you asked
+about.
+
+It exits 0 by default even when it finds problems - the everyday use is a human
+reading a report, and a non-zero exit makes it unusable in a shell with
+`set -e`. Pass `--strict` when you want a verdict rather than a report.
+
+## The traps that cost the most time
+
+These are in rough order of how often they are the actual answer.
+
+### A 200 proves nothing about routing
+
+The console's catch-all answers **every** unmatched request on port 80 with its
+own page - from any address, for any path no other rule matched. So a service
+you believe you routed can be dead while `curl` reports a cheerful 200 and a
+page full of somebody else's markup.
+
+It is the most convincing false positive available on this machine.
+
+**Assert on content, never on a status code.** Check the service on **its own
+published port**, and check that the bytes that came back are its bytes. This is
+exactly what `just verify` does.
+
+### A `Host()` rule registers as enabled and matches nothing
+
+There is no name layer. A `Host()` rule appears in the router table, looks
+healthy, and never fires - forever. Publish a port instead. If you genuinely
+need a Traefik route, it has to be a **host-less exact `Path()`** rule;
+`edge/dynamic/project.example.yml` is the template.
+
+### `edge/dynamic` goes stale after a `git checkout`
+
+A bind mount pins the host inode when the container is created, and `git
+checkout` deletes and recreates directories. So after switching branches Traefik
+keeps reading an **orphaned** copy of `edge/dynamic/` and silently serves its
+last in-memory config. `--providers.file.watch=true` stops meaning anything, and
+every edit to a routing file appears to have no effect.
+
+```sh
+docker compose -f edge/compose.yml up -d --force-recreate
+```
+
+It ran that way for five days once.
+
+### Listing `networks:` drops a service off the default network
+
+Writing `networks: [devnet]` removes the compose default network, so the service
+loses its own database. Always `[default, devnet]`. Nothing warns you.
+
+### A dotless hostname in a host process
+
+A bare compose service name - `tempo`, `redis` - leaking out of a container into
+a host process is a landmine. Without DNS configured to refuse them outright,
+each lookup hangs for tens of seconds, and because `getaddrinfo` runs on a small
+thread pool a handful of them starve **every other lookup in the process**.
+
+It presents as unrelated database timeouts on a healthy database. That is a very
+expensive way to learn about DNS.
+
+### `just urls` is not an authoritative port registry
+
+It lists the **stack's** ports. A project's claims live in its own
+`project.dev.yml`, and nothing reconciles the two. Check **both** `ss -ltn` and
+the project manifests before publishing a port.
+
+This is not hypothetical: the stack once published Keycloak on a port a stopped
+project had already declared, the collector found something listening there, and
+reported a service nobody had started as up. See
+[Declaring a project](projects.md) for how that probe was fixed.
+
+### A service is reachable from the box but not from a laptop
+
+Almost always the process bound `127.0.0.1` rather than `0.0.0.0`. Loopback is
+reachable only from this machine - not from a container, and not from any other
+device on the tailnet.
+
+## Reading the route table
+
+There is **no Traefik dashboard** to check. It was deleted deliberately: its
+`/api/rawdata` endpoint dumped the merged configuration and leaked a credential
+that a headers middleware had injected. **A headers middleware hides a secret
+from the browser, not from the config dump.**
+
+The router table is served at `http://<node-ip>/-/api/traefik/http/routers`, and
+rendered in the console under Control.
+
+## Editing is not applying
+
+A change that appears to do nothing usually did nothing *yet*:
+
+| You changed | What applies it |
+|---|---|
+| a compose label or port | the container must be **recreated**, not restarted |
+| `.env` | nothing is live until the stack is brought up again |
+| a file in `edge/dynamic/` | picked up live - unless the mount is stale, above |
+| a `policy.toml` | the service reloads it at start, and **fails closed** if it cannot parse it |
+
+[The files you will actually edit](configuring.md) covers this properly,
+including the doubled-brace trap that voids a whole routing file with no error.
+
+## Logs
+
+Every container's logs are in Loki with no per-service setup, labelled by
+container name and compose project - see [Monitoring](monitoring.md). For one
+container, quickly:
+
+```sh
+just logs <service>          # or: bothy logs <service>
+docker logs --tail 100 <container>
+```
+
+## When the box will not answer at all
+
+If nothing responds - not the console, not SSH - the problem is usually not the
+services. Check in this order: is the machine awake, is the network path up, is
+the Docker daemon running, and only then look at containers.
+
+On a WSL2 host specifically, the VM is destroyed shortly after the last
+Windows-side client disconnects, taking Docker and every container with it.
+`restart: unless-stopped` is inert if the daemon never starts. `host/README.md`
+covers keeping it alive.
+
+> This guide stops at the general case on purpose. One machine's outage history,
+> with real addresses and real incidents, lives in [`docs/kb/`](../kb/README.md)
+> - it is correct, and it is that box's operational record rather than user
+> documentation.
+
+## Related
+
+- [Backups](backups.md) - `doctor` checks their age and size, not their existence
+- [The files you will actually edit](configuring.md) - what applies a change
+- [Monitoring](monitoring.md) - where the logs and metrics already are
+- [`README.md`](../../README.md) - the same traps, beside the repository map

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -1,0 +1,109 @@
+# Upgrading
+
+An upgrade is two commands, and they update two different things. Running only
+one of them is the most common way to end up confused about what version you are
+on.
+
+```
+bothy upgrade        the BOX - pulls the checkout and re-applies it
+bothy self-update    the SCRIPT - replaces the bothy on your PATH
+```
+
+## What `bothy upgrade` does
+
+Four steps, and it stops at the first that fails:
+
+1. Find the checkout ([The `bothy` command](the-cli.md) explains how) and enter
+   it.
+2. `git pull --ff-only`. Fast-forward only, so a checkout with local commits or
+   local edits **refuses to upgrade** rather than merging. That is deliberate:
+   the alternative is a merge conflict inside a directory that is also a running
+   system.
+3. If the commit did not move, it says so and stops. There is nothing to apply.
+4. `just up`.
+
+That last step is the whole of "apply". There is **no `down`**, and no `-v`.
+
+## Your data survives, and that is tested rather than promised
+
+`just up` recreates containers whose definitions changed and leaves volumes
+alone. The claim that this preserves data is asserted in CI by the Upgrade
+workflow (`.github/workflows/upgrade.yml`), which installs the previous commit,
+writes a row to the database, upgrades to `HEAD`, and then checks two things:
+
+- the row is still readable;
+- **no volume was recreated** - compared by volume **ID**, not by name, because
+  a recreated volume keeps its name and comparing names would pass exactly when
+  the data was lost.
+
+So the thing that would break this is not an ordinary upgrade. It is somebody
+adding a `down -v` to the apply step, or renaming a volume in a compose file -
+which is rare and always deliberate, and which that workflow exists to catch.
+
+Take a backup anyway before an upgrade you are unsure about. See
+[Backups](backups.md); it is one command and the restore path is documented.
+
+## Upgrading with no network
+
+`bothy download` pre-fetches every image named by **every** compose file in the
+checkout - not only the ones `up` starts, because the point of the command is
+that a later `up` needs no network at all, and that includes the tiers you may
+start by hand. It also runs `npm ci` for the portal's web sources if `npm` is
+present, though the image build does not need it.
+
+The order for an offline or slow-link upgrade is:
+
+```
+bothy upgrade      # pulls the checkout (this part needs the network)
+bothy download     # pulls the images
+bothy up
+```
+
+`upgrade` already runs `up` at the end, so on a good link the middle step is
+just insurance.
+
+## After upgrading, update the CLI too
+
+The `bothy` on your `PATH` is a **copy** of `scripts/bothy`, made when you
+installed. `upgrade` pulls the repository and does not touch it. That drift is
+harmless right up until the day a subcommand is added, removed or renamed - and
+then a dispatcher is resolving what you typed against a justfile it no longer
+matches.
+
+```
+bothy self-update
+```
+
+`scripts/checks/cli-commands.sh` asserts that every subcommand the CLI names
+still resolves - but it asserts it **inside a checkout**. Nothing checks the
+copy on your `PATH`, which is exactly why the command exists.
+
+## Checking what you are on
+
+```
+bothy version
+```
+
+Version, short commit, `(modified)` if the working tree is dirty, and the
+checkout path. The `(modified)` marker is the one that matters when a box
+behaves unlike its version number says it should: it is the only thing that
+distinguishes two machines claiming the same release.
+
+## When an upgrade goes wrong
+
+- **`pull failed - the checkout has local changes or has diverged`.** Expected,
+  and the right answer is not `--force`. Look at `git status` in the checkout.
+  If the change is yours and wanted, commit it on a branch; if it is not, it is
+  usually an edit made through [Bothy Files](files.md), and the file's history
+  is in the reader.
+- **A container will not start after an upgrade.** `bothy doctor` first - it
+  covers containers, ports, routes, targets, DNS and disk, and the failing line
+  is often not the one you expect. See [Troubleshooting](troubleshooting.md).
+- **A setting you changed has stopped taking effect.** Editing is not applying.
+  A changed label or port does nothing until the container is recreated; see
+  [The files you will actually edit](configuring.md).
+
+## Next
+
+- [Backups](backups.md) - what to take before an upgrade you are unsure about
+- [Troubleshooting](troubleshooting.md) - when the box comes back up wrong


### PR DESCRIPTION
Step 7 of `docs/plans/the-guide-and-the-reader.md` §9, and the last of today's issues that has code.

The guide covered installing, configuring, the console, files, roles and themes. Everything below was documented only in a design document, only in `ARCHITECTURE.md`, or only in the source — which is the definition of not being in a guide *"written for somebody who has not read the source"*.

| New page | Covers |
|---|---|
| `the-cli.md` | every `bothy` subcommand, native vs dispatched, how it finds your checkout, and why `upgrade` and `self-update` are two different things |
| `projects.md` | `project.dev.yml` — every key, every service key, every state, and why a port is an address rather than an identity |
| `services.md` | adding a container this repo runs: the port, `devnet`, `just urls`, the `dev.portal.*` labels, the checklist |
| `settings.md` | the three things "settings" collapses, and why the page is read-only by design rather than by omission |
| `monitoring.md` | what is scraped with no per-service setup, the two retention limits, and why a scrape job for a deleted service is not harmless |
| `backups.md` | what is covered, why it is `pg_dumpall`, the three pieces of scar tissue in the script, restoring, and what is honestly not solved |
| `upgrading.md` | what `upgrade` touches, why data survives and how that is tested, updating the CLI afterwards |
| `troubleshooting.md` | the traps, generalised past this one box |

## One correction, made loudly

The issue asked for "how to create projects toml". **It is `project.dev.yml`, and it is YAML.** The two `.toml` files on the box — `apps/portal-files/policy.toml` and `apps/bothy-config/policy.toml` — are **access policy** for those services and have nothing to do with declaring a project. A guide that conflated them would be worse than no guide, so `projects.md` says so in its second section rather than burying it.

## One manifest instead of four lists

Adding a page meant hand-editing three lists that already disagreed — the table in `docs/guide/index.md`, the table in `README.md`, and the `## Next` footers — and the reader's tree (#150) made four.

`GUIDE_ORDER` in `guide.ts` is the one a program can check, and `checks/start-table.mjs` asserts it against the folder on disk **in both directions**:

- a page named there that is not on disk → a row that opens "No such file";
- a page on disk that is *not* named there → still renders, at the bottom, alphabetically, where nobody notices it is last. That is the direction worth having.

**`README.md`'s "Seven pages" is gone rather than corrected.** A count in prose is the fastest-rotting sentence available — `start.ts` says exactly that where it refuses to put one in a blurb — and this one was already about to be wrong for the second time. The README now points at the index and at the check that keeps the index honest.

The `## Next` / `## Related` footers of the six existing pages are wired into the new reading order, so the chain runs end to end rather than stopping at Themes.

## Reading order

```
Getting it running   index · installing · the-cli · configuring
Using it             the-console · files · settings · roles · themes
Your own things      services · projects
Keeping it running   monitoring · backups · upgrading · troubleshooting
```

## How this was confirmed

```
scripts/checks/doc-links.sh   79 markdown files, every relative link resolves
apps/portal-next checks       247 pass · 0 fail (20 of them the guide's order)
typecheck                     clean

rendered in the reader (rebuilt portal-next, Chromium):
  15 index rows, in reading order - no alphabetical fallback
  the-cli.md           8 headings   2 tables   3 live cross-doc links
  projects.md          9 headings   3 tables   4 live cross-doc links
  troubleshooting.md  14 headings              8 live cross-doc links
  0 unresolved cross-document links on any of them
  0 console errors or warnings
```

The "0 unresolved" number is the one worth reading: `md.tsx` renders a repo-relative link it cannot resolve as inert text with the target beside it, so a broken cross-reference is visible in the DOM rather than silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
